### PR TITLE
Harden MoGe mirror staging

### DIFF
--- a/scripts/_mirror_common.py
+++ b/scripts/_mirror_common.py
@@ -30,7 +30,12 @@ def gitattributes() -> str:
     return fetch_text(GITATTRIBUTES_SOURCE)
 
 
-def parse_args(description: str, sizes: list[str]) -> argparse.Namespace:
+def parse_args(
+    description: str,
+    sizes: list[str],
+    *,
+    create_staging: bool = True,
+) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         "sizes",
@@ -50,9 +55,10 @@ def parse_args(description: str, sizes: list[str]) -> argparse.Namespace:
         help="stage only; do not create or push the Hugging Face repo",
     )
     args = parser.parse_args()
-    if args.staging is None:
+    if args.staging is None and create_staging:
         args.staging = Path(tempfile.mkdtemp(prefix="libreyolo-mirror-"))
-    args.staging.mkdir(parents=True, exist_ok=True)
+    if create_staging:
+        args.staging.mkdir(parents=True, exist_ok=True)
     return args
 
 
@@ -60,5 +66,7 @@ def check_five_file_contract(out: Path) -> list[str]:
     """The contract in skills/libreyolo-upload-hf-model: exactly five files."""
     files = sorted(p.name for p in out.iterdir() if p.is_file())
     if len(files) != 5:
-        raise SystemExit(f"{out.name}: expected exactly 5 files, got {len(files)}: {files}")
+        raise SystemExit(
+            f"{out.name}: expected exactly 5 files, got {len(files)}: {files}"
+        )
     return files

--- a/scripts/mirror_moge2.py
+++ b/scripts/mirror_moge2.py
@@ -337,7 +337,10 @@ def _windows_directory_handle(
     share = 0x1 | 0x2
     desired_access = 0x80
     if not prevent_rename:
-        share |= 0x4
+        # The publishing handle itself needs DELETE access for
+        # SetFileInformationByHandle, but sharing DELETE would let another
+        # process rename the temporary directory while Windows child opens
+        # are still path-based.
         desired_access |= 0x00010000
     handle = create_file(
         str(path),

--- a/scripts/mirror_moge2.py
+++ b/scripts/mirror_moge2.py
@@ -11,19 +11,36 @@ MIT, which permits redistribution, so there is no reason for that dependency.
 This stages one directory per size following the 5-file contract in
 skills/libreyolo-upload-hf-model. It does not upload; upload is a separate,
 deliberate step.
+
+A size is stageable only after reproducible double conversion, tensor audit,
+and parity/load validation produce an approved converted SHA-256 recorded in
+``SIZES``.
 """
 
 from __future__ import annotations
 
-import shutil
+import ctypes
+import errno
+import hashlib
+import os
+import secrets
+import stat
 import sys
+import tempfile
+import urllib.request
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO, Iterator
 
 import torch
 
-from _mirror_common import fetch_text, gitattributes, parse_args
+from _mirror_common import parse_args
 
-from libreyolo.utils.serialization import validate_checkpoint_metadata
+from libreyolo.utils.serialization import (
+    CheckpointMetadataError,
+    validate_checkpoint_metadata,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WEIGHTS = REPO_ROOT / "weights"
@@ -35,16 +52,52 @@ SIZES = {
         "upstream": "Ruicheng/moge-2-vitl-normal",
         "revision": "b135031bae30b5ac2ae141a0e68717795ce38340",
         "arch": "MoGe-2 ViT-L/14",
+        "sha256": "342c13b7028a2e87d164ee9647ad4f34d822dcb73221004c9f25d0458e17580a",
+        "card_size": 24,
+        "card_sha256": "d8d7a46d41a1a37fe4f0a5f637bf55c649310185329127d8a2204632e480be17",
     },
     "s": {
         "converted": "LibreMoGe2s-normal-LibreMoGe2s-normal.pt",
         "upstream": "Ruicheng/moge-2-vits-normal",
         "revision": "679230677b4d282c6f304189a93e98e14f085902",
         "arch": "MoGe-2 ViT-S/14",
+        "sha256": "0b3c1301ddcae5569234010905f093fa8bec5866c7c06197761ea501651f9d9c",
+        "card_size": 24,
+        "card_sha256": "d8d7a46d41a1a37fe4f0a5f637bf55c649310185329127d8a2204632e480be17",
+    },
+    "b": {
+        "converted": "LibreMoGe2b-normal-LibreMoGe2b-normal.pt",
+        "upstream": "Ruicheng/moge-2-vitb-normal",
+        "revision": "54ad3a693e61907ea4633d13dec6ee682fa09419",
+        "arch": "MoGe-2 ViT-B/14",
+        # Unapproved until reproducible conversion and parity produce a receipt.
+        "sha256": None,
+        "card_size": 24,
+        "card_sha256": "d8d7a46d41a1a37fe4f0a5f637bf55c649310185329127d8a2204632e480be17",
     },
 }
 
-LICENSE_URL = "https://raw.githubusercontent.com/microsoft/MoGe/main/LICENSE"
+MOGE_LICENSE_REVISION = "925b8ed835a7a9cdb7578ba15c658a0afc969030"
+MOGE_SOURCE_URL = f"https://github.com/microsoft/MoGe/tree/{MOGE_LICENSE_REVISION}"
+MOGE_DINOV2_URL = f"{MOGE_SOURCE_URL}/moge/model/dinov2"
+MOGE_LICENSE_PAGE_URL = (
+    f"https://github.com/microsoft/MoGe/blob/{MOGE_LICENSE_REVISION}/LICENSE"
+)
+LICENSE_URL = (
+    f"https://raw.githubusercontent.com/microsoft/MoGe/{MOGE_LICENSE_REVISION}/LICENSE"
+)
+LICENSE_SHA256 = "ad7d951c80c5fc2b2bce035f2041bc0a0dbf9028c8ecc4c9a8e1fba8130b6b59"
+LICENSE_SIZE = 12_500
+GITATTRIBUTES_REVISION = "1c54f3073f8e03f5818d74ca03e3e2fe5cddfbe0"
+GITATTRIBUTES_URL = (
+    "https://huggingface.co/LibreYOLO/LibreSegformerb5-sem/resolve/"
+    f"{GITATTRIBUTES_REVISION}/.gitattributes"
+)
+GITATTRIBUTES_SHA256 = (
+    "88023d0a029a0c409b30c03b689c68605b559f5cefe06376e4a26b38ed795269"
+)
+GITATTRIBUTES_SIZE = 1_554
+SUPPORT_FETCH_TIMEOUT_SECONDS = 15
 
 README = """---
 license: mit
@@ -61,16 +114,21 @@ tags:
 
 ## Source
 
-Derived from [{upstream}](https://huggingface.co/{upstream})
+Derived from [{upstream} `model.pt`]({source_url})
 at revision `{revision}`, the exact commit LibreYOLO pins.
-Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+The [revision-pinned source model card]({source_card_url}) declares these
+weights MIT.
 
-The DINOv2 encoder MoGe-2 builds on is separately licensed Apache-2.0 by
-Meta AI.
+Conversion follows [MoGe-2 at the audited source commit]({moge_source_url}).
+The [vendored DINOv2 encoder snapshot]({moge_dinov2_url}) MoGe-2 builds on is
+separately licensed Apache-2.0 by Meta AI; the exact notices are preserved in
+MoGe's [commit-pinned composite license]({moge_license_url}).
 
 ## Modifications
 
-State-dict key remapping only. Learned parameters are unchanged.
+Unused point, mask, and metric-scale head tensors are removed. Encoder, neck,
+and normal-head tensors are retained unchanged, and LibreYOLO checkpoint v1.0
+metadata is added.
 See `weights/convert_moge2_weights.py` in the
 [LibreYOLO source repository](https://github.com/LibreYOLO/libreyolo).
 
@@ -94,64 +152,936 @@ NOTICE = """LibreMoGe2 weights
 ------------------
 
 This product contains weights derived from MoGe-2
-(https://github.com/microsoft/MoGe).
+({moge_source_url}).
 Copyright (c) Microsoft Corporation.
-Licensed under the MIT License.
+The revision-pinned source model card declares these weights MIT:
+{source_card_url}
 
-Source artifact:  https://huggingface.co/{upstream}
+Source artifact:  {source_url}
 Source revision:  {revision}
 Source file:      model.pt
-Modification:     state-dict key remapping only, by
-                  weights/convert_moge2_weights.py in LibreYOLO. Learned
-                  parameters are unchanged.
+Modification:     unused point, mask, and metric-scale head tensors are
+                  removed; encoder, neck, and normal-head tensors are retained
+                  unchanged; LibreYOLO checkpoint v1.0 metadata is added by
+                  weights/convert_moge2_weights.py in LibreYOLO.
 
 The DINOv2 encoder these weights build on is separately licensed under the
 Apache License, Version 2.0, by Meta AI
-(https://github.com/facebookresearch/dinov2).
+({moge_dinov2_url}). The exact MIT and Apache notices are preserved in MoGe's
+commit-pinned composite license ({moge_license_url}).
 """
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    size: int
+    sha256: str
+    identity: tuple[int, int]
+
+
+@dataclass
+class DirectoryHandle:
+    path: Path
+    path_identity: tuple[int, int]
+    native_identity: tuple[int, int]
+    fd: int | None = None
+    win_handle: int | None = None
+    parent: DirectoryHandle | None = None
+    name: str | None = None
+
+
+def _identity(info: os.stat_result) -> tuple[int, int]:
+    return info.st_dev, info.st_ino
+
+
+def _is_reparse(info: os.stat_result) -> bool:
+    attributes = getattr(info, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(attributes & reparse_flag)
+
+
+def _is_unlinked_regular(info: os.stat_result) -> bool:
+    return stat.S_ISREG(info.st_mode) and not _is_reparse(info) and info.st_nlink == 1
+
+
+def _open_regular_source(path: Path) -> BinaryIO:
+    try:
+        entry_info = os.lstat(path)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"converted checkpoint missing: {path}") from exc
+    if not _is_unlinked_regular(entry_info):
+        raise SystemExit(
+            f"converted checkpoint must be an unlinked regular file: {path}"
+        )
+
+    handle = path.open("rb")
+    opened_info = os.fstat(handle.fileno())
+    if not _is_unlinked_regular(opened_info) or _identity(opened_info) != _identity(
+        entry_info
+    ):
+        handle.close()
+        raise SystemExit(f"converted checkpoint changed while opening: {path}")
+    return handle
+
+
+def _hash_stream(handle: BinaryIO) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    size = 0
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+        size += len(chunk)
+    return size, digest.hexdigest()
+
+
+def _copy_and_hash(source: BinaryIO, destination: BinaryIO) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    size = 0
+    for chunk in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(chunk)
+        size += len(chunk)
+        destination.write(chunk)
+    destination.flush()
+    os.fsync(destination.fileno())
+    return size, digest.hexdigest()
+
+
+def _fetch_verified_bytes(
+    url: str,
+    expected_size: int,
+    expected_sha256: str,
+    label: str,
+) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept-Encoding": "identity",
+            "User-Agent": "LibreYOLO-MoGe-mirror-audit",
+        },
+    )
+    with urllib.request.urlopen(
+        request,
+        timeout=SUPPORT_FETCH_TIMEOUT_SECONDS,
+    ) as response:
+        status = response.getcode()
+        if status != 200:
+            raise SystemExit(f"{label} fetch returned HTTP {status}")
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                declared_size = int(content_length)
+            except ValueError as exc:
+                raise SystemExit(
+                    f"{label} returned invalid Content-Length {content_length!r}"
+                ) from exc
+            if declared_size != expected_size:
+                raise SystemExit(
+                    f"{label} size mismatch: expected {expected_size}, "
+                    f"server declared {declared_size}"
+                )
+
+        chunks: list[bytes] = []
+        remaining = expected_size + 1
+        while remaining:
+            chunk = response.read(min(64 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+
+    content = b"".join(chunks)
+    if len(content) != expected_size:
+        raise SystemExit(
+            f"{label} size mismatch: expected {expected_size}, got {len(content)}"
+        )
+    actual_sha256 = hashlib.sha256(content).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise SystemExit(
+            f"{label} SHA-256 mismatch: expected {expected_sha256}, got {actual_sha256}"
+        )
+    return content
+
+
+def _windows_directory_handle(
+    path: Path,
+    *,
+    prevent_rename: bool,
+) -> tuple[int, tuple[int, int]]:
+    from ctypes import wintypes
+
+    class ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", wintypes.FILETIME),
+            ("ftLastAccessTime", wintypes.FILETIME),
+            ("ftLastWriteTime", wintypes.FILETIME),
+            ("dwVolumeSerialNumber", wintypes.DWORD),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("nNumberOfLinks", wintypes.DWORD),
+            ("nFileIndexHigh", wintypes.DWORD),
+            ("nFileIndexLow", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    share = 0x1 | 0x2
+    desired_access = 0x80
+    if not prevent_rename:
+        share |= 0x4
+        desired_access |= 0x00010000
+    handle = create_file(
+        str(path),
+        desired_access,
+        share,
+        None,
+        3,
+        0x02000000 | 0x00200000,
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    get_info = kernel32.GetFileInformationByHandle
+    get_info.argtypes = [wintypes.HANDLE, ctypes.POINTER(ByHandleFileInformation)]
+    get_info.restype = wintypes.BOOL
+    info = ByHandleFileInformation()
+    if not get_info(handle, ctypes.byref(info)):
+        error = ctypes.get_last_error()
+        _close_windows_handle(int(handle))
+        raise ctypes.WinError(error)
+    if not info.dwFileAttributes & 0x10 or info.dwFileAttributes & 0x400:
+        _close_windows_handle(int(handle))
+        raise SystemExit(f"staging path is not an unlinked directory: {path}")
+    file_index = (info.nFileIndexHigh << 32) | info.nFileIndexLow
+    return int(handle), (info.dwVolumeSerialNumber, file_index)
+
+
+def _close_windows_handle(handle: int) -> None:
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    if not close_handle(handle):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _directory_native_identity(directory: DirectoryHandle) -> tuple[int, int]:
+    if directory.fd is not None:
+        return _identity(os.fstat(directory.fd))
+    assert directory.win_handle is not None
+    from ctypes import wintypes
+
+    class ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", wintypes.FILETIME),
+            ("ftLastAccessTime", wintypes.FILETIME),
+            ("ftLastWriteTime", wintypes.FILETIME),
+            ("dwVolumeSerialNumber", wintypes.DWORD),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("nNumberOfLinks", wintypes.DWORD),
+            ("nFileIndexHigh", wintypes.DWORD),
+            ("nFileIndexLow", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_info = kernel32.GetFileInformationByHandle
+    get_info.argtypes = [wintypes.HANDLE, ctypes.POINTER(ByHandleFileInformation)]
+    get_info.restype = wintypes.BOOL
+    info = ByHandleFileInformation()
+    if not get_info(
+        directory.win_handle,
+        ctypes.byref(info),
+    ):
+        raise ctypes.WinError(ctypes.get_last_error())
+    file_index = (info.nFileIndexHigh << 32) | info.nFileIndexLow
+    return info.dwVolumeSerialNumber, file_index
+
+
+@contextmanager
+def _open_directory(
+    path: Path,
+    *,
+    prevent_rename: bool,
+    parent: DirectoryHandle | None = None,
+    name: str | None = None,
+) -> Iterator[DirectoryHandle]:
+    entry_info = (
+        os.stat(name, dir_fd=parent.fd, follow_symlinks=False)
+        if parent is not None and parent.fd is not None and name is not None
+        else os.lstat(path)
+    )
+    if not stat.S_ISDIR(entry_info.st_mode) or _is_reparse(entry_info):
+        raise SystemExit(f"staging path is not an unlinked directory: {path}")
+
+    if os.name == "nt":
+        win_handle, native_identity = _windows_directory_handle(
+            path,
+            prevent_rename=prevent_rename,
+        )
+        if entry_info.st_ino != native_identity[1]:
+            _close_windows_handle(win_handle)
+            raise SystemExit(f"staging directory changed while opening: {path}")
+        directory = DirectoryHandle(
+            path=path,
+            path_identity=_identity(entry_info),
+            native_identity=native_identity,
+            win_handle=win_handle,
+            parent=parent,
+            name=name,
+        )
+        try:
+            yield directory
+        finally:
+            _close_windows_handle(win_handle)
+        return
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    if parent is not None and parent.fd is not None and name is not None:
+        fd = os.open(name, flags, dir_fd=parent.fd)
+    else:
+        fd = os.open(path, flags)
+    opened_info = os.fstat(fd)
+    if _identity(opened_info) != _identity(entry_info):
+        os.close(fd)
+        raise SystemExit(f"staging directory changed while opening: {path}")
+    directory = DirectoryHandle(
+        path=path,
+        path_identity=_identity(entry_info),
+        native_identity=_identity(opened_info),
+        fd=fd,
+        parent=parent,
+        name=name,
+    )
+    try:
+        yield directory
+    finally:
+        os.close(fd)
+
+
+def _directory_entry_info(directory: DirectoryHandle) -> os.stat_result:
+    if (
+        directory.parent is not None
+        and directory.parent.fd is not None
+        and directory.name is not None
+    ):
+        return os.stat(
+            directory.name,
+            dir_fd=directory.parent.fd,
+            follow_symlinks=False,
+        )
+    return os.lstat(directory.path)
+
+
+def _validate_directory_binding(directory: DirectoryHandle) -> None:
+    if _directory_native_identity(directory) != directory.native_identity:
+        raise SystemExit(f"staging directory handle changed: {directory.path}")
+    try:
+        entry_info = _directory_entry_info(directory)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"staging directory disappeared: {directory.path}") from exc
+    if (
+        not stat.S_ISDIR(entry_info.st_mode)
+        or _is_reparse(entry_info)
+        or _identity(entry_info) != directory.path_identity
+    ):
+        raise SystemExit(f"staging directory path changed: {directory.path}")
+
+
+def _ensure_staging_root(path: Path) -> None:
+    if not os.path.lexists(path):
+        path.mkdir(parents=True)
+    info = os.lstat(path)
+    if not stat.S_ISDIR(info.st_mode) or _is_reparse(info):
+        raise SystemExit(f"staging root must be an unlinked directory: {path}")
+
+
+def _create_private_temp(root: DirectoryHandle, repo: str) -> tuple[str, Path]:
+    for _ in range(100):
+        name = f".{repo}.{secrets.token_hex(12)}"
+        path = root.path / name
+        try:
+            if root.fd is not None:
+                os.mkdir(name, mode=0o700, dir_fd=root.fd)
+            else:
+                os.mkdir(path, mode=0o700)
+        except FileExistsError:
+            continue
+        return name, path
+    raise RuntimeError(f"could not allocate a private staging directory for {repo}")
+
+
+def _entry_path(directory: DirectoryHandle, name: str) -> Path:
+    return directory.path / name
+
+
+def _entry_lstat(directory: DirectoryHandle, name: str) -> os.stat_result:
+    if directory.fd is not None:
+        return os.stat(name, dir_fd=directory.fd, follow_symlinks=False)
+    return os.lstat(_entry_path(directory, name))
+
+
+def _open_entry(
+    directory: DirectoryHandle, name: str, flags: int, mode: int = 0o600
+) -> int:
+    flags |= getattr(os, "O_BINARY", 0)
+    if directory.fd is not None:
+        return os.open(name, flags, mode, dir_fd=directory.fd)
+    return os.open(_entry_path(directory, name), flags, mode)
+
+
+def _finish_created_entry(
+    directory: DirectoryHandle,
+    name: str,
+    info: os.stat_result,
+    size: int,
+    sha256: str,
+) -> FileRecord:
+    entry_info = _entry_lstat(directory, name)
+    if (
+        not _is_unlinked_regular(info)
+        or not _is_unlinked_regular(entry_info)
+        or _identity(info) != _identity(entry_info)
+        or info.st_size != size
+    ):
+        raise SystemExit(f"staged file changed while writing: {name}")
+    return FileRecord(size=size, sha256=sha256, identity=_identity(info))
+
+
+def _write_exclusive_bytes(
+    directory: DirectoryHandle,
+    name: str,
+    content: bytes,
+) -> FileRecord:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = _open_entry(directory, name, flags)
+    try:
+        view = memoryview(content)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                raise OSError(f"short write while staging {name}")
+            view = view[written:]
+        os.fsync(fd)
+        info = os.fstat(fd)
+    finally:
+        os.close(fd)
+    return _finish_created_entry(
+        directory,
+        name,
+        info,
+        len(content),
+        hashlib.sha256(content).hexdigest(),
+    )
+
+
+def _copy_exclusive_weight(
+    directory: DirectoryHandle,
+    name: str,
+    source: BinaryIO,
+) -> FileRecord:
+    flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = _open_entry(directory, name, flags)
+    try:
+        with os.fdopen(fd, "w+b", closefd=False) as destination:
+            size, sha256 = _copy_and_hash(source, destination)
+        info = os.fstat(fd)
+    finally:
+        os.close(fd)
+    return _finish_created_entry(directory, name, info, size, sha256)
+
+
+def _read_entry_record(directory: DirectoryHandle, name: str) -> FileRecord:
+    before = _entry_lstat(directory, name)
+    if not _is_unlinked_regular(before):
+        raise SystemExit(f"staged entry is not an unlinked regular file: {name}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = _open_entry(directory, name, flags)
+    try:
+        opened = os.fstat(fd)
+        if not _is_unlinked_regular(opened) or _identity(opened) != _identity(before):
+            raise SystemExit(f"staged entry changed while opening: {name}")
+        with os.fdopen(fd, "rb", closefd=False) as handle:
+            size, sha256 = _hash_stream(handle)
+        after = os.fstat(fd)
+    finally:
+        os.close(fd)
+    final_entry = _entry_lstat(directory, name)
+    if (
+        not _is_unlinked_regular(after)
+        or not _is_unlinked_regular(final_entry)
+        or _identity(after) != _identity(before)
+        or _identity(final_entry) != _identity(before)
+        or after.st_size != size
+    ):
+        raise SystemExit(f"staged entry changed while hashing: {name}")
+    return FileRecord(size=size, sha256=sha256, identity=_identity(after))
+
+
+@contextmanager
+def _open_verified_entry(
+    directory: DirectoryHandle,
+    name: str,
+    expected: FileRecord,
+) -> Iterator[BinaryIO]:
+    before = _entry_lstat(directory, name)
+    if (
+        not _is_unlinked_regular(before)
+        or _identity(before) != expected.identity
+        or before.st_size != expected.size
+    ):
+        raise SystemExit(f"staged entry changed before opening: {name}")
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = _open_entry(directory, name, flags)
+    try:
+        opened = os.fstat(fd)
+        if (
+            not _is_unlinked_regular(opened)
+            or _identity(opened) != expected.identity
+            or opened.st_size != expected.size
+        ):
+            raise SystemExit(f"staged entry changed while opening: {name}")
+        with os.fdopen(fd, "rb", buffering=0, closefd=False) as handle:
+            yield handle
+        after = os.fstat(fd)
+    finally:
+        os.close(fd)
+
+    final_entry = _entry_lstat(directory, name)
+    if (
+        not _is_unlinked_regular(after)
+        or not _is_unlinked_regular(final_entry)
+        or _identity(after) != expected.identity
+        or _identity(final_entry) != expected.identity
+        or after.st_size != expected.size
+    ):
+        raise SystemExit(f"staged entry changed while open: {name}")
+
+
+def _validate_record(
+    directory: DirectoryHandle,
+    expected: dict[str, FileRecord],
+) -> None:
+    _validate_directory_binding(directory)
+    names = os.listdir(directory.fd if directory.fd is not None else directory.path)
+    if sorted(names) != sorted(expected):
+        raise SystemExit(
+            f"staged inventory mismatch: expected {sorted(expected)}, got {sorted(names)}"
+        )
+    for name, expected_record in expected.items():
+        actual = _read_entry_record(directory, name)
+        if actual != expected_record:
+            raise SystemExit(
+                f"staged file record mismatch for {name}: expected "
+                f"{expected_record}, got {actual}"
+            )
+
+
+def _raise_rename_error(error: int, destination: Path) -> None:
+    if error in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise FileExistsError(
+            error,
+            "staging destination already exists",
+            str(destination),
+        )
+    raise OSError(error, os.strerror(error), str(destination))
+
+
+def _native_rename_create_only(
+    root: DirectoryHandle,
+    temporary: DirectoryHandle,
+    destination_name: str,
+) -> None:
+    destination = root.path / destination_name
+    if os.name == "nt":
+        from ctypes import wintypes
+
+        assert root.win_handle is not None
+        assert temporary.win_handle is not None
+        # FileRenameInfo is compatible across supported Windows versions with
+        # an absolute target. The source stays bound to temporary.win_handle;
+        # root remains open without FILE_SHARE_DELETE and is checked on both
+        # sides of the rename.
+        destination_path = str(destination.absolute())
+        destination_bytes = destination_path.encode("utf-16-le")
+
+        class FileRenameInfo(ctypes.Structure):
+            _fields_ = [
+                ("ReplaceIfExists", wintypes.BOOLEAN),
+                ("RootDirectory", wintypes.HANDLE),
+                ("FileNameLength", wintypes.DWORD),
+                ("FileName", wintypes.WCHAR * 1),
+            ]
+
+        filename_offset = FileRenameInfo.FileName.offset
+        buffer_size = (
+            filename_offset + len(destination_bytes) + ctypes.sizeof(wintypes.WCHAR)
+        )
+        rename_buffer = ctypes.create_string_buffer(buffer_size)
+        rename_info = FileRenameInfo.from_buffer(rename_buffer)
+        rename_info.ReplaceIfExists = False
+        rename_info.RootDirectory = None
+        rename_info.FileNameLength = len(destination_bytes)
+        ctypes.memmove(
+            ctypes.addressof(rename_buffer) + filename_offset,
+            destination_bytes,
+            len(destination_bytes),
+        )
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        set_information = kernel32.SetFileInformationByHandle
+        set_information.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        set_information.restype = wintypes.BOOL
+        if not set_information(
+            temporary.win_handle,
+            3,
+            ctypes.byref(rename_buffer),
+            buffer_size,
+        ):
+            error = ctypes.get_last_error()
+            if error in {80, 183}:
+                raise FileExistsError(
+                    errno.EEXIST,
+                    "staging destination already exists",
+                    str(destination),
+                )
+            raise ctypes.WinError(error)
+        return
+
+    assert temporary.name is not None
+    source_name = temporary.name
+    assert root.fd is not None
+    libc = ctypes.CDLL(None, use_errno=True)
+    if sys.platform.startswith("linux"):
+        renameat2 = getattr(libc, "renameat2", None)
+        if renameat2 is None:
+            raise RuntimeError("atomic create-only rename requires renameat2")
+        renameat2.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        renameat2.restype = ctypes.c_int
+        result = renameat2(
+            root.fd,
+            os.fsencode(source_name),
+            root.fd,
+            os.fsencode(destination_name),
+            1,
+        )
+    elif sys.platform == "darwin":
+        renameatx_np = getattr(libc, "renameatx_np", None)
+        if renameatx_np is None:
+            raise RuntimeError("atomic create-only rename requires renameatx_np")
+        renameatx_np.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        renameatx_np.restype = ctypes.c_int
+        result = renameatx_np(
+            root.fd,
+            os.fsencode(source_name),
+            root.fd,
+            os.fsencode(destination_name),
+            0x4,
+        )
+    else:
+        raise RuntimeError(
+            f"atomic create-only rename is unsupported on {sys.platform!r}"
+        )
+    if result != 0:
+        _raise_rename_error(ctypes.get_errno(), destination)
+
+
+def _rename_create_only(
+    root: DirectoryHandle,
+    temporary: DirectoryHandle,
+    destination_name: str,
+    expected: dict[str, FileRecord],
+) -> None:
+    _validate_directory_binding(root)
+    _validate_record(temporary, expected)
+    _validate_directory_binding(root)
+    _validate_directory_binding(temporary)
+    assert temporary.name is not None
+    _native_rename_create_only(root, temporary, destination_name)
+    temporary.name = destination_name
+    temporary.path = root.path / destination_name
+    try:
+        _validate_directory_binding(root)
+        _validate_record(temporary, expected)
+    except BaseException as exc:
+        raise SystemExit(
+            f"published destination failed final validation and was left for "
+            f"manual removal: {temporary.path}: {exc}"
+        ) from exc
+
+
+def validate_staged_checkpoint(checkpoint: object, *, size: str, repo: str) -> None:
+    try:
+        validate_checkpoint_metadata(checkpoint, strict=True)
+    except CheckpointMetadataError as exc:
+        raise SystemExit(f"{repo}: checkpoint metadata invalid: {exc}") from exc
+
+    expected = {
+        "model_family": "moge2",
+        "size": size,
+        "task": "normal",
+        "nc": 1,
+        "names": {0: "normal"},
+        "imgsz": 518,
+    }
+    if not isinstance(checkpoint, dict):  # Defensive: strict validation rejects this.
+        raise SystemExit(f"{repo}: checkpoint metadata invalid: expected a dictionary")
+    mismatches = [
+        f"{key} expected {value!r}, got {checkpoint.get(key)!r}"
+        for key, value in expected.items()
+        if checkpoint.get(key) != value
+    ]
+    if mismatches:
+        raise SystemExit(
+            f"{repo}: checkpoint metadata mismatch: {'; '.join(mismatches)}"
+        )
+
+
+def _require_approved(size: str, spec: dict) -> str:
+    repo = f"LibreMoGe2{size}-normal"
+    expected_sha256 = spec.get("sha256")
+    if not expected_sha256:
+        raise SystemExit(
+            f"{repo}: converted artifact is not approved; complete reproducible "
+            "double conversion, tensor audit, and parity/load validation, then "
+            "record its SHA-256 before staging"
+        )
+    return expected_sha256
+
+
+def _destination_exists(root: DirectoryHandle, name: str) -> bool:
+    if root.fd is None:
+        return os.path.lexists(root.path / name)
+    try:
+        os.stat(name, dir_fd=root.fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    return True
 
 
 def stage(size: str, spec: dict, out_root: Path) -> Path:
     repo = f"LibreMoGe2{size}-normal"
+    expected_sha256 = _require_approved(size, spec)
+
     src = WEIGHTS / spec["converted"]
-    if not src.exists():
-        raise FileNotFoundError(f"converted checkpoint missing: {src}")
-
-    checkpoint = torch.load(src, map_location="cpu", weights_only=False)
-    errors = validate_checkpoint_metadata(checkpoint, strict=False)
-    if errors:
-        raise SystemExit(f"{repo}: checkpoint metadata invalid: {errors}")
-
     out = out_root / repo
-    out.mkdir(parents=True, exist_ok=True)
+    if os.path.lexists(out):
+        raise FileExistsError(f"staging destination already exists: {out}")
 
-    (out / ".gitattributes").write_text(gitattributes(), encoding="utf-8")
-    (out / "LICENSE").write_text(fetch_text(LICENSE_URL), encoding="utf-8")
-    (out / "NOTICE").write_text(
-        NOTICE.format(upstream=spec["upstream"], revision=spec["revision"]), encoding="utf-8"
-    )
-    (out / "README.md").write_text(
-        README.format(repo=repo, arch=spec["arch"], upstream=spec["upstream"],
-                      revision=spec["revision"]),
-        encoding="utf-8",
-    )
-    # Canonical filename, not the doubled name the converter leaves behind.
-    shutil.copy2(src, out / f"{repo}.pt")
+    with _open_regular_source(src) as source_handle:
+        source_size, actual_sha256 = _hash_stream(source_handle)
+        if actual_sha256 != expected_sha256:
+            raise SystemExit(
+                f"{repo}: converted checkpoint SHA-256 mismatch: expected "
+                f"{expected_sha256}, got {actual_sha256}"
+            )
 
-    files = sorted(p.name for p in out.iterdir())
-    size_mb = (out / f"{repo}.pt").stat().st_size / 1e6
+        source_url = (
+            f"https://huggingface.co/{spec['upstream']}/blob/"
+            f"{spec['revision']}/model.pt"
+        )
+        source_card_url = (
+            f"https://huggingface.co/{spec['upstream']}/blob/"
+            f"{spec['revision']}/README.md"
+        )
+        source_card_fetch_url = (
+            f"https://huggingface.co/{spec['upstream']}/resolve/"
+            f"{spec['revision']}/README.md"
+        )
+        format_args = {
+            "repo": repo,
+            "arch": spec["arch"],
+            "upstream": spec["upstream"],
+            "revision": spec["revision"],
+            "source_url": source_url,
+            "source_card_url": source_card_url,
+            "moge_source_url": MOGE_SOURCE_URL,
+            "moge_dinov2_url": MOGE_DINOV2_URL,
+            "moge_license_url": MOGE_LICENSE_PAGE_URL,
+        }
+        attributes_bytes = _fetch_verified_bytes(
+            GITATTRIBUTES_URL,
+            GITATTRIBUTES_SIZE,
+            GITATTRIBUTES_SHA256,
+            ".gitattributes",
+        )
+        license_bytes = _fetch_verified_bytes(
+            LICENSE_URL,
+            LICENSE_SIZE,
+            LICENSE_SHA256,
+            "LICENSE",
+        )
+        _fetch_verified_bytes(
+            source_card_fetch_url,
+            spec["card_size"],
+            spec["card_sha256"],
+            "source model card",
+        )
+        notice_bytes = NOTICE.format(**format_args).encode("utf-8")
+        readme_bytes = README.format(**format_args).encode("utf-8")
+
+        _ensure_staging_root(out_root)
+        temporary_path: Path | None = None
+        try:
+            with _open_directory(out_root, prevent_rename=True) as root:
+                _validate_directory_binding(root)
+                if _destination_exists(root, repo):
+                    raise FileExistsError(f"staging destination already exists: {out}")
+                temporary_name, temporary_path = _create_private_temp(root, repo)
+                with _open_directory(
+                    temporary_path,
+                    prevent_rename=False,
+                    parent=root,
+                    name=temporary_name,
+                ) as temporary:
+                    source_handle.seek(0)
+                    weight_name = f"{repo}.pt"
+                    weight_record = _copy_exclusive_weight(
+                        temporary,
+                        weight_name,
+                        source_handle,
+                    )
+                    if (
+                        weight_record.size != source_size
+                        or weight_record.sha256 != expected_sha256
+                    ):
+                        raise SystemExit(
+                            f"{repo}: source changed during descriptor-bound copy"
+                        )
+
+                    with _open_verified_entry(
+                        temporary,
+                        weight_name,
+                        weight_record,
+                    ) as staged_weight:
+                        staged_size, staged_sha256 = _hash_stream(staged_weight)
+                        if (
+                            staged_size != weight_record.size
+                            or staged_sha256 != weight_record.sha256
+                        ):
+                            raise SystemExit(
+                                f"{repo}: private checkpoint changed before load"
+                            )
+                        staged_weight.seek(0)
+                        checkpoint = torch.load(
+                            staged_weight,
+                            map_location="cpu",
+                            weights_only=True,
+                        )
+                        validate_staged_checkpoint(checkpoint, size=size, repo=repo)
+                        staged_weight.seek(0)
+                        loaded_size, loaded_sha256 = _hash_stream(staged_weight)
+                        if (
+                            loaded_size != weight_record.size
+                            or loaded_sha256 != weight_record.sha256
+                        ):
+                            raise SystemExit(
+                                f"{repo}: private checkpoint changed during load"
+                            )
+
+                    if _read_entry_record(temporary, weight_name) != weight_record:
+                        raise SystemExit(
+                            f"{repo}: private checkpoint changed after load"
+                        )
+                    expected = {
+                        weight_name: weight_record,
+                        ".gitattributes": _write_exclusive_bytes(
+                            temporary,
+                            ".gitattributes",
+                            attributes_bytes,
+                        ),
+                        "LICENSE": _write_exclusive_bytes(
+                            temporary,
+                            "LICENSE",
+                            license_bytes,
+                        ),
+                        "NOTICE": _write_exclusive_bytes(
+                            temporary,
+                            "NOTICE",
+                            notice_bytes,
+                        ),
+                        "README.md": _write_exclusive_bytes(
+                            temporary,
+                            "README.md",
+                            readme_bytes,
+                        ),
+                    }
+                    _rename_create_only(root, temporary, repo, expected)
+        except BaseException:
+            retained = [
+                candidate
+                for candidate in (temporary_path, out)
+                if candidate is not None and os.path.lexists(candidate)
+            ]
+            if retained:
+                print(
+                    f"{repo}: staging failed; no cleanup attempted; retained "
+                    f"{', '.join(map(str, retained))} for explicit manual "
+                    "inspection/removal",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{repo}: staging failed; no cleanup attempted; a sealed "
+                    "staging directory may have moved and requires explicit "
+                    "manual inspection",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            raise
+
+    files = sorted(expected)
+    size_mb = source_size / 1e6
     print(f"  {repo}: {files} ({size_mb:.0f} MB)", flush=True)
-    if len(files) != 5:
-        raise SystemExit(f"{repo}: expected exactly 5 files, got {len(files)}")
     return out
 
 
 def main() -> int:
-    args = parse_args(__doc__ or "Mirror MoGe-2", list(SIZES))
-    print(f"staging MoGe-2 mirrors under {args.staging}", flush=True)
+    args = parse_args(
+        __doc__ or "Mirror MoGe-2",
+        list(SIZES),
+        create_staging=False,
+    )
     for size in args.sizes:
         if size not in SIZES:
             raise SystemExit(f"unknown size {size!r}; expected one of {list(SIZES)}")
+        _require_approved(size, SIZES[size])
+    if args.staging is None:
+        args.staging = Path(tempfile.mkdtemp(prefix="libreyolo-mirror-"))
+    print(f"staging MoGe-2 mirrors under {args.staging}", flush=True)
+    for size in args.sizes:
         stage(size, SIZES[size], args.staging)
     print("staged. upload with huggingface_hub.HfApi().upload_folder(...).", flush=True)
     return 0

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -312,6 +312,8 @@ LibreDepthAnythingV2l-depth.pt, LibreDepthAnythingV2g-depth.pt,
 
 LibreDepthAnything3l-depth.pt,
 
+LibreMoGe2s-normal.pt, LibreMoGe2b-normal.pt, LibreMoGe2l-normal.pt,
+
 LibreZipDepthb-depth.pt, LibreZipDepthbnpu-depth.pt,
 
 LibreFOMOs-point.pt, LibreFOMOm-point.pt, LibreFOMOl-point.pt

--- a/tests/unit/test_mirror_moge2.py
+++ b/tests/unit/test_mirror_moge2.py
@@ -1,0 +1,993 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.unit
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+
+def _load_mirror_module():
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "mirror_moge2_under_test",
+            SCRIPTS / "mirror_moge2.py",
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop(spec.name, None)
+        return module
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.fixture
+def mirror_moge2(monkeypatch):
+    module = _load_mirror_module()
+    support = {
+        module.GITATTRIBUTES_URL: b"lfs contract\n",
+        module.LICENSE_URL: b"test license\n",
+    }
+
+    def fake_fetch(url, _expected_size, _expected_sha256, _label):
+        if url.endswith("/README.md"):
+            return b"---\r\nlicense: mit\r\n---\r\n"
+        if url == module.GITATTRIBUTES_URL:
+            return support[url]
+        if url == module.LICENSE_URL:
+            return support[url]
+        pytest.fail(f"unexpected network URL: {url}")
+
+    monkeypatch.setattr(module, "_fetch_verified_bytes", fake_fetch)
+    return module
+
+
+def _checkpoint(**overrides):
+    checkpoint = {
+        "model": {"normal_head.weight": torch.tensor([1.0])},
+        "schema_version": "1.0",
+        "libreyolo_version": "test",
+        "model_family": "moge2",
+        "size": "b",
+        "task": "normal",
+        "nc": 1,
+        "names": {0: "normal"},
+        "imgsz": 518,
+    }
+    checkpoint.update(overrides)
+    return checkpoint
+
+
+def _approved_b_spec(mirror_moge2, source: Path):
+    spec = dict(mirror_moge2.SIZES["b"])
+    spec["sha256"] = hashlib.sha256(source.read_bytes()).hexdigest()
+    return spec
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes, *, content_length: str | None = None):
+        self.payload = payload
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = content_length
+        self.offset = 0
+        self.read_sizes: list[int] = []
+        self.closed = False
+
+    def getcode(self):
+        return 200
+
+    def read(self, size: int):
+        self.read_sizes.append(size)
+        chunk = self.payload[self.offset : self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        self.closed = True
+
+
+def test_b_source_config_and_license_revision_are_pinned():
+    mirror_moge2 = _load_mirror_module()
+    assert mirror_moge2.SIZES["b"] == {
+        "converted": "LibreMoGe2b-normal-LibreMoGe2b-normal.pt",
+        "upstream": "Ruicheng/moge-2-vitb-normal",
+        "revision": "54ad3a693e61907ea4633d13dec6ee682fa09419",
+        "arch": "MoGe-2 ViT-B/14",
+        "sha256": None,
+        "card_size": 24,
+        "card_sha256": (
+            "d8d7a46d41a1a37fe4f0a5f637bf55c649310185329127d8a2204632e480be17"
+        ),
+    }
+    assert mirror_moge2.SIZES["s"]["sha256"] == (
+        "0b3c1301ddcae5569234010905f093fa8bec5866c7c06197761ea501651f9d9c"
+    )
+    assert mirror_moge2.SIZES["l"]["sha256"] == (
+        "342c13b7028a2e87d164ee9647ad4f34d822dcb73221004c9f25d0458e17580a"
+    )
+    assert mirror_moge2.GITATTRIBUTES_REVISION == (
+        "1c54f3073f8e03f5818d74ca03e3e2fe5cddfbe0"
+    )
+    assert mirror_moge2.GITATTRIBUTES_URL == (
+        "https://huggingface.co/LibreYOLO/LibreSegformerb5-sem/resolve/"
+        "1c54f3073f8e03f5818d74ca03e3e2fe5cddfbe0/.gitattributes"
+    )
+    assert mirror_moge2.GITATTRIBUTES_SHA256 == (
+        "88023d0a029a0c409b30c03b689c68605b559f5cefe06376e4a26b38ed795269"
+    )
+    assert mirror_moge2.LICENSE_SHA256 == (
+        "ad7d951c80c5fc2b2bce035f2041bc0a0dbf9028c8ecc4c9a8e1fba8130b6b59"
+    )
+    assert mirror_moge2.GITATTRIBUTES_SIZE == 1_554
+    assert mirror_moge2.LICENSE_SIZE == 12_500
+    assert (
+        mirror_moge2.LICENSE_URL == "https://raw.githubusercontent.com/microsoft/MoGe/"
+        "925b8ed835a7a9cdb7578ba15c658a0afc969030/LICENSE"
+    )
+
+
+def test_upload_whitelist_contains_all_moge2_normal_artifacts():
+    skill = (ROOT / "skills/libreyolo-upload-hf-model/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    whitelist = skill.split("## Canonical filename whitelist", maxsplit=1)[1]
+    whitelist = whitelist.split("```", maxsplit=2)[1]
+    assert "LibreMoGe2s-normal.pt" in whitelist
+    assert "LibreMoGe2b-normal.pt" in whitelist
+    assert "LibreMoGe2l-normal.pt" in whitelist
+
+
+def test_stage_refuses_unapproved_b_before_loading_or_stamping(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        mirror_moge2.torch,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("unapproved artifact was loaded"),
+    )
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match="not approved.*reproducible.*parity/load"):
+        mirror_moge2.stage("b", mirror_moge2.SIZES["b"], staging)
+
+    assert not staging.exists()
+
+
+def test_stage_rejects_digest_mismatch_before_loading_or_stamping(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    source.write_bytes(b"not the approved artifact")
+    spec = dict(mirror_moge2.SIZES["b"])
+    spec["sha256"] = "0" * 64
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+    monkeypatch.setattr(
+        mirror_moge2.torch,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("digest-mismatched artifact was loaded"),
+    )
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match="SHA-256 mismatch"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert not (staging / "LibreMoGe2b-normal").exists()
+    assert not staging.exists() or not any(staging.iterdir())
+
+
+def test_source_path_swap_cannot_change_descriptor_or_stamp_provenance(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    replacement = weights / "replacement.pt"
+    backup = weights / "approved-backup.pt"
+    torch.save(_checkpoint(model={"approved.weight": torch.tensor([1.0])}), source)
+    torch.save(_checkpoint(model={"forged.weight": torch.tensor([2.0])}), replacement)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+    monkeypatch.setattr(
+        mirror_moge2.torch,
+        "load",
+        lambda *_args, **_kwargs: pytest.fail("path-swapped artifact was loaded"),
+    )
+
+    real_open = mirror_moge2.Path.open
+    swapped = False
+
+    def swapping_open(path, mode="r", *args, **kwargs):
+        nonlocal swapped
+        if path == source and mode == "rb" and not swapped:
+            source.rename(backup)
+            replacement.rename(source)
+            swapped = True
+        return real_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(mirror_moge2.Path, "open", swapping_open)
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match="changed while opening"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert swapped
+    assert not staging.exists()
+
+
+def test_source_path_swap_after_hash_cannot_change_staged_bytes(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    replacement = weights / "replacement.pt"
+    backup = weights / "approved-backup.pt"
+    torch.save(_checkpoint(model={"approved.weight": torch.tensor([1.0])}), source)
+    torch.save(_checkpoint(model={"forged.weight": torch.tensor([2.0])}), replacement)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    real_copy_and_hash = mirror_moge2._copy_and_hash
+    swap_blocked = False
+
+    def swap_after_hash(source_handle, destination_handle):
+        nonlocal swap_blocked
+        digest = real_copy_and_hash(source_handle, destination_handle)
+        try:
+            source.rename(backup)
+        except PermissionError:
+            swap_blocked = True
+        else:
+            replacement.rename(source)
+        return digest
+
+    monkeypatch.setattr(mirror_moge2, "_copy_and_hash", swap_after_hash)
+
+    staged = mirror_moge2.stage("b", spec, tmp_path / "staging")
+    staged_weight = staged / "LibreMoGe2b-normal.pt"
+
+    if swap_blocked:
+        assert staged_weight.read_bytes() == source.read_bytes()
+        assert replacement.exists()
+    else:
+        assert staged_weight.read_bytes() == backup.read_bytes()
+        assert staged_weight.read_bytes() != source.read_bytes()
+    assert hashlib.sha256(staged_weight.read_bytes()).hexdigest() == spec["sha256"]
+
+
+def test_load_uses_verified_private_copy_and_publishes_those_exact_bytes(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    forged = weights / "forged.pt"
+    torch.save(_checkpoint(model={"approved.weight": torch.tensor([1.0])}), source)
+    torch.save(_checkpoint(model={"forged.weight": torch.tensor([2.0])}), forged)
+    approved_bytes = source.read_bytes()
+    forged_bytes = forged.read_bytes()
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    private_path = None
+    real_copy = mirror_moge2._copy_exclusive_weight
+
+    def record_private_copy(directory, name, source_handle):
+        nonlocal private_path
+        record = real_copy(directory, name, source_handle)
+        private_path = mirror_moge2._entry_path(directory, name)
+        return record
+
+    monkeypatch.setattr(
+        mirror_moge2,
+        "_copy_exclusive_weight",
+        record_private_copy,
+    )
+    real_load = mirror_moge2.torch.load
+    loaded_private = False
+
+    def mutate_original_then_load(handle, *args, **kwargs):
+        nonlocal loaded_private
+        assert kwargs["weights_only"] is True
+        assert private_path is not None
+        assert mirror_moge2._identity(os.fstat(handle.fileno())) == (
+            mirror_moge2._identity(os.lstat(private_path))
+        )
+        assert hashlib.sha256(handle.read()).hexdigest() == spec["sha256"]
+        handle.seek(0)
+        source.write_bytes(forged_bytes)
+        checkpoint = real_load(handle, *args, **kwargs)
+        assert "approved.weight" in checkpoint["model"]
+        assert "forged.weight" not in checkpoint["model"]
+        loaded_private = True
+        return checkpoint
+
+    monkeypatch.setattr(mirror_moge2.torch, "load", mutate_original_then_load)
+
+    staged = mirror_moge2.stage("b", spec, tmp_path / "staging")
+    published = staged / "LibreMoGe2b-normal.pt"
+
+    assert loaded_private
+    assert source.read_bytes() == forged_bytes
+    assert published.read_bytes() == approved_bytes
+    assert hashlib.sha256(published.read_bytes()).hexdigest() == spec["sha256"]
+
+
+def test_private_checkpoint_is_revalidated_after_load(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    private_path = None
+    real_copy = mirror_moge2._copy_exclusive_weight
+
+    def record_private_copy(directory, name, source_handle):
+        nonlocal private_path
+        record = real_copy(directory, name, source_handle)
+        private_path = mirror_moge2._entry_path(directory, name)
+        return record
+
+    monkeypatch.setattr(
+        mirror_moge2,
+        "_copy_exclusive_weight",
+        record_private_copy,
+    )
+    real_load = mirror_moge2.torch.load
+
+    def mutate_private_after_load(handle, *args, **kwargs):
+        checkpoint = real_load(handle, *args, **kwargs)
+        assert private_path is not None
+        private_path.write_bytes(b"changed after deserialization")
+        return checkpoint
+
+    monkeypatch.setattr(mirror_moge2.torch, "load", mutate_private_after_load)
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match="private checkpoint changed during load"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert not (staging / "LibreMoGe2b-normal").exists()
+
+
+def test_hardlinked_source_is_rejected(mirror_moge2, monkeypatch, tmp_path):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    target = weights / "target.pt"
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), target)
+    try:
+        source.hardlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"hard links unavailable: {exc}")
+    spec = dict(mirror_moge2.SIZES["b"])
+    spec["sha256"] = hashlib.sha256(target.read_bytes()).hexdigest()
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    with pytest.raises(SystemExit, match="unlinked regular file"):
+        mirror_moge2.stage("b", spec, tmp_path / "staging")
+
+    assert not (tmp_path / "staging").exists()
+
+
+def test_existing_destination_is_preserved(mirror_moge2, monkeypatch, tmp_path):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    staging = tmp_path / "staging"
+    existing = staging / "LibreMoGe2b-normal"
+    existing.mkdir(parents=True)
+    sentinel = existing / "keep.txt"
+    sentinel.write_bytes(b"preserve me")
+
+    with pytest.raises(FileExistsError, match="destination already exists"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert sentinel.read_bytes() == b"preserve me"
+    assert {path.name for path in existing.iterdir()} == {"keep.txt"}
+
+
+def test_destination_created_at_publish_is_preserved(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    real_rename = mirror_moge2._rename_create_only
+
+    def race_destination(root, temporary, destination_name, expected):
+        destination = root.path / destination_name
+        destination.mkdir()
+        (destination / "keep.txt").write_bytes(b"preserve race winner")
+        real_rename(root, temporary, destination_name, expected)
+
+    monkeypatch.setattr(mirror_moge2, "_rename_create_only", race_destination)
+    staging = tmp_path / "staging"
+
+    with pytest.raises(FileExistsError, match="destination already exists"):
+        mirror_moge2.stage("b", spec, staging)
+
+    destination = staging / "LibreMoGe2b-normal"
+    assert (destination / "keep.txt").read_bytes() == b"preserve race winner"
+    retained = [
+        path
+        for path in staging.iterdir()
+        if path.name.startswith(".LibreMoGe2b-normal.")
+    ]
+    assert len(retained) == 1
+    assert {path.name for path in retained[0].iterdir()} == {
+        ".gitattributes",
+        "LICENSE",
+        "NOTICE",
+        "README.md",
+        "LibreMoGe2b-normal.pt",
+    }
+
+
+def test_repeated_publication_uses_exact_windows_leaf_without_trailing_garbage(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+    repo = "LibreMoGe2b-normal"
+
+    for iteration in range(32):
+        pair_root = tmp_path / f"pair-{iteration:02d}"
+        for leaf in ("first", "second"):
+            staging = pair_root / leaf
+            staged = mirror_moge2.stage("b", spec, staging)
+            names = [path.name for path in staging.iterdir()]
+            assert staged == staging / repo
+            assert names == [repo]
+            assert not any(name.startswith(repo) and name != repo for name in names)
+
+
+def test_broken_symlink_destination_is_rejected(mirror_moge2, tmp_path):
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    destination = staging / "LibreMoGe2b-normal"
+    try:
+        destination.symlink_to(tmp_path / "missing", target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    spec = dict(mirror_moge2.SIZES["b"])
+    spec["sha256"] = "0" * 64
+
+    with pytest.raises(FileExistsError, match="destination already exists"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert destination.is_symlink()
+
+
+def test_gitattributes_digest_mismatch_leaves_no_output(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    def altered_fetch(url, _expected_size, _expected_sha256, _label):
+        if url == mirror_moge2.GITATTRIBUTES_URL:
+            raise SystemExit(".gitattributes SHA-256 mismatch")
+        return b"test support bytes"
+
+    monkeypatch.setattr(mirror_moge2, "_fetch_verified_bytes", altered_fetch)
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match=r"\.gitattributes SHA-256 mismatch"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert not staging.exists()
+
+
+def test_source_card_digest_mismatch_leaves_no_output(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    def altered_fetch(url, _expected_size, _expected_sha256, _label):
+        if url.endswith("/README.md"):
+            raise SystemExit("source model card SHA-256 mismatch")
+        return b"test support bytes"
+
+    monkeypatch.setattr(mirror_moge2, "_fetch_verified_bytes", altered_fetch)
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match="source model card SHA-256 mismatch"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert not staging.exists()
+
+
+def test_bounded_fetch_rejects_declared_oversize_without_reading(
+    monkeypatch,
+):
+    mirror_moge2 = _load_mirror_module()
+    response = _FakeResponse(b"x" * 2_000_000, content_length="2000000")
+    observed = {}
+
+    def fake_urlopen(request, *, timeout):
+        observed["url"] = request.full_url
+        observed["timeout"] = timeout
+        return response
+
+    monkeypatch.setattr(mirror_moge2.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(SystemExit, match="server declared 2000000"):
+        mirror_moge2._fetch_verified_bytes(
+            "https://example.invalid/LICENSE",
+            4,
+            hashlib.sha256(b"test").hexdigest(),
+            "LICENSE",
+        )
+
+    assert response.read_sizes == []
+    assert response.closed
+    assert observed == {
+        "url": "https://example.invalid/LICENSE",
+        "timeout": mirror_moge2.SUPPORT_FETCH_TIMEOUT_SECONDS,
+    }
+
+
+def test_bounded_fetch_reads_at_most_expected_plus_one(monkeypatch):
+    mirror_moge2 = _load_mirror_module()
+    response = _FakeResponse(b"x" * 2_000_000)
+    monkeypatch.setattr(
+        mirror_moge2.urllib.request,
+        "urlopen",
+        lambda _request, *, timeout: response,
+    )
+
+    with pytest.raises(SystemExit, match="expected 4, got 5"):
+        mirror_moge2._fetch_verified_bytes(
+            "https://example.invalid/README.md",
+            4,
+            hashlib.sha256(b"test").hexdigest(),
+            "source model card",
+        )
+
+    assert sum(response.read_sizes) == 5
+    assert response.offset == 5
+    assert response.closed
+
+
+def test_bounded_fetch_accepts_only_exact_bytes(monkeypatch):
+    mirror_moge2 = _load_mirror_module()
+    content = b"test"
+    response = _FakeResponse(content, content_length=str(len(content)))
+    monkeypatch.setattr(
+        mirror_moge2.urllib.request,
+        "urlopen",
+        lambda _request, *, timeout: response,
+    )
+
+    actual = mirror_moge2._fetch_verified_bytes(
+        "https://example.invalid/.gitattributes",
+        len(content),
+        hashlib.sha256(content).hexdigest(),
+        ".gitattributes",
+    )
+
+    assert actual == content
+    assert max(response.read_sizes) <= len(content) + 1
+    assert response.closed
+
+
+def test_temp_hardlink_injection_cannot_overwrite_external_license(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    victim = tmp_path / "external-license"
+    victim.write_bytes(b"external bytes must survive")
+    real_write = mirror_moge2._write_exclusive_bytes
+    injected = False
+
+    def inject_hardlink(directory, name, content):
+        nonlocal injected
+        if name == "LICENSE" and not injected:
+            try:
+                os.link(victim, mirror_moge2._entry_path(directory, name))
+            except OSError as exc:
+                pytest.skip(f"hard links unavailable: {exc}")
+            injected = True
+        return real_write(directory, name, content)
+
+    monkeypatch.setattr(mirror_moge2, "_write_exclusive_bytes", inject_hardlink)
+    staging = tmp_path / "staging"
+
+    with pytest.raises(FileExistsError):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert injected
+    assert victim.read_bytes() == b"external bytes must survive"
+    assert not (staging / "LibreMoGe2b-normal").exists()
+
+
+def test_pre_publish_weight_and_license_swap_is_rejected(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    real_rename = mirror_moge2._rename_create_only
+
+    def swap_before_validation(root, temporary, destination_name, expected):
+        (temporary.path / "LibreMoGe2b-normal.pt").write_bytes(b"forged weight")
+        (temporary.path / "LICENSE").write_bytes(b"forged license")
+        real_rename(root, temporary, destination_name, expected)
+
+    monkeypatch.setattr(
+        mirror_moge2,
+        "_rename_create_only",
+        swap_before_validation,
+    )
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match="staged file record mismatch"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert not (staging / "LibreMoGe2b-normal").exists()
+    assert (
+        len(
+            [
+                path
+                for path in staging.iterdir()
+                if path.name.startswith(".LibreMoGe2b-normal.")
+            ]
+        )
+        == 1
+    )
+
+
+def test_post_publish_mutation_is_reported_and_left_for_manual_removal(
+    mirror_moge2, monkeypatch, tmp_path, capsys
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    real_native_rename = mirror_moge2._native_rename_create_only
+
+    def mutate_after_rename(root, temporary, destination_name):
+        real_native_rename(root, temporary, destination_name)
+        (root.path / destination_name / "LICENSE").write_bytes(
+            b"post-publication mutation"
+        )
+
+    monkeypatch.setattr(
+        mirror_moge2,
+        "_native_rename_create_only",
+        mutate_after_rename,
+    )
+    staging = tmp_path / "staging"
+
+    with pytest.raises(
+        SystemExit,
+        match="published destination failed final validation.*manual removal",
+    ):
+        mirror_moge2.stage("b", spec, staging)
+
+    destination = staging / "LibreMoGe2b-normal"
+    assert (destination / "LICENSE").read_bytes() == b"post-publication mutation"
+    assert "no cleanup attempted" in capsys.readouterr().err
+
+
+def test_replacement_victim_tree_is_never_deleted(mirror_moge2, monkeypatch, tmp_path):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "preserve.txt").write_bytes(b"do not delete")
+    owned_backup = tmp_path / "owned-backup"
+    replacement_path = None
+    real_rename = mirror_moge2._rename_create_only
+
+    def replace_owned_temp(root, temporary, destination_name, expected):
+        nonlocal replacement_path
+        replacement_path = temporary.path
+        temporary.path.rename(owned_backup)
+        victim.rename(replacement_path)
+        real_rename(root, temporary, destination_name, expected)
+
+    monkeypatch.setattr(mirror_moge2, "_rename_create_only", replace_owned_temp)
+    staging = tmp_path / "staging"
+
+    with pytest.raises(SystemExit, match="staging directory path changed"):
+        mirror_moge2.stage("b", spec, staging)
+
+    assert replacement_path is not None
+    assert (replacement_path / "preserve.txt").read_bytes() == b"do not delete"
+    assert (owned_backup / "LibreMoGe2b-normal.pt").exists()
+    assert not (staging / "LibreMoGe2b-normal").exists()
+
+
+def test_staging_root_swap_cannot_redirect_successful_publication(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    staging = tmp_path / "staging"
+    original_root = tmp_path / "sealed-root-backup"
+    real_native_rename = mirror_moge2._native_rename_create_only
+    state = {"blocked": False, "swapped": False}
+
+    def swap_root_before_rename(root, temporary, destination_name):
+        try:
+            root.path.rename(original_root)
+        except OSError:
+            state["blocked"] = True
+        else:
+            state["swapped"] = True
+            root.path.mkdir()
+        real_native_rename(root, temporary, destination_name)
+
+    monkeypatch.setattr(
+        mirror_moge2,
+        "_native_rename_create_only",
+        swap_root_before_rename,
+    )
+
+    if os.name == "nt":
+        staged = mirror_moge2.stage("b", spec, staging)
+        assert state == {"blocked": True, "swapped": False}
+        assert staged == staging / "LibreMoGe2b-normal"
+        assert (staged / "LibreMoGe2b-normal.pt").exists()
+    else:
+        with pytest.raises(SystemExit, match="staging directory path changed"):
+            mirror_moge2.stage("b", spec, staging)
+        assert state == {"blocked": False, "swapped": True}
+        assert not (staging / "LibreMoGe2b-normal").exists()
+        assert (original_root / "LibreMoGe2b-normal").exists()
+
+
+def test_cli_b_refusal_does_not_create_explicit_staging(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    staging = tmp_path / "must-not-exist"
+    monkeypatch.setattr(
+        mirror_moge2,
+        "stage",
+        lambda *_args, **_kwargs: pytest.fail("stage was reached before preflight"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["mirror_moge2.py", "b", "--staging", str(staging)],
+    )
+
+    with pytest.raises(SystemExit, match="not approved.*reproducible.*parity/load"):
+        mirror_moge2.main()
+
+    assert not staging.exists()
+
+
+def test_cli_default_preflight_refuses_all_before_partial_staging(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    staging = tmp_path / "must-not-exist"
+    monkeypatch.setattr(
+        mirror_moge2,
+        "stage",
+        lambda *_args, **_kwargs: pytest.fail("stage was reached before preflight"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["mirror_moge2.py", "--staging", str(staging)],
+    )
+
+    with pytest.raises(SystemExit, match="LibreMoGe2b-normal.*not approved"):
+        mirror_moge2.main()
+
+    assert not staging.exists()
+
+
+def test_parse_args_default_keeps_existing_scripts_create_behavior(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    staging = tmp_path / "compat-staging"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["mirror_other.py", "--staging", str(staging)],
+    )
+
+    args = mirror_moge2.parse_args("other mirror", ["s"])
+
+    assert args.staging == staging
+    assert staging.is_dir()
+
+
+def test_stage_is_deterministic_and_uses_exact_metadata_claims(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+    fetched_urls = []
+
+    def fake_fetch(url, _expected_size, _expected_sha256, _label):
+        fetched_urls.append(url)
+        if url == mirror_moge2.GITATTRIBUTES_URL:
+            return b"lfs contract\n"
+        if url == mirror_moge2.LICENSE_URL:
+            return b"audited composite license\n"
+        if url.endswith("/README.md"):
+            return b"---\r\nlicense: mit\r\n---\r\n"
+        pytest.fail(f"unexpected network URL: {url}")
+
+    monkeypatch.setattr(mirror_moge2, "_fetch_verified_bytes", fake_fetch)
+    approved_spec = _approved_b_spec(mirror_moge2, source)
+
+    first = mirror_moge2.stage("b", approved_spec, tmp_path / "first")
+    second = mirror_moge2.stage("b", approved_spec, tmp_path / "second")
+
+    expected_files = {
+        ".gitattributes",
+        "LICENSE",
+        "NOTICE",
+        "README.md",
+        "LibreMoGe2b-normal.pt",
+    }
+    assert {path.name for path in first.iterdir()} == expected_files
+    assert {path.name for path in second.iterdir()} == expected_files
+    for filename in expected_files:
+        assert (first / filename).read_bytes() == (second / filename).read_bytes()
+
+    assert (first / "LibreMoGe2b-normal.pt").read_bytes() == source.read_bytes()
+    assert (first / ".gitattributes").read_bytes() == b"lfs contract\n"
+    assert (first / "LICENSE").read_bytes() == b"audited composite license\n"
+    assert fetched_urls == [
+        mirror_moge2.GITATTRIBUTES_URL,
+        mirror_moge2.LICENSE_URL,
+        (
+            "https://huggingface.co/Ruicheng/moge-2-vitb-normal/resolve/"
+            "54ad3a693e61907ea4633d13dec6ee682fa09419/README.md"
+        ),
+        mirror_moge2.GITATTRIBUTES_URL,
+        mirror_moge2.LICENSE_URL,
+        (
+            "https://huggingface.co/Ruicheng/moge-2-vitb-normal/resolve/"
+            "54ad3a693e61907ea4633d13dec6ee682fa09419/README.md"
+        ),
+    ]
+
+    readme = (first / "README.md").read_text(encoding="utf-8")
+    notice = (first / "NOTICE").read_text(encoding="utf-8")
+    exact_claims = (
+        "Unused point, mask, and metric-scale head tensors are removed.",
+        "Encoder, neck,\nand normal-head tensors are retained unchanged",
+        "LibreYOLO checkpoint v1.0\nmetadata is added",
+    )
+    for claim in exact_claims:
+        assert claim in readme
+    assert "unused point, mask, and metric-scale head tensors are\n" in notice
+    assert "encoder, neck, and normal-head tensors are retained\n" in notice
+    assert "LibreYOLO checkpoint v1.0 metadata is added by\n" in notice
+    assert "State-dict key remapping only" not in readme
+    assert "state-dict key remapping only" not in notice
+
+    source_url = (
+        "https://huggingface.co/Ruicheng/moge-2-vitb-normal/blob/"
+        "54ad3a693e61907ea4633d13dec6ee682fa09419/model.pt"
+    )
+    source_card_url = (
+        "https://huggingface.co/Ruicheng/moge-2-vitb-normal/blob/"
+        "54ad3a693e61907ea4633d13dec6ee682fa09419/README.md"
+    )
+    for document in (readme, notice):
+        assert source_url in document
+        assert source_card_url in document
+        assert "declares these weights MIT" in " ".join(document.split())
+        assert mirror_moge2.MOGE_SOURCE_URL in document
+        assert mirror_moge2.MOGE_DINOV2_URL in document
+        assert mirror_moge2.MOGE_LICENSE_PAGE_URL in document
+        assert "https://github.com/facebookresearch/dinov2" not in document
+
+
+@pytest.mark.parametrize(
+    ("field", "overrides"),
+    [
+        ("model_family", {"model_family": "other"}),
+        ("size", {"size": "s"}),
+        ("task", {"task": "depth"}),
+        ("nc", {"nc": 2, "names": {0: "normal", 1: "normal"}}),
+        ("names", {"names": {0: "not-normal"}}),
+        ("imgsz", {"imgsz": 512}),
+    ],
+)
+def test_stage_rejects_unexpected_b_metadata(
+    mirror_moge2, monkeypatch, tmp_path, field, overrides
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(**overrides), source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+    approved_spec = _approved_b_spec(mirror_moge2, source)
+
+    with pytest.raises(SystemExit, match=rf"metadata mismatch: .*{field} expected"):
+        mirror_moge2.stage("b", approved_spec, tmp_path / "staging")
+
+
+def test_stage_uses_strict_schema_validation(mirror_moge2, monkeypatch, tmp_path):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    checkpoint = _checkpoint()
+    del checkpoint["schema_version"]
+    torch.save(checkpoint, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+    approved_spec = _approved_b_spec(mirror_moge2, source)
+
+    with pytest.raises(SystemExit, match="checkpoint metadata invalid"):
+        mirror_moge2.stage("b", approved_spec, tmp_path / "staging")

--- a/tests/unit/test_mirror_moge2.py
+++ b/tests/unit/test_mirror_moge2.py
@@ -741,25 +741,84 @@ def test_replacement_victim_tree_is_never_deleted(mirror_moge2, monkeypatch, tmp
     (victim / "preserve.txt").write_bytes(b"do not delete")
     owned_backup = tmp_path / "owned-backup"
     replacement_path = None
+    swap_blocked = False
     real_rename = mirror_moge2._rename_create_only
 
     def replace_owned_temp(root, temporary, destination_name, expected):
-        nonlocal replacement_path
+        nonlocal replacement_path, swap_blocked
         replacement_path = temporary.path
-        temporary.path.rename(owned_backup)
+        try:
+            temporary.path.rename(owned_backup)
+        except PermissionError:
+            swap_blocked = True
+            real_rename(root, temporary, destination_name, expected)
+            return
         victim.rename(replacement_path)
         real_rename(root, temporary, destination_name, expected)
 
     monkeypatch.setattr(mirror_moge2, "_rename_create_only", replace_owned_temp)
     staging = tmp_path / "staging"
 
-    with pytest.raises(SystemExit, match="staging directory path changed"):
-        mirror_moge2.stage("b", spec, staging)
+    if os.name == "nt":
+        staged = mirror_moge2.stage("b", spec, staging)
+        assert swap_blocked
+        assert replacement_path is not None
+        assert (victim / "preserve.txt").read_bytes() == b"do not delete"
+        assert not owned_backup.exists()
+        assert staged == staging / "LibreMoGe2b-normal"
+        assert (staged / "LibreMoGe2b-normal.pt").exists()
+    else:
+        with pytest.raises(SystemExit, match="staging directory path changed"):
+            mirror_moge2.stage("b", spec, staging)
 
-    assert replacement_path is not None
-    assert (replacement_path / "preserve.txt").read_bytes() == b"do not delete"
-    assert (owned_backup / "LibreMoGe2b-normal.pt").exists()
-    assert not (staging / "LibreMoGe2b-normal").exists()
+        assert not swap_blocked
+        assert replacement_path is not None
+        assert (replacement_path / "preserve.txt").read_bytes() == b"do not delete"
+        assert (owned_backup / "LibreMoGe2b-normal.pt").exists()
+        assert not (staging / "LibreMoGe2b-normal").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows directory sharing regression")
+def test_windows_private_directory_cannot_be_swapped_before_child_write(
+    mirror_moge2, monkeypatch, tmp_path
+):
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    source = weights / mirror_moge2.SIZES["b"]["converted"]
+    torch.save(_checkpoint(), source)
+    spec = _approved_b_spec(mirror_moge2, source)
+    monkeypatch.setattr(mirror_moge2, "WEIGHTS", weights)
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    sentinel = victim / "preserve.txt"
+    sentinel.write_bytes(b"do not write here")
+    owned_backup = tmp_path / "owned-backup"
+    swap_attempted = False
+    real_copy = mirror_moge2._copy_exclusive_weight
+
+    def swap_before_first_child_write(directory, name, source_handle):
+        nonlocal swap_attempted
+        swap_attempted = True
+        with pytest.raises(PermissionError):
+            directory.path.rename(owned_backup)
+        return real_copy(directory, name, source_handle)
+
+    monkeypatch.setattr(
+        mirror_moge2,
+        "_copy_exclusive_weight",
+        swap_before_first_child_write,
+    )
+
+    staging = tmp_path / "staging"
+    staged = mirror_moge2.stage("b", spec, staging)
+
+    assert swap_attempted
+    assert sentinel.read_bytes() == b"do not write here"
+    assert {path.name for path in victim.iterdir()} == {"preserve.txt"}
+    assert not owned_backup.exists()
+    assert staged == staging / "LibreMoGe2b-normal"
+    assert (staged / "LibreMoGe2b-normal.pt").exists()
 
 
 def test_staging_root_swap_cannot_redirect_successful_publication(


### PR DESCRIPTION
- Add MoGe-2B source metadata while keeping its converted artifact disabled until an approved deterministic digest exists.
- Make mirror staging descriptor-bound, byte-capped, create-only, and race-safe on supported platforms.
- Pin and verify the model card, composite license, and LFS attributes before publication.
- Add Windows/POSIX publication, mutation, cleanup, and no-side-effect regressions.

Verified: 49 tests passed, 1 Windows symlink-privilege skip; Ruff, format, diff check, and Greptile passed.

Not verified: no 2B weight was downloaded, converted, benchmarked, staged, or uploaded.

## Code provenance

- Staging, validation, publication, and test code is original LibreYOLO code written for this PR.
- No third-party implementation code was copied or adapted.
- Source metadata references `Ruicheng/moge-2-vitb-normal@54ad3a693e61907ea4633d13dec6ee682fa09419`; legal attribution is pinned to `microsoft/MoGe@925b8ed835a7a9cdb7578ba15c658a0afc969030` (MIT). The upstream card/license support bytes are fetched verbatim and SHA-256 verified.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds disabled MoGe-2B source metadata and hardens MoGe mirror staging with pinned support artifacts, descriptor-bound validation, byte caps, and create-only publication.
- Pins model-card, license, and LFS-attributes bytes by revision, size, and SHA-256.
- Rejects unapproved or digest-mismatched converted checkpoints before staging.
- Adds platform-specific race and mutation protections with extensive POSIX and Windows regression coverage.
- Updates the canonical upload filename whitelist for MoGe-2 normal models.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/mirror_moge2.py | Adds pinned MoGe-2B metadata and a descriptor-bound, digest-verified, create-only staging and publication pipeline. |
| scripts/_mirror_common.py | Allows callers to delay staging-directory creation while preserving eager creation as the default. |
| tests/unit/test_mirror_moge2.py | Adds broad validation, mutation, race, cleanup, publication, and platform-specific regression coverage. |
| skills/libreyolo-upload-hf-model/SKILL.md | Adds the three canonical MoGe-2 normal checkpoint filenames to the upload whitelist. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse requested sizes] --> B[Require approved converted digest]
    B --> C[Open and hash source checkpoint]
    C --> D[Fetch and verify pinned support artifacts]
    D --> E[Create private staging directory]
    E --> F[Copy, hash, and load-validate checkpoint]
    F --> G[Write five-file mirror contract]
    G --> H[Validate directory binding and inventory]
    H --> I[Atomic create-only publication]
    I --> J[Final binding and content validation]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Seal Windows mirror staging directory"](https://github.com/libreyolo/libreyolo/commit/7f0403ac6a82c5179f1ccacd3c487b640a4fc072) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53808325)</sub>

<!-- /greptile_comment -->