### PR TITLE
Pin SAM3DBody and MHR assets

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1996,13 +1996,17 @@ LibreYOLO Hugging Face org as librefacerec-det.onnx). Consumed via
 OpenCV's bundled cv2.FaceDetectorYN; no code is ported.
 MHR / Momentum Human Rig (Meta Platforms, Inc.)
 --------------------------------------------------------------------
-Source: https://github.com/facebookresearch/MHR
+Source: https://github.com/facebookresearch/MHR/tree/4998cec385b1aaa07abdefba71bfba2f83c7db32
 License: Apache License 2.0 (see licenses/Apache-2.0.txt)
 Copyright (c) Meta Platforms, Inc. and affiliates.
 Used for: the body model behind the `mesh` task. No MHR code is ported. The
 TorchScript asset assets/mhr_model.pt is downloaded at runtime from the public
-upstream release by libreyolo/models/sam3dbody/mhr_body.py and cached locally;
-it is NOT mirrored by LibreYOLO. The parameter layout used to drive it (204
+upstream v1.0.1 release by libreyolo/models/sam3dbody/mhr_body.py and cached
+locally; it is NOT mirrored by LibreYOLO. The release archive SHA-256 is
+e4f4f205cd87c0fa106577ba1de4fc763e4eb197c924461d2ef7e6944e9d6b94 and the
+extracted mhr_model.pt SHA-256 is
+352e271a6c42729c68554ceaea0c955e866970160c31e35506d782dc0f7377bc. The
+parameter layout used to drive it (204
 model parameters, 45 identity coefficients, 72 expression coefficients) is
 documented by the upstream Apache-2.0 demo.py and mhr.py and was additionally
 verified empirically against the released asset.
@@ -2010,7 +2014,7 @@ verified empirically against the released asset.
 --------------------------------------------------------------------
 SAM 3D Body (Meta Platforms, Inc.)
 --------------------------------------------------------------------
-Source: https://github.com/facebookresearch/sam-3d-body
+Source: https://github.com/facebookresearch/sam-3d-body/tree/b5c765a0d89d789985e186d396315e7590887b94
 License: SAM License (NOT a permissive license; it carries field-of-use
          restrictions including military, nuclear, espionage and weapons use,
          a no-reverse-engineering clause, and unilateral amendment by Meta)
@@ -2026,8 +2030,16 @@ Model weights: the SAM License permits redistribution provided its terms are
 passed through, so the checkpoints are mirrored byte-identically at
 huggingface.co/LibreYOLO/LibreSAM3DBodyd3-mesh and
 huggingface.co/LibreYOLO/LibreSAM3DBodyh-mesh, each carrying the SAM License
-text and an access gate recording acceptance. Mirroring does not change the
-license: those weights remain SAM-licensed, not MIT.
+text and an automatic access gate recording license acceptance plus
+self-attested identity and jurisdiction. The gate is not manual approval or
+screening by Meta. Mirroring does not change the license: those weights remain
+SAM-licensed, not MIT. Runtime transport is pinned respectively to Hub commits
+46e286e25347518d861ab0f21e1b2b5b630dc21f and
+a745fa6fcd5d71e16c4da921a28a6bb6f1ff9e3e and verifies the complete local
+runtime file set immediately before and after the SAM-licensed path-only loader
+runs. That handoff requires a trusted, quiescent same-user local filesystem;
+the wrapper does not claim to prevent transient substitution by a process that
+can mutate the same paths between the two checks.
 
 --------------------------------------------------------------------
 TEED (Xavier Soria Poma)

--- a/docs/adr/0013-mesh-task-contract.md
+++ b/docs/adr/0013-mesh-task-contract.md
@@ -86,6 +86,15 @@ The asset is fetched from the public upstream release and cached locally rather
 than mirrored on the LibreYOLO org: it is freely reachable and 700 MB, so a
 second copy would serve no one.
 
+The transport is pinned. LibreYOLO fetches the exact MHR v1.0.1 archive,
+checks its reviewed size and SHA-256 while streaming with a hard byte cap, and
+extracts only the exact reviewed `assets/mhr_model.pt` ZIP member. The member is
+checked again before create-only cache publication. LibreYOLO's standalone MHR
+decoder passes the same verified descriptor to `torch.jit.load`; the SAM 3D
+Body wrapper instead gives the upstream path-only constructor a pathname and
+rehashes it immediately before and after construction. Existing cache files are
+never trusted by existence alone.
+
 ### Deferred deliberately
 
 * **Export** is gated off with an explicit error, as semantic and point were.
@@ -122,9 +131,30 @@ never encounters SAM terms at all.
 
 Weights are a separate question from code. The SAM License does permit
 redistribution provided the terms are passed through, so the checkpoints are
-mirrored on the LibreYOLO org with the license included, behind a gate
-comparable to Meta's. Redistributing them ungated would route around Meta's
-sanctions screening and move that exposure onto this project.
+mirrored on the LibreYOLO org with the license included, behind an automatic
+gate. The gate records license acceptance plus self-attested identity and
+jurisdiction. It is not manual approval, sanctions screening, or other review
+by Meta.
+
+Each mirror is addressed by an immutable Hub commit. During online acquisition,
+LibreYOLO requires the reviewed `auto` gate and exact repository tree metadata,
+then dry-runs all five reviewed repository files to check the requested commit
+and transport-declared size before any runtime payload fetch. Offline
+acquisition makes no remote Hub API or network request and checks only the
+three runtime objects already present in the local Hub cache. Both paths materialize only
+`model.ckpt`, `model_config.yaml`, and `LICENSE` into a revision-keyed private
+cache view and hash every local byte. An explicit local checkpoint path must
+satisfy the same byte contract.
+
+The upstream SAM 3D Body constructor accepts checkpoint and MHR pathnames only;
+it has no descriptor-based loading API. LibreYOLO therefore validates the full
+snapshot and MHR file immediately before construction, validates both again
+after construction, and fails closed on a persistent change. This is not an
+immutable handoff: a same-user process could transiently substitute bytes and
+restore them between those checks. Checkpoint, config, license, and MHR paths
+must be held on a trusted, quiescent same-user local filesystem while the
+constructor runs. Network shares, adversarially writable directories, and a
+concurrent process mutating those paths are outside this wrapper's trust model.
 
 Consequences the wrapper accepts: the upstream repository has no packaging
 metadata, so it cannot be `pip install`ed and the user must clone it and point

--- a/docs/adr/0013-mesh-task-contract.md
+++ b/docs/adr/0013-mesh-task-contract.md
@@ -146,6 +146,21 @@ three runtime objects already present in the local Hub cache. Both paths materia
 cache view and hash every local byte. An explicit local checkpoint path must
 satisfy the same byte contract.
 
+Online acquisition downloads directly into the private same-filesystem staging
+directory, removes Hugging Face's small local metadata tree after strict link
+checks, and therefore does not retain a second multi-gigabyte copy in the
+shared Hub cache. An incomplete private stage is removed when its filesystem
+identity is still the one this process created. A fully verified stage is kept
+only when publication fails or an invalid concurrent destination wins; a later
+retry refuses to create another stage until the recovery path is inspected and
+removed, so repeated failures cannot silently accumulate full checkpoints.
+
+Legacy LibreYOLO caches are the migration exception. Their runtime files are
+copied into the current revision-keyed view and retained because those paths
+predate this transport and are user-owned. The migration warning names the
+three old files and their storage cost so the user can remove them after
+validating the new cache.
+
 The upstream SAM 3D Body constructor accepts checkpoint and MHR pathnames only;
 it has no descriptor-based loading API. LibreYOLO therefore validates the full
 snapshot and MHR file immediately before construction, validates both again

--- a/libreyolo/models/sam3dbody/_assets.py
+++ b/libreyolo/models/sam3dbody/_assets.py
@@ -603,6 +603,146 @@ def make_private_stage(parent: Path, *, prefix: str) -> tuple[Path, FileSeal]:
     return path, require_unlinked_directory(path, label="asset staging directory")
 
 
+def cleanup_private_file(
+    path: Path,
+    *,
+    expected_object: FileSeal,
+    label: str,
+) -> bool:
+    """Remove a process-created private file if it is still the same object.
+
+    Returns ``False`` when publication already moved the pathname. Cleanup is
+    deliberately limited to unpredictable, mode-0600 staging names created by
+    this process; callers must never use it for user-supplied cache entries.
+    """
+
+    try:
+        observed = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not inspect {label}: {path}") from exc
+    if (
+        _is_link_or_reparse(path, observed)
+        or not stat.S_ISREG(observed.st_mode)
+        or not _same_object(expected_object, observed)
+    ):
+        raise AssetIntegrityError(
+            f"refusing to clean a replaced or non-regular {label}: {path}"
+        )
+    try:
+        path.unlink()
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not clean {label}: {path}") from exc
+    return True
+
+
+def _collect_private_tree(
+    root: Path,
+    *,
+    label: str,
+) -> tuple[list[tuple[Path, FileSeal]], list[tuple[Path, FileSeal]]]:
+    files: list[tuple[Path, FileSeal]] = []
+    directories: list[tuple[Path, FileSeal]] = []
+    try:
+        entries = list(os.scandir(root))
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not inspect {label}: {root}") from exc
+    for entry in entries:
+        path = root / entry.name
+        try:
+            observed = os.lstat(path)
+        except OSError as exc:
+            raise AssetIntegrityError(f"could not inspect {label}: {path}") from exc
+        if _is_link_or_reparse(path, observed):
+            raise AssetIntegrityError(
+                f"refusing to clean linked or reparsed {label}: {path}"
+            )
+        if stat.S_ISDIR(observed.st_mode):
+            nested_files, nested_directories = _collect_private_tree(
+                path,
+                label=label,
+            )
+            files.extend(nested_files)
+            directories.extend(nested_directories)
+            directories.append((path, _seal(observed)))
+        elif stat.S_ISREG(observed.st_mode) and getattr(observed, "st_nlink", 1) == 1:
+            files.append((path, _seal(observed)))
+        else:
+            raise AssetIntegrityError(
+                f"refusing to clean non-private {label} entry: {path}"
+            )
+    return files, directories
+
+
+def cleanup_private_tree(
+    path: Path,
+    *,
+    expected_object: FileSeal,
+    label: str,
+) -> bool:
+    """Remove a process-created private tree after strict link/object checks.
+
+    The tree is scanned before deletion and every entry is revalidated at the
+    point of removal. Returns ``False`` when publication already moved the root.
+    As with asset loading, concurrent mutation by another same-user process is
+    outside the supported local-filesystem trust boundary.
+    """
+
+    try:
+        observed_root = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not inspect {label}: {path}") from exc
+    if (
+        _is_link_or_reparse(path, observed_root)
+        or not stat.S_ISDIR(observed_root.st_mode)
+        or not _same_object(expected_object, observed_root)
+    ):
+        raise AssetIntegrityError(
+            f"refusing to clean a replaced or non-directory {label}: {path}"
+        )
+
+    files, directories = _collect_private_tree(path, label=label)
+    try:
+        for file_path, expected in files:
+            current = os.lstat(file_path)
+            if (
+                _is_link_or_reparse(file_path, current)
+                or not stat.S_ISREG(current.st_mode)
+                or not _same_seal(expected, current)
+            ):
+                raise AssetIntegrityError(
+                    f"refusing to clean changed {label} entry: {file_path}"
+                )
+            file_path.unlink()
+        for directory, expected in directories:
+            current = os.lstat(directory)
+            if (
+                _is_link_or_reparse(directory, current)
+                or not stat.S_ISDIR(current.st_mode)
+                or not _same_object(expected, current)
+            ):
+                raise AssetIntegrityError(
+                    f"refusing to clean changed {label} directory: {directory}"
+                )
+            directory.rmdir()
+        final_root = os.lstat(path)
+        if (
+            _is_link_or_reparse(path, final_root)
+            or not stat.S_ISDIR(final_root.st_mode)
+            or not _same_object(expected_object, final_root)
+        ):
+            raise AssetIntegrityError(f"refusing to clean changed {label}: {path}")
+        path.rmdir()
+    except AssetIntegrityError:
+        raise
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not clean {label}: {path}") from exc
+    return True
+
+
 __all__ = [
     "AssetIntegrityError",
     "FileIdentity",
@@ -610,6 +750,8 @@ __all__ = [
     "PinnedFile",
     "atomic_rename_create_only",
     "canonical_json_bytes",
+    "cleanup_private_file",
+    "cleanup_private_tree",
     "copy_pinned_source",
     "ensure_unlinked_directory",
     "inspect_pinned_file",

--- a/libreyolo/models/sam3dbody/_assets.py
+++ b/libreyolo/models/sam3dbody/_assets.py
@@ -1,0 +1,620 @@
+"""Strict byte-identity helpers for SAM 3D Body and MHR assets.
+
+This module contains LibreYOLO-authored transport code only.  It does not
+inspect, import, or derive from the SAM 3D Body implementation.  The wrapper
+uses it to ensure that pickle/TorchScript inputs match reviewed upstream bytes
+before handing them to third-party loaders.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import hashlib
+import json
+import os
+import stat
+import sys
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Iterator
+
+
+_CHUNK_BYTES = 1024 * 1024
+_REPARSE_POINT = 0x400
+
+
+class AssetIntegrityError(RuntimeError):
+    """A local or downloaded model asset failed its pinned byte contract."""
+
+
+@dataclass(frozen=True)
+class PinnedFile:
+    """One reviewed file identity."""
+
+    path: str
+    size: int
+    sha256: str
+
+    def __post_init__(self) -> None:
+        if (
+            not self.path
+            or Path(self.path).name != self.path
+            or "/" in self.path
+            or "\\" in self.path
+        ):
+            raise ValueError(
+                f"pinned asset path must be a safe basename: {self.path!r}"
+            )
+        if (
+            isinstance(self.size, bool)
+            or not isinstance(self.size, int)
+            or self.size <= 0
+        ):
+            raise ValueError(
+                f"pinned asset size must be a positive integer: {self.path}"
+            )
+        if (
+            not isinstance(self.sha256, str)
+            or len(self.sha256) != 64
+            or any(char not in "0123456789abcdef" for char in self.sha256)
+        ):
+            raise ValueError(f"pinned asset SHA-256 is malformed: {self.path}")
+
+
+@dataclass(frozen=True)
+class FileIdentity:
+    """Observed pinned byte identity for one regular file."""
+
+    path: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class FileSeal:
+    """Filesystem identity held across a publication operation."""
+
+    device: int
+    inode: int
+    mode: int
+    size: int
+    mtime_ns: int
+    links: int
+
+
+def _is_link_or_reparse(path: Path, identity: os.stat_result | None = None) -> bool:
+    info = identity if identity is not None else os.lstat(path)
+    return stat.S_ISLNK(info.st_mode) or bool(
+        getattr(info, "st_file_attributes", 0) & _REPARSE_POINT
+    )
+
+
+def _seal(identity: os.stat_result) -> FileSeal:
+    return FileSeal(
+        device=identity.st_dev,
+        inode=identity.st_ino,
+        mode=identity.st_mode,
+        size=identity.st_size,
+        mtime_ns=identity.st_mtime_ns,
+        links=getattr(identity, "st_nlink", 1),
+    )
+
+
+def _same_seal(left: FileSeal, right: os.stat_result) -> bool:
+    return left == _seal(right)
+
+
+def _same_object(left: FileSeal, right: FileSeal | os.stat_result) -> bool:
+    observed = right if isinstance(right, FileSeal) else _seal(right)
+    return (
+        left.device == observed.device
+        and left.inode == observed.inode
+        and stat.S_IFMT(left.mode) == stat.S_IFMT(observed.mode)
+    )
+
+
+def _directory_chain(path: Path) -> tuple[Path, ...]:
+    """Return lexical path components from the filesystem anchor to ``path``."""
+
+    current = path.absolute()
+    chain = [current]
+    while current.parent != current:
+        current = current.parent
+        chain.append(current)
+    return tuple(reversed(chain))
+
+
+def _require_existing_directory_chain(path: Path, *, label: str) -> FileSeal:
+    """Reject a linked, reparsed, or non-directory component in ``path``."""
+
+    leaf: os.stat_result | None = None
+    for component in _directory_chain(path):
+        try:
+            identity = os.lstat(component)
+        except OSError as exc:
+            raise AssetIntegrityError(
+                f"{label} has a missing or inaccessible path component: {component}"
+            ) from exc
+        if _is_link_or_reparse(component, identity) or not stat.S_ISDIR(
+            identity.st_mode
+        ):
+            raise AssetIntegrityError(
+                f"{label} must contain only unlinked directories: {component}"
+            )
+        leaf = identity
+    if leaf is None:  # pragma: no cover - every absolute path has an anchor
+        raise AssetIntegrityError(f"{label} has no filesystem anchor: {path}")
+    return _seal(leaf)
+
+
+def require_unlinked_directory(path: Path, *, label: str) -> FileSeal:
+    """Seal a directory whose entire lexical path is link/reparse-free."""
+
+    return _require_existing_directory_chain(path, label=label)
+
+
+def ensure_unlinked_directory(path: Path, *, label: str) -> FileSeal:
+    """Create a cache directory if absent, then seal its lexical location."""
+
+    absolute = path.absolute()
+    for component in _directory_chain(absolute):
+        if not os.path.lexists(component):
+            break
+        try:
+            identity = os.lstat(component)
+        except OSError as exc:
+            raise AssetIntegrityError(
+                f"could not inspect {label} path component: {component}"
+            ) from exc
+        if _is_link_or_reparse(component, identity) or not stat.S_ISDIR(
+            identity.st_mode
+        ):
+            raise AssetIntegrityError(
+                f"{label} must contain only unlinked directories: {component}"
+            )
+    try:
+        absolute.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not create {label}: {absolute}") from exc
+    return require_unlinked_directory(absolute, label=label)
+
+
+def _open_regular_file(
+    path: Path,
+    *,
+    label: str,
+    require_single_link: bool,
+) -> tuple[int, FileSeal]:
+    try:
+        before = os.lstat(path)
+    except OSError as exc:
+        raise AssetIntegrityError(
+            f"{label} is missing or inaccessible: {path}"
+        ) from exc
+    if (
+        _is_link_or_reparse(path, before)
+        or not stat.S_ISREG(before.st_mode)
+        or (require_single_link and getattr(before, "st_nlink", 1) != 1)
+    ):
+        raise AssetIntegrityError(f"{label} must be an unlinked regular file: {path}")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not open {label}: {path}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        expected = _seal(before)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or (require_single_link and getattr(opened, "st_nlink", 1) != 1)
+            or not _same_seal(expected, opened)
+        ):
+            raise AssetIntegrityError(f"{label} changed while it was opened: {path}")
+        return descriptor, expected
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _hash_open_file(
+    stream: BinaryIO,
+    *,
+    expected_size: int,
+    label: str,
+) -> tuple[int, str]:
+    stream.seek(0)
+    digest = hashlib.sha256()
+    total = 0
+    while True:
+        chunk = stream.read(min(_CHUNK_BYTES, expected_size - total + 1))
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > expected_size:
+            raise AssetIntegrityError(
+                f"{label} exceeds its pinned {expected_size}-byte size"
+            )
+        digest.update(chunk)
+    return total, digest.hexdigest()
+
+
+@contextmanager
+def open_verified_file(
+    path: Path,
+    expected: PinnedFile,
+    *,
+    label: str,
+) -> Iterator[BinaryIO]:
+    """Yield the same descriptor whose complete bytes were verified.
+
+    A second descriptor-bound hash and a pathname identity check run after the
+    caller returns.  This closes pathname substitution and persistent in-place
+    mutation around deserialization without trusting a prior stat call.
+    """
+
+    descriptor, original = _open_regular_file(
+        path,
+        label=label,
+        require_single_link=True,
+    )
+    stream = os.fdopen(descriptor, "rb")
+    try:
+        observed_size, observed_sha = _hash_open_file(
+            stream,
+            expected_size=expected.size,
+            label=label,
+        )
+        if observed_size != expected.size or observed_sha != expected.sha256:
+            raise AssetIntegrityError(
+                f"{label} does not match the reviewed bytes "
+                f"(expected {expected.size} bytes/{expected.sha256}, got "
+                f"{observed_size} bytes/{observed_sha})"
+            )
+        if not _same_seal(original, os.fstat(stream.fileno())):
+            raise AssetIntegrityError(f"{label} changed during verification: {path}")
+        stream.seek(0)
+        yield stream
+
+        final_size, final_sha = _hash_open_file(
+            stream,
+            expected_size=expected.size,
+            label=label,
+        )
+        if final_size != expected.size or final_sha != expected.sha256:
+            raise AssetIntegrityError(f"{label} changed while it was in use: {path}")
+        if not _same_seal(original, os.fstat(stream.fileno())):
+            raise AssetIntegrityError(f"{label} changed while it was in use: {path}")
+        try:
+            after = os.lstat(path)
+        except OSError as exc:
+            raise AssetIntegrityError(
+                f"{label} disappeared while it was in use: {path}"
+            ) from exc
+        if _is_link_or_reparse(path, after) or not _same_seal(original, after):
+            raise AssetIntegrityError(
+                f"{label} path changed while it was in use: {path}"
+            )
+    finally:
+        stream.close()
+
+
+def inspect_pinned_file(
+    path: Path, expected: PinnedFile, *, label: str
+) -> FileIdentity:
+    """Hash a local file through a stable descriptor and return its identity."""
+
+    descriptor, original = _open_regular_file(
+        path,
+        label=label,
+        require_single_link=True,
+    )
+    with os.fdopen(descriptor, "rb") as stream:
+        observed_size, observed_sha = _hash_open_file(
+            stream,
+            expected_size=expected.size,
+            label=label,
+        )
+        if observed_size != expected.size or observed_sha != expected.sha256:
+            raise AssetIntegrityError(
+                f"{label} does not match the reviewed bytes "
+                f"(expected {expected.size} bytes/{expected.sha256}, got "
+                f"{observed_size} bytes/{observed_sha})"
+            )
+        if not _same_seal(original, os.fstat(stream.fileno())):
+            raise AssetIntegrityError(f"{label} changed during verification: {path}")
+    try:
+        after = os.lstat(path)
+    except OSError as exc:
+        raise AssetIntegrityError(
+            f"{label} disappeared during verification: {path}"
+        ) from exc
+    if _is_link_or_reparse(path, after) or not _same_seal(original, after):
+        raise AssetIntegrityError(f"{label} path changed during verification: {path}")
+    return FileIdentity(path=expected.path, size=expected.size, sha256=expected.sha256)
+
+
+def copy_pinned_source(
+    source: Path, destination: Path, expected: PinnedFile
+) -> FileSeal:
+    """Copy exact reviewed bytes from a Hub/cache source into a private file.
+
+    Hub snapshot paths may themselves be symlinks into a content-addressed blob
+    store.  The source is therefore allowed to resolve through a link, but the
+    opened target descriptor and copied bytes are fully verified.  The private
+    destination is always a create-only, single-link regular file.
+    """
+
+    try:
+        resolved = source.resolve(strict=True)
+        source_before = os.stat(resolved, follow_symlinks=False)
+    except OSError as exc:
+        raise AssetIntegrityError(
+            f"downloaded source is inaccessible: {source}"
+        ) from exc
+    if _is_link_or_reparse(resolved, source_before) or not stat.S_ISREG(
+        source_before.st_mode
+    ):
+        raise AssetIntegrityError(f"downloaded source is not a regular file: {source}")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        source_descriptor = os.open(resolved, flags)
+        destination_descriptor = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+    except OSError as exc:
+        if "source_descriptor" in locals():
+            os.close(source_descriptor)
+        raise AssetIntegrityError(
+            f"could not stage pinned asset {expected.path}"
+        ) from exc
+
+    digest = hashlib.sha256()
+    total = 0
+    source_stream = os.fdopen(source_descriptor, "rb")
+    try:
+        destination_stream = os.fdopen(destination_descriptor, "wb")
+    except BaseException:
+        source_stream.close()
+        os.close(destination_descriptor)
+        raise
+    try:
+        with source_stream as src, destination_stream as dst:
+            source_opened = os.fstat(src.fileno())
+            if _seal(source_before) != _seal(source_opened):
+                raise AssetIntegrityError(
+                    f"downloaded source changed while opening: {expected.path}"
+                )
+            while True:
+                chunk = src.read(min(_CHUNK_BYTES, expected.size - total + 1))
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > expected.size:
+                    raise AssetIntegrityError(
+                        f"downloaded {expected.path} exceeds its pinned size"
+                    )
+                digest.update(chunk)
+                dst.write(chunk)
+            dst.flush()
+            os.fsync(dst.fileno())
+            if _seal(source_opened) != _seal(os.fstat(src.fileno())):
+                raise AssetIntegrityError(
+                    f"downloaded source changed while copied: {expected.path}"
+                )
+            destination_seal = _seal(os.fstat(dst.fileno()))
+    except BaseException:
+        # The caller deliberately owns cleanup.  Never unlink a pathname after
+        # a separate identity check: a concurrent replacement could be user data.
+        raise
+
+    observed_sha = digest.hexdigest()
+    if total != expected.size or observed_sha != expected.sha256:
+        raise AssetIntegrityError(
+            f"downloaded {expected.path} does not match the reviewed bytes "
+            f"(expected {expected.size}/{expected.sha256}, got {total}/{observed_sha})"
+        )
+    destination_after = os.lstat(destination)
+    if (
+        _is_link_or_reparse(destination, destination_after)
+        or not stat.S_ISREG(destination_after.st_mode)
+        or getattr(destination_after, "st_nlink", 1) != 1
+        or not _same_seal(destination_seal, destination_after)
+    ):
+        raise AssetIntegrityError(f"staged asset changed after copy: {expected.path}")
+    return destination_seal
+
+
+def write_create_only(path: Path, payload: bytes, *, label: str) -> FileSeal:
+    """Write and fsync one private create-only file."""
+
+    try:
+        descriptor = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+            result = _seal(os.fstat(stream.fileno()))
+    except OSError as exc:
+        raise AssetIntegrityError(f"could not create {label}: {path}") from exc
+    return result
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Encode a strict stable JSON file."""
+
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _raise_rename_error(number: int, destination: Path) -> None:
+    if number in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise FileExistsError(
+            number,
+            "refusing to replace an existing pinned asset",
+            os.fspath(destination),
+        )
+    raise OSError(number, os.strerror(number), os.fspath(destination))
+
+
+def atomic_rename_create_only(
+    source: Path,
+    destination: Path,
+    *,
+    expected_source: FileSeal,
+    expected_parent: FileSeal,
+) -> None:
+    """Publish one file or directory without replacing an existing name.
+
+    POSIX calls are relative to an opened parent descriptor, preventing a
+    renamed parent from redirecting publication.  Every platform validates the
+    destination inode and lexical parent after the syscall; on uncertainty the
+    function fails and intentionally leaves the new entry for manual recovery.
+    """
+
+    if source.parent != destination.parent:
+        raise ValueError("create-only asset publication requires one shared parent")
+    parent = source.parent
+    current_parent = require_unlinked_directory(parent, label="asset cache parent")
+    if not _same_object(expected_parent, current_parent):
+        raise AssetIntegrityError("asset cache parent changed before publication")
+    try:
+        source_before = os.lstat(source)
+    except OSError as exc:
+        raise AssetIntegrityError(
+            "asset staging entry disappeared before publication"
+        ) from exc
+    if _is_link_or_reparse(source, source_before) or not _same_seal(
+        expected_source, source_before
+    ):
+        raise AssetIntegrityError("asset staging entry changed before publication")
+
+    if os.name == "nt":
+        try:
+            os.rename(source, destination)
+        except (FileExistsError, PermissionError) as exc:
+            if os.path.lexists(destination):
+                raise FileExistsError(
+                    f"refusing to replace an existing pinned asset: {destination}"
+                ) from exc
+            raise
+    else:
+        parent_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        if hasattr(os, "O_NOFOLLOW"):
+            parent_flags |= os.O_NOFOLLOW
+        parent_descriptor = os.open(parent, parent_flags)
+        try:
+            if not _same_object(expected_parent, os.fstat(parent_descriptor)):
+                raise AssetIntegrityError(
+                    "asset cache parent changed while opening for publication"
+                )
+            libc = ctypes.CDLL(None, use_errno=True)
+            if sys.platform.startswith("linux"):
+                rename = getattr(libc, "renameat2", None)
+                if rename is None:
+                    raise AssetIntegrityError(
+                        "atomic create-only asset publication requires renameat2"
+                    )
+                rename.argtypes = [
+                    ctypes.c_int,
+                    ctypes.c_char_p,
+                    ctypes.c_int,
+                    ctypes.c_char_p,
+                    ctypes.c_uint,
+                ]
+                rename.restype = ctypes.c_int
+                result = rename(
+                    parent_descriptor,
+                    os.fsencode(source.name),
+                    parent_descriptor,
+                    os.fsencode(destination.name),
+                    1,
+                )
+            elif sys.platform == "darwin":
+                rename = getattr(libc, "renameatx_np", None)
+                if rename is None:
+                    raise AssetIntegrityError(
+                        "atomic create-only asset publication requires renameatx_np"
+                    )
+                rename.argtypes = [
+                    ctypes.c_int,
+                    ctypes.c_char_p,
+                    ctypes.c_int,
+                    ctypes.c_char_p,
+                    ctypes.c_uint,
+                ]
+                rename.restype = ctypes.c_int
+                result = rename(
+                    parent_descriptor,
+                    os.fsencode(source.name),
+                    parent_descriptor,
+                    os.fsencode(destination.name),
+                    0x00000004,
+                )
+            else:
+                raise AssetIntegrityError(
+                    f"atomic asset publication is unsupported on {sys.platform!r}"
+                )
+            if result != 0:
+                _raise_rename_error(ctypes.get_errno(), destination)
+        finally:
+            os.close(parent_descriptor)
+
+    final_parent = require_unlinked_directory(parent, label="asset cache parent")
+    if not _same_object(expected_parent, final_parent):
+        raise AssetIntegrityError("asset cache parent changed during publication")
+    try:
+        published = os.lstat(destination)
+    except OSError as exc:
+        raise AssetIntegrityError("published asset disappeared") from exc
+    if _is_link_or_reparse(destination, published) or not _same_seal(
+        expected_source, published
+    ):
+        raise AssetIntegrityError("published asset identity changed during publication")
+
+
+def make_private_stage(parent: Path, *, prefix: str) -> tuple[Path, FileSeal]:
+    """Create and seal a private same-filesystem staging directory."""
+
+    try:
+        path = Path(tempfile.mkdtemp(dir=parent, prefix=prefix))
+        os.chmod(path, 0o700)
+    except OSError as exc:
+        raise AssetIntegrityError(
+            f"could not create asset staging directory in {parent}"
+        ) from exc
+    return path, require_unlinked_directory(path, label="asset staging directory")
+
+
+__all__ = [
+    "AssetIntegrityError",
+    "FileIdentity",
+    "FileSeal",
+    "PinnedFile",
+    "atomic_rename_create_only",
+    "canonical_json_bytes",
+    "copy_pinned_source",
+    "ensure_unlinked_directory",
+    "inspect_pinned_file",
+    "make_private_stage",
+    "open_verified_file",
+    "require_unlinked_directory",
+    "write_create_only",
+]

--- a/libreyolo/models/sam3dbody/mhr_body.py
+++ b/libreyolo/models/sam3dbody/mhr_body.py
@@ -28,29 +28,66 @@ documentation:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
-import shutil
 import tempfile
 import urllib.request
 import zipfile
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import BinaryIO, Optional, Tuple
 
 import torch
+
+from ._assets import (
+    AssetIntegrityError,
+    FileIdentity,
+    FileSeal,
+    PinnedFile,
+    atomic_rename_create_only,
+    ensure_unlinked_directory,
+    inspect_pinned_file,
+    open_verified_file,
+    require_unlinked_directory,
+)
 
 
 logger = logging.getLogger(__name__)
 
 
-# Public, ungated Apache-2.0 release asset. Not mirrored on the LibreYOLO org:
-# the upstream release is authoritative and freely reachable, so there is no
-# reason to hold a second copy of a 700 MB artifact.
+# Public, ungated Apache-2.0 release asset.  The exact release archive and
+# member identities were independently checked against GitHub release v1.0.1.
+# The archive is not retained after the reviewed member is extracted.
+MHR_RELEASE = "v1.0.1"
+MHR_SOURCE_REVISION = "4998cec385b1aaa07abdefba71bfba2f83c7db32"
 MHR_ASSETS_URL = (
-    "https://github.com/facebookresearch/MHR/releases/latest/download/assets.zip"
+    f"https://github.com/facebookresearch/MHR/releases/download/"
+    f"{MHR_RELEASE}/assets.zip"
+)
+MHR_ARCHIVE = PinnedFile(
+    path="assets.zip",
+    size=198_943_157,
+    sha256="e4f4f205cd87c0fa106577ba1de4fc763e4eb197c924461d2ef7e6944e9d6b94",
 )
 MHR_ARCHIVE_MEMBER = "assets/mhr_model.pt"
-MHR_LICENSE_URL = "https://github.com/facebookresearch/MHR/blob/main/LICENSE"
+MHR_MODEL_FILE = PinnedFile(
+    path="mhr_model.pt",
+    size=696_110_248,
+    sha256="352e271a6c42729c68554ceaea0c955e866970160c31e35506d782dc0f7377bc",
+)
+MHR_MEMBER_COMPRESSED_SIZE = 26_223_048
+MHR_MEMBER_CRC32 = 0x8A4C817C
+MHR_LICENSE_MEMBER = "assets/LICENSE.txt"
+MHR_LICENSE_URL = (
+    f"https://github.com/facebookresearch/MHR/blob/{MHR_SOURCE_REVISION}/LICENSE"
+)
+MHR_LICENSE_FILE = PinnedFile(
+    path="LICENSE",
+    size=11_358,
+    sha256="cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+)
+_DOWNLOAD_TIMEOUT_SECONDS = 60
+_COPY_CHUNK_BYTES = 1024 * 1024
 
 
 class MHRBodyModel(torch.nn.Module):
@@ -80,14 +117,30 @@ class MHRBodyModel(torch.nn.Module):
     def from_file(
         cls, path: str | Path, device: str | torch.device = "cpu"
     ) -> "MHRBodyModel":
-        """Load the TorchScript MHR model from a local file."""
-        path = Path(path)
-        if not path.exists():
+        """Load the reviewed TorchScript MHR model from a local file."""
+        path = Path(path).absolute()
+        if not os.path.lexists(path):
             raise FileNotFoundError(
                 f"MHR body model not found at {path}. Fetch it with "
                 "libreyolo.models.sam3dbody.mhr_body.ensure_mhr_model()."
             )
-        module = torch.jit.load(str(path), map_location=str(device)).eval()
+        require_unlinked_directory(path.parent, label="MHR model directory")
+        try:
+            # torch.jit.load accepts a file object.  Passing the descriptor that
+            # was hashed avoids reopening a mutable pathname after verification.
+            with open_verified_file(
+                path,
+                MHR_MODEL_FILE,
+                label="MHR TorchScript model",
+            ) as stream:
+                module = torch.jit.load(stream, map_location=str(device)).eval()
+        except Exception as exc:
+            if isinstance(exc, AssetIntegrityError):
+                raise
+            raise RuntimeError(
+                f"could not load the reviewed MHR model at {path}"
+            ) from exc
+        require_unlinked_directory(path.parent, label="MHR model directory")
         return cls(module).to(device).eval()
 
     @property
@@ -152,9 +205,7 @@ class MHRBodyModel(torch.nn.Module):
     @staticmethod
     def _check_width(name: str, tensor: torch.Tensor, expected: int) -> None:
         if tensor.shape[-1] != expected:
-            raise ValueError(
-                f"{name} must be {expected} wide, got {tensor.shape[-1]}"
-            )
+            raise ValueError(f"{name} must be {expected} wide, got {tensor.shape[-1]}")
 
 
 def default_mhr_path() -> Path:
@@ -165,48 +216,299 @@ def default_mhr_path() -> Path:
     return Path.home() / ".cache" / "libreyolo" / "mhr" / "mhr_model.pt"
 
 
+def inspect_mhr_model(path: str | Path) -> FileIdentity:
+    """Validate one MHR file and its complete unlinked parent chain."""
+
+    target = Path(path).absolute()
+    require_unlinked_directory(target.parent, label="MHR model directory")
+    identity = inspect_pinned_file(
+        target,
+        MHR_MODEL_FILE,
+        label="MHR TorchScript model",
+    )
+    require_unlinked_directory(target.parent, label="MHR model directory")
+    return identity
+
+
 def ensure_mhr_model(path: str | Path | None = None) -> Path:
     """Return a local MHR model path, downloading the release asset if absent.
 
     The asset is Apache 2.0 and served from a public GitHub release, so no
     token, registration or license acceptance is involved.
     """
-    target = Path(path) if path is not None else default_mhr_path()
-    if target.exists():
+    target = (Path(path) if path is not None else default_mhr_path()).absolute()
+    if os.path.lexists(target):
+        inspect_mhr_model(target)
         return target
 
-    target.parent.mkdir(parents=True, exist_ok=True)
+    ensure_unlinked_directory(
+        target.parent,
+        label="MHR cache directory",
+    )
     logger.info(
-        "Downloading the MHR body model (Apache 2.0, ~700 MB) from %s",
+        "Downloading the pinned MHR %s body model (Apache 2.0, ~700 MB) from %s",
+        MHR_RELEASE,
         MHR_ASSETS_URL,
     )
 
-    with tempfile.TemporaryDirectory() as tmp:
-        archive = Path(tmp) / "assets.zip"
-        request = urllib.request.Request(
-            MHR_ASSETS_URL, headers={"User-Agent": "libreyolo"}
-        )
-        with urllib.request.urlopen(request) as response, open(archive, "wb") as fh:
-            shutil.copyfileobj(response, fh)
+    with (
+        tempfile.TemporaryFile(mode="w+b") as archive,
+        tempfile.TemporaryFile(mode="w+b") as extracted,
+    ):
+        _download_archive(archive)
+        _extract_model(archive, extracted)
+        staged, staged_seal = _stage_model(extracted, target)
 
-        with zipfile.ZipFile(archive) as zf:
-            member = next(
-                (n for n in zf.namelist() if n.endswith("mhr_model.pt")), None
+    # Creating the stage changes the parent directory metadata, so capture its
+    # stable object identity after staging and immediately before publication.
+    parent_seal = require_unlinked_directory(
+        target.parent,
+        label="MHR cache directory",
+    )
+    try:
+        atomic_rename_create_only(
+            staged,
+            target,
+            expected_source=staged_seal,
+            expected_parent=parent_seal,
+        )
+    except FileExistsError:
+        # A concurrent process may have won the create-only race.  Its output
+        # is accepted only if it independently matches the same reviewed bytes.
+        try:
+            inspect_mhr_model(target)
+        except BaseException:
+            logger.warning(
+                "A concurrent MHR publication produced an invalid winner; the "
+                "owned staging file is recoverable at %s and the invalid competing "
+                "destination remains at %s; neither path was deleted",
+                staged,
+                target,
             )
-            if member is None:
-                raise RuntimeError(
-                    f"{MHR_ARCHIVE_MEMBER} is missing from the MHR release archive. "
-                    "The upstream release layout may have changed."
-                )
-            staged = Path(tmp) / "mhr_model.pt"
-            with zf.open(member) as src, open(staged, "wb") as dst:
-                shutil.copyfileobj(src, dst)
-            # Move into place only once complete, so an interrupted download
-            # never leaves a truncated file that later loads as corrupt.
-            shutil.move(str(staged), str(target))
+            raise
+        logger.warning(
+            "A concurrent MHR download won publication; conservative cleanup left "
+            "the verified staging file at %s",
+            staged,
+        )
+        return target
+    except BaseException:
+        logger.warning(
+            "MHR publication failed or its outcome was uncertain; recovery may be "
+            "at staging path %s or destination path %s; neither path was deleted "
+            "because either pathname may have been concurrently replaced",
+            staged,
+            target,
+        )
+        raise
+
+    try:
+        inspect_mhr_model(target)
+    except BaseException:
+        logger.warning(
+            "MHR post-publication validation failed; recovery may be at staging "
+            "path %s or destination path %s; neither path was deleted",
+            staged,
+            target,
+        )
+        raise
 
     logger.info("MHR body model ready at %s (license: %s)", target, MHR_LICENSE_URL)
     return target
+
+
+def _download_archive(destination: BinaryIO) -> None:
+    request = urllib.request.Request(
+        MHR_ASSETS_URL,
+        headers={"User-Agent": "libreyolo"},
+    )
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        response = urllib.request.urlopen(
+            request,
+            timeout=_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        raise RuntimeError(f"could not download pinned MHR archive: {exc}") from exc
+    with response:
+        declared = response.headers.get("Content-Length")
+        if declared is not None:
+            try:
+                declared_size = int(declared)
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError(
+                    "MHR archive returned an invalid Content-Length"
+                ) from exc
+            if declared_size != MHR_ARCHIVE.size:
+                raise RuntimeError(
+                    "MHR archive Content-Length does not match the reviewed release "
+                    f"({declared_size} != {MHR_ARCHIVE.size})"
+                )
+        while True:
+            chunk = response.read(min(_COPY_CHUNK_BYTES, MHR_ARCHIVE.size - total + 1))
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > MHR_ARCHIVE.size:
+                raise RuntimeError("MHR archive exceeded its reviewed byte size")
+            digest.update(chunk)
+            destination.write(chunk)
+    observed = digest.hexdigest()
+    if total != MHR_ARCHIVE.size or observed != MHR_ARCHIVE.sha256:
+        raise RuntimeError(
+            "MHR archive does not match the reviewed release bytes "
+            f"(expected {MHR_ARCHIVE.size}/{MHR_ARCHIVE.sha256}, got "
+            f"{total}/{observed})"
+        )
+    destination.flush()
+    destination.seek(0)
+
+
+def _extract_model(archive: BinaryIO, destination: BinaryIO) -> None:
+    archive.seek(0)
+    try:
+        with zipfile.ZipFile(archive) as bundle:
+            license_matches = [
+                item
+                for item in bundle.infolist()
+                if item.filename == MHR_LICENSE_MEMBER
+            ]
+            if len(license_matches) != 1:
+                raise RuntimeError(
+                    f"MHR archive must contain exactly one {MHR_LICENSE_MEMBER}"
+                )
+            license_entry = license_matches[0]
+            if (
+                license_entry.flag_bits & 0x1
+                or license_entry.is_dir()
+                or license_entry.file_size != MHR_LICENSE_FILE.size
+            ):
+                raise RuntimeError("MHR archive license metadata does not match v1.0.1")
+            license_digest = hashlib.sha256()
+            license_size = 0
+            with bundle.open(license_entry, "r") as license_stream:
+                while True:
+                    chunk = license_stream.read(
+                        min(
+                            _COPY_CHUNK_BYTES,
+                            MHR_LICENSE_FILE.size - license_size + 1,
+                        )
+                    )
+                    if not chunk:
+                        break
+                    license_size += len(chunk)
+                    if license_size > MHR_LICENSE_FILE.size:
+                        raise RuntimeError(
+                            "MHR archive license exceeded its reviewed size"
+                        )
+                    license_digest.update(chunk)
+            if (
+                license_size != MHR_LICENSE_FILE.size
+                or license_digest.hexdigest() != MHR_LICENSE_FILE.sha256
+            ):
+                raise RuntimeError("MHR archive license does not match v1.0.1")
+
+            matches = [
+                entry
+                for entry in bundle.infolist()
+                if entry.filename == MHR_ARCHIVE_MEMBER
+            ]
+            if len(matches) != 1:
+                raise RuntimeError(
+                    f"MHR archive must contain exactly one {MHR_ARCHIVE_MEMBER}"
+                )
+            entry = matches[0]
+            if (
+                entry.flag_bits & 0x1
+                or entry.is_dir()
+                or entry.compress_type != zipfile.ZIP_DEFLATED
+                or entry.file_size != MHR_MODEL_FILE.size
+                or entry.compress_size != MHR_MEMBER_COMPRESSED_SIZE
+                or entry.CRC != MHR_MEMBER_CRC32
+            ):
+                raise RuntimeError("MHR archive member metadata does not match v1.0.1")
+
+            digest = hashlib.sha256()
+            total = 0
+            with bundle.open(entry, "r") as source:
+                while True:
+                    chunk = source.read(
+                        min(_COPY_CHUNK_BYTES, MHR_MODEL_FILE.size - total + 1)
+                    )
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > MHR_MODEL_FILE.size:
+                        raise RuntimeError(
+                            "MHR model member exceeded its reviewed size"
+                        )
+                    digest.update(chunk)
+                    destination.write(chunk)
+    except (zipfile.BadZipFile, EOFError) as exc:
+        raise RuntimeError("MHR release archive is not a valid ZIP file") from exc
+    observed = digest.hexdigest()
+    if total != MHR_MODEL_FILE.size or observed != MHR_MODEL_FILE.sha256:
+        raise RuntimeError(
+            "MHR model member does not match the reviewed bytes "
+            f"(expected {MHR_MODEL_FILE.size}/{MHR_MODEL_FILE.sha256}, got "
+            f"{total}/{observed})"
+        )
+    destination.flush()
+    destination.seek(0)
+
+
+def _stage_model(source: BinaryIO, target: Path) -> tuple[Path, FileSeal]:
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.staging-",
+        suffix=".tmp",
+    )
+    staged = Path(temporary_name)
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with os.fdopen(descriptor, "wb") as destination:
+            source.seek(0)
+            while True:
+                chunk = source.read(
+                    min(_COPY_CHUNK_BYTES, MHR_MODEL_FILE.size - total + 1)
+                )
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MHR_MODEL_FILE.size:
+                    raise AssetIntegrityError(
+                        "verified MHR stream grew while preparing publication"
+                    )
+                digest.update(chunk)
+                destination.write(chunk)
+            destination.flush()
+            os.fsync(destination.fileno())
+            staged_identity = os.fstat(destination.fileno())
+    except BaseException:
+        logger.warning(
+            "MHR staging failed; the partial file was left at %s so cleanup cannot "
+            "delete a concurrently replaced path",
+            staged,
+        )
+        raise
+    observed = digest.hexdigest()
+    if total != MHR_MODEL_FILE.size or observed != MHR_MODEL_FILE.sha256:
+        logger.warning(
+            "MHR staging verification failed; the file was left at %s so cleanup "
+            "cannot delete a concurrently replaced path",
+            staged,
+        )
+        raise AssetIntegrityError("verified MHR stream changed before publication")
+    return staged, FileSeal(
+        device=staged_identity.st_dev,
+        inode=staged_identity.st_ino,
+        mode=staged_identity.st_mode,
+        size=staged_identity.st_size,
+        mtime_ns=staged_identity.st_mtime_ns,
+        links=getattr(staged_identity, "st_nlink", 1),
+    )
 
 
 def load_mhr_body_model(
@@ -215,8 +517,8 @@ def load_mhr_body_model(
     download: bool = True,
 ) -> MHRBodyModel:
     """Load the MHR body model, fetching it on first use when allowed."""
-    target = Path(path) if path is not None else default_mhr_path()
-    if not target.exists():
+    target = (Path(path) if path is not None else default_mhr_path()).absolute()
+    if not os.path.lexists(target):
         if not download:
             raise FileNotFoundError(
                 f"MHR body model not found at {target} and download=False."

--- a/libreyolo/models/sam3dbody/mhr_body.py
+++ b/libreyolo/models/sam3dbody/mhr_body.py
@@ -45,6 +45,7 @@ from ._assets import (
     FileSeal,
     PinnedFile,
     atomic_rename_create_only,
+    cleanup_private_file,
     ensure_unlinked_directory,
     inspect_pinned_file,
     open_verified_file,
@@ -230,6 +231,19 @@ def inspect_mhr_model(path: str | Path) -> FileIdentity:
     return identity
 
 
+def _mhr_staging_recoveries(target: Path) -> tuple[Path, ...]:
+    prefix = f".{target.name}.staging-"
+    try:
+        entries = list(os.scandir(target.parent))
+    except OSError as exc:
+        raise AssetIntegrityError(
+            f"could not inspect MHR cache directory: {target.parent}"
+        ) from exc
+    return tuple(
+        target.parent / entry.name for entry in entries if entry.name.startswith(prefix)
+    )
+
+
 def ensure_mhr_model(path: str | Path | None = None) -> Path:
     """Return a local MHR model path, downloading the release asset if absent.
 
@@ -245,6 +259,14 @@ def ensure_mhr_model(path: str | Path | None = None) -> Path:
         target.parent,
         label="MHR cache directory",
     )
+    recoveries = _mhr_staging_recoveries(target)
+    if recoveries:
+        paths = ", ".join(str(path) for path in recoveries)
+        raise AssetIntegrityError(
+            "A previous MHR acquisition left private recovery data. Inspect and "
+            "remove it before retrying so 700 MB staging files cannot accumulate: "
+            f"{paths}"
+        )
     logger.info(
         "Downloading the pinned MHR %s body model (Apache 2.0, ~700 MB) from %s",
         MHR_RELEASE,
@@ -286,11 +308,19 @@ def ensure_mhr_model(path: str | Path | None = None) -> Path:
                 target,
             )
             raise
-        logger.warning(
-            "A concurrent MHR download won publication; conservative cleanup left "
-            "the verified staging file at %s",
-            staged,
-        )
+        try:
+            cleanup_private_file(
+                staged,
+                expected_object=staged_seal,
+                label="losing MHR staging file",
+            )
+        except AssetIntegrityError:
+            logger.warning(
+                "A concurrent MHR download won publication, but its losing staging "
+                "file could not be cleaned safely: %s",
+                staged,
+                exc_info=True,
+            )
         return target
     except BaseException:
         logger.warning(
@@ -465,6 +495,15 @@ def _stage_model(source: BinaryIO, target: Path) -> tuple[Path, FileSeal]:
         suffix=".tmp",
     )
     staged = Path(temporary_name)
+    created_identity = os.fstat(descriptor)
+    created_seal = FileSeal(
+        device=created_identity.st_dev,
+        inode=created_identity.st_ino,
+        mode=created_identity.st_mode,
+        size=created_identity.st_size,
+        mtime_ns=created_identity.st_mtime_ns,
+        links=getattr(created_identity, "st_nlink", 1),
+    )
     digest = hashlib.sha256()
     total = 0
     try:
@@ -487,19 +526,34 @@ def _stage_model(source: BinaryIO, target: Path) -> tuple[Path, FileSeal]:
             os.fsync(destination.fileno())
             staged_identity = os.fstat(destination.fileno())
     except BaseException:
-        logger.warning(
-            "MHR staging failed; the partial file was left at %s so cleanup cannot "
-            "delete a concurrently replaced path",
-            staged,
-        )
+        try:
+            cleanup_private_file(
+                staged,
+                expected_object=created_seal,
+                label="incomplete MHR staging file",
+            )
+        except AssetIntegrityError:
+            logger.warning(
+                "MHR staging failed and its partial file could not be cleaned safely: %s",
+                staged,
+                exc_info=True,
+            )
         raise
     observed = digest.hexdigest()
     if total != MHR_MODEL_FILE.size or observed != MHR_MODEL_FILE.sha256:
-        logger.warning(
-            "MHR staging verification failed; the file was left at %s so cleanup "
-            "cannot delete a concurrently replaced path",
-            staged,
-        )
+        try:
+            cleanup_private_file(
+                staged,
+                expected_object=created_seal,
+                label="invalid MHR staging file",
+            )
+        except AssetIntegrityError:
+            logger.warning(
+                "MHR staging verification failed and its private file could not be "
+                "cleaned safely: %s",
+                staged,
+                exc_info=True,
+            )
         raise AssetIntegrityError("verified MHR stream changed before publication")
     return staged, FileSeal(
         device=staged_identity.st_dev,

--- a/libreyolo/models/sam3dbody/model.py
+++ b/libreyolo/models/sam3dbody/model.py
@@ -10,11 +10,19 @@ The practical consequence is that the upstream package is an optional
 dependency the user installs themselves. LibreYOLO ships no SAM-licensed bytes,
 and a user who never touches the mesh task never encounters those terms. The
 weights are a separate matter: the SAM License does permit redistribution with
-passthrough, so they are mirrored on the LibreYOLO org behind the same kind of
-gate Meta uses.
+passthrough, so they are mirrored on the LibreYOLO org behind an automatic
+gate that records license acceptance plus self-attested identity and
+jurisdiction. It is not manual approval or screening by Meta.
 
 The body model underneath is MHR, which is Apache 2.0 and fetched from its
 public release by :func:`~libreyolo.models.sam3dbody.mhr_body.ensure_mhr_model`.
+
+Security boundary: the upstream public constructor accepts checkpoint and MHR
+pathnames, not already-open descriptors. LibreYOLO hashes both exact file sets
+immediately before and after construction and rejects linked parent chains,
+but a same-user process could still perform a transient valid-to-invalid-to-
+valid replacement between those checks. These paths therefore must be on a
+trusted, quiescent local filesystem while the model is being constructed.
 """
 
 from __future__ import annotations
@@ -29,13 +37,23 @@ import torch
 import torch.nn as nn
 
 from ..base.model import BaseModel
-from .mhr_body import ensure_mhr_model
+from .mhr_body import ensure_mhr_model, inspect_mhr_model
 from .person import PersonDetector, resolve_person_detector
+from .snapshot import (
+    acquire_sam_snapshot,
+    inspect_sam_snapshot,
+)
 
 logger = logging.getLogger(__name__)
 
 UPSTREAM_REPO = "https://github.com/facebookresearch/sam-3d-body"
-SAM_LICENSE_URL = f"{UPSTREAM_REPO}/blob/main/LICENSE"
+UPSTREAM_REVISION = "b5c765a0d89d789985e186d396315e7590887b94"
+UPSTREAM_SOURCE_URL = f"{UPSTREAM_REPO}/tree/{UPSTREAM_REVISION}"
+SAM_LICENSE_URL = f"{UPSTREAM_REPO}/blob/{UPSTREAM_REVISION}/LICENSE"
+UPSTREAM_PATH_TRUST_BOUNDARY = (
+    "checkpoint and MHR paths must be on a trusted, quiescent same-user local "
+    "filesystem while the upstream path-only constructor runs"
+)
 
 
 class LibreSAM3DBody(BaseModel):
@@ -79,7 +97,9 @@ class LibreSAM3DBody(BaseModel):
         )
         self.names = {0: "person"}
         self.person_detector = (
-            resolve_person_detector(person_detector) if person_detector is not None else None
+            resolve_person_detector(person_detector)
+            if person_detector is not None
+            else None
         )
         self.model.eval()
 
@@ -110,6 +130,7 @@ class LibreSAM3DBody(BaseModel):
                 "License rather than a permissive one.\n\n"
                 "Install it yourself:\n"
                 f"  git clone {UPSTREAM_REPO}\n"
+                f"  git -C sam-3d-body checkout --detach {UPSTREAM_REVISION}\n"
                 "  pip install roma einops yacs omegaconf braceexpand "
                 "pytorch-lightning timm\n\n"
                 "Then point LibreYOLO at the clone, either with\n"
@@ -118,66 +139,79 @@ class LibreSAM3DBody(BaseModel):
                 f"Its terms, which you accept by using it: {SAM_LICENSE_URL}"
             ) from e
 
-    @classmethod
-    def _resolve_checkpoint(cls, model_path, size: str) -> Path:
-        """Locate the upstream checkpoint, downloading from the mirror if needed."""
+    def _resolve_checkpoint(self, model_path, size: str) -> Path:
+        """Locate and byte-validate the exact reviewed upstream checkpoint."""
         if model_path is not None:
-            path = Path(model_path)
+            path = Path(model_path).absolute()
             if path.is_dir():
-                path = path / "model.ckpt"
-            if not path.exists():
+                root = path
+            else:
+                if path.name != "model.ckpt":
+                    raise ValueError(
+                        "SAM 3D Body explicit checkpoints must be named model.ckpt "
+                        "and sit beside their reviewed model_config.yaml and LICENSE"
+                    )
+                root = path.parent
+            if not os.path.lexists(path):
                 raise FileNotFoundError(f"SAM 3D Body checkpoint not found: {path}")
-            return path
-
-        cache = Path.home() / ".cache" / "libreyolo" / "sam3dbody" / size
-        ckpt = cache / "model.ckpt"
-        if ckpt.exists():
-            return ckpt
-        return cls._download_checkpoint(cache, size)
+            identity = inspect_sam_snapshot(root, size, managed=False)
+        else:
+            identity = acquire_sam_snapshot(size)
+        self._checkpoint_snapshot_identity = identity
+        return identity.root / "model.ckpt"
 
     @classmethod
     def _download_checkpoint(cls, cache: Path, size: str) -> Path:
-        """Fetch the checkpoint and its config from the gated LibreYOLO mirror."""
-        repo = f"LibreYOLO/{cls.FILENAME_PREFIX}{size}-mesh"
-        try:
-            from huggingface_hub import hf_hub_download
-        except ImportError as e:
-            raise ImportError(
-                "huggingface_hub is required to download SAM 3D Body weights."
-            ) from e
-
-        cache.mkdir(parents=True, exist_ok=True)
-        try:
-            # The config must sit beside the checkpoint: upstream's loader looks
-            # for model_config.yaml next to (or one level above) the weights.
-            for filename in ("model_config.yaml", "LICENSE", "model.ckpt"):
-                hf_hub_download(repo_id=repo, filename=filename, local_dir=str(cache))
-        except Exception as e:  # noqa: BLE001 - surface the gate, whatever the cause
-            raise RuntimeError(
-                f"Could not download SAM 3D Body weights from {repo}.\n\n"
-                "These weights are redistributed under Meta's SAM License, and "
-                "the mirror is gated: you must accept the license terms on the "
-                f"model page (https://huggingface.co/{repo}) and authenticate "
-                "with `hf auth login`.\n\n"
-                f"Underlying error: {e}"
-            ) from e
-        return cache / "model.ckpt"
+        """Fetch a revision-keyed checkpoint view (legacy private helper)."""
+        identity = acquire_sam_snapshot(size, cache_root=cache)
+        return identity.root / "model.ckpt"
 
     # =========================================================================
     # BaseModel surface
     # =========================================================================
 
     def _init_model(self) -> nn.Module:
+        """Construct upstream under the documented path-only trust boundary."""
         self._import_upstream()
         from sam_3d_body import load_sam_3d_body
 
-        mhr = Path(self._mhr_path) if self._mhr_path else ensure_mhr_model()
+        mhr = (
+            Path(self._mhr_path).absolute()
+            if self._mhr_path is not None
+            else ensure_mhr_model()
+        )
+        mhr_before = inspect_mhr_model(mhr)
+        before = inspect_sam_snapshot(
+            self._checkpoint_snapshot_identity.root,
+            self.size,
+            managed=None,
+        )
+        if before != self._checkpoint_snapshot_identity:
+            raise RuntimeError(
+                "SAM 3D Body checkpoint/config bytes changed before the upstream "
+                "loader could construct the model"
+            )
         # Honour the caller's device rather than grabbing any available GPU:
         # device="cpu" on a CUDA machine is a legitimate request, and silently
         # overriding it would also desynchronize the guard in estimate().
         model, cfg = load_sam_3d_body(
             str(self._ckpt_path), device=str(self.device), mhr_path=str(mhr)
         )
+        mhr_observed = inspect_mhr_model(mhr)
+        if mhr_observed != mhr_before:
+            raise RuntimeError(
+                "MHR bytes changed while the upstream loader was constructing the model"
+            )
+        observed = inspect_sam_snapshot(
+            self._checkpoint_snapshot_identity.root,
+            self.size,
+            managed=None,
+        )
+        if observed != self._checkpoint_snapshot_identity:
+            raise RuntimeError(
+                "SAM 3D Body checkpoint/config bytes changed while the upstream "
+                "loader was constructing the model"
+            )
         self._cfg = cfg
         return model
 
@@ -232,14 +266,20 @@ class LibreSAM3DBody(BaseModel):
         if focal_length is not None:
             h, w = image_rgb.shape[:2]
             cam_int = torch.tensor(
-                [[[float(focal_length), 0.0, w / 2.0],
-                  [0.0, float(focal_length), h / 2.0],
-                  [0.0, 0.0, 1.0]]],
+                [
+                    [
+                        [float(focal_length), 0.0, w / 2.0],
+                        [0.0, float(focal_length), h / 2.0],
+                        [0.0, 0.0, 1.0],
+                    ]
+                ],
                 dtype=torch.float32,
             )
         return self.estimator.process_one_image(
-            image_rgb, bboxes=np.asarray(boxes_xyxy, dtype=np.float32),
-            cam_int=cam_int, inference_type="body",
+            image_rgb,
+            bboxes=np.asarray(boxes_xyxy, dtype=np.float32),
+            cam_int=cam_int,
+            inference_type="body",
         )
 
     @property
@@ -302,7 +342,7 @@ class LibreSAM3DBody(BaseModel):
     def train(self, *args, **kwargs):
         raise NotImplementedError(
             "Training is out of scope for LibreSAM3DBody. Train upstream at "
-            f"{UPSTREAM_REPO}."
+            f"{UPSTREAM_SOURCE_URL}."
         )
 
     def export(self, format: str = "onnx", **kwargs) -> str:

--- a/libreyolo/models/sam3dbody/model.py
+++ b/libreyolo/models/sam3dbody/model.py
@@ -133,6 +133,8 @@ class LibreSAM3DBody(BaseModel):
                 f"  git -C sam-3d-body checkout --detach {UPSTREAM_REVISION}\n"
                 "  pip install roma einops yacs omegaconf braceexpand "
                 "pytorch-lightning timm\n\n"
+                "For automatic checkpoint acquisition, also install\n"
+                '  pip install "libreyolo[hf]"\n\n'
                 "Then point LibreYOLO at the clone, either with\n"
                 "  LibreSAM3DBody(..., sam_3d_body_path='/path/to/sam-3d-body')\n"
                 "or by setting the SAM_3D_BODY_PATH environment variable.\n\n"

--- a/libreyolo/models/sam3dbody/snapshot.py
+++ b/libreyolo/models/sam3dbody/snapshot.py
@@ -23,6 +23,7 @@ from ._assets import (
     PinnedFile,
     atomic_rename_create_only,
     canonical_json_bytes,
+    cleanup_private_tree,
     copy_pinned_source,
     ensure_unlinked_directory,
     inspect_pinned_file,
@@ -414,6 +415,30 @@ def _validated_previous_revision_sources(
     return None
 
 
+def _staging_recoveries(parent: Path, pin: SAMSnapshotPin) -> tuple[Path, ...]:
+    prefix = f".{pin.revision}.staging-"
+    try:
+        entries = list(os.scandir(parent))
+    except OSError as exc:
+        raise AssetIntegrityError(
+            f"could not inspect SAM 3D Body cache directory: {parent}"
+        ) from exc
+    return tuple(
+        parent / entry.name for entry in entries if entry.name.startswith(prefix)
+    )
+
+
+def _require_no_staging_recovery(parent: Path, pin: SAMSnapshotPin) -> None:
+    recoveries = _staging_recoveries(parent, pin)
+    if recoveries:
+        paths = ", ".join(str(path) for path in recoveries)
+        raise AssetIntegrityError(
+            "A previous SAM 3D Body acquisition left private recovery data. "
+            "Inspect and remove it before retrying so multi-gigabyte staging "
+            f"copies cannot accumulate: {paths}"
+        )
+
+
 def _remote_preflight(hub, pin: SAMSnapshotPin) -> None:
     api = hub.HfApi()
     info = api.model_info(
@@ -511,15 +536,22 @@ def acquire_sam_snapshot(
 
     parent = destination.parent
     ensure_unlinked_directory(parent, label="SAM 3D Body cache directory")
+    _require_no_staging_recovery(parent, pin)
     sources = _validated_legacy_sources(parent, pin)
     if sources is None:
         sources = _validated_previous_revision_sources(parent, pin)
+    legacy_migration = sources is not None
+    legacy_paths = tuple(sources.values()) if sources is not None else ()
+    hub = None
+    offline = False
+    direct_download = False
     if sources is None:
         try:
             import huggingface_hub as hub
         except ImportError as exc:
             raise ImportError(
-                "huggingface_hub>=1.0 is required to acquire SAM 3D Body weights"
+                "huggingface_hub>=1.0 is required to acquire SAM 3D Body weights. "
+                'Install it with `pip install "libreyolo[hf]"`.'
             ) from exc
 
         offline = _offline_mode()
@@ -543,34 +575,91 @@ def acquire_sam_snapshot(
                 f"{pin.repo_id}@{pin.revision}: {exc}"
             ) from exc
 
-        sources = {}
-        try:
-            for expected in pin.runtime_files:
-                sources[expected.path] = Path(
-                    hub.hf_hub_download(
-                        repo_id=pin.repo_id,
-                        filename=expected.path,
-                        revision=pin.revision,
-                        local_files_only=offline,
+        if offline:
+            sources = {}
+            try:
+                for expected in pin.runtime_files:
+                    sources[expected.path] = Path(
+                        hub.hf_hub_download(
+                            repo_id=pin.repo_id,
+                            filename=expected.path,
+                            revision=pin.revision,
+                            local_files_only=True,
+                        )
                     )
-                )
-        except Exception as exc:
-            raise RuntimeError(
-                f"Could not download SAM 3D Body weights from {pin.repo_id}@{pin.revision}.\n\n"
-                "These weights are redistributed under Meta's SAM License and the mirror "
-                "is gated. Accept its terms on the model page and authenticate with "
-                "`hf auth login`, or populate the exact pinned Hub cache before enabling "
-                f"offline mode.\n\nUnderlying error: {exc}"
-            ) from exc
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Could not load cached SAM 3D Body weights from "
+                    f"{pin.repo_id}@{pin.revision}. Populate the exact pinned Hub "
+                    f"cache before enabling offline mode.\n\nUnderlying error: {exc}"
+                ) from exc
+        else:
+            direct_download = True
 
-    stage, _ = make_private_stage(parent, prefix=f".{pin.revision}.staging-")
+    stage, stage_object = make_private_stage(
+        parent,
+        prefix=f".{pin.revision}.staging-",
+    )
+    staged_identity: SAMSnapshotIdentity | None = None
     try:
-        for expected in pin.runtime_files:
-            copy_pinned_source(
-                sources[expected.path],
-                stage / expected.path,
-                expected,
-            )
+        if direct_download:
+            assert hub is not None
+            try:
+                for expected in pin.runtime_files:
+                    expected_path = (stage / expected.path).absolute()
+                    if os.path.lexists(expected_path):
+                        raise AssetIntegrityError(
+                            f"private download destination already exists: {expected.path}"
+                        )
+                    downloaded = Path(
+                        hub.hf_hub_download(
+                            repo_id=pin.repo_id,
+                            filename=expected.path,
+                            revision=pin.revision,
+                            local_files_only=False,
+                            local_dir=stage,
+                        )
+                    ).absolute()
+                    if downloaded != expected_path:
+                        raise AssetIntegrityError(
+                            "Hugging Face returned an unexpected local download path "
+                            f"for {expected.path}: {downloaded}"
+                        )
+                    inspect_pinned_file(
+                        expected_path,
+                        expected,
+                        label=f"downloaded SAM 3D Body file {expected.path}",
+                    )
+            except Exception as exc:
+                if isinstance(exc, AssetIntegrityError):
+                    raise
+                raise RuntimeError(
+                    f"Could not download SAM 3D Body weights from "
+                    f"{pin.repo_id}@{pin.revision}.\n\nThese weights are redistributed "
+                    "under Meta's SAM License and the mirror is gated. Accept its "
+                    "terms on the model page and authenticate with `hf auth login`.\n\n"
+                    f"Underlying error: {exc}"
+                ) from exc
+
+            hub_metadata = stage / ".cache"
+            if os.path.lexists(hub_metadata):
+                metadata_seal = require_unlinked_directory(
+                    hub_metadata,
+                    label="private Hugging Face download metadata",
+                )
+                cleanup_private_tree(
+                    hub_metadata,
+                    expected_object=metadata_seal,
+                    label="private Hugging Face download metadata",
+                )
+        else:
+            assert sources is not None
+            for expected in pin.runtime_files:
+                copy_pinned_source(
+                    sources[expected.path],
+                    stage / expected.path,
+                    expected,
+                )
         write_create_only(
             stage / SNAPSHOT_MARKER,
             _marker_bytes(pin),
@@ -603,6 +692,15 @@ def acquire_sam_snapshot(
             raise AssetIntegrityError(
                 "SAM 3D Body snapshot changed during create-only publication"
             )
+        if legacy_migration:
+            logger.warning(
+                "Migrated verified SAM 3D Body runtime files to %s. The source "
+                "files remain and consume another %.1f GB; remove them only after "
+                "confirming the revision-keyed cache works: %s",
+                destination,
+                sum(file.size for file in pin.runtime_files) / 1e9,
+                ", ".join(str(path) for path in legacy_paths),
+            )
         return published
     except FileExistsError:
         try:
@@ -616,20 +714,43 @@ def acquire_sam_snapshot(
                 destination,
             )
             raise
-        logger.warning(
-            "A concurrent SAM 3D Body download won publication; conservative cleanup "
-            "left the verified staging directory at %s",
-            stage,
-        )
+        try:
+            cleanup_private_tree(
+                stage,
+                expected_object=stage_object,
+                label="losing SAM 3D Body staging directory",
+            )
+        except AssetIntegrityError:
+            logger.warning(
+                "A concurrent SAM 3D Body download won publication, but its losing "
+                "staging directory could not be cleaned safely: %s",
+                stage,
+                exc_info=True,
+            )
         return winner
     except BaseException:
-        logger.warning(
-            "SAM 3D Body staging or post-publication validation failed; recovery "
-            "may be at staging path %s or destination path %s; neither path was "
-            "deleted because either pathname may have been concurrently replaced",
-            stage,
-            destination,
-        )
+        if staged_identity is None and os.path.lexists(stage):
+            try:
+                cleanup_private_tree(
+                    stage,
+                    expected_object=stage_object,
+                    label="incomplete SAM 3D Body staging directory",
+                )
+            except AssetIntegrityError:
+                logger.warning(
+                    "SAM 3D Body staging failed and its incomplete private directory "
+                    "could not be cleaned safely: %s",
+                    stage,
+                    exc_info=True,
+                )
+        else:
+            logger.warning(
+                "SAM 3D Body publication or post-publication validation failed; "
+                "verified recovery may be at staging path %s or destination path %s. "
+                "Inspect it before retrying.",
+                stage,
+                destination,
+            )
         raise
 
 

--- a/libreyolo/models/sam3dbody/snapshot.py
+++ b/libreyolo/models/sam3dbody/snapshot.py
@@ -1,0 +1,644 @@
+"""Pinned SAM 3D Body checkpoint transport.
+
+The mirrored checkpoints are SAM-licensed pickle files.  They are downloaded
+only from reviewed immutable Hub commits, copied into an exact allow-listed
+view, and fully hashed immediately before and after the upstream path-only
+loader runs.  That API cannot accept an already-open verified descriptor, so
+the handoff assumes a trusted, quiescent same-user local filesystem.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from ._assets import (
+    AssetIntegrityError,
+    FileIdentity,
+    PinnedFile,
+    atomic_rename_create_only,
+    canonical_json_bytes,
+    copy_pinned_source,
+    ensure_unlinked_directory,
+    inspect_pinned_file,
+    make_private_stage,
+    require_unlinked_directory,
+    write_create_only,
+)
+
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_MARKER = ".libreyolo_sam3dbody_snapshot.json"
+SNAPSHOT_SCHEMA = "libreyolo.sam3dbody-snapshot.v1"
+_RUNTIME_NAMES = ("LICENSE", "model.ckpt", "model_config.yaml")
+_REMOTE_NAMES = (
+    ".gitattributes",
+    "LICENSE",
+    "README.md",
+    "model.ckpt",
+    "model_config.yaml",
+)
+_REPARSE_POINT = 0x400
+
+
+@dataclass(frozen=True)
+class SAMSnapshotPin:
+    """One reviewed gated Hub snapshot."""
+
+    size: str
+    repo_id: str
+    revision: str
+    files: tuple[PinnedFile, ...]
+    gated: str = "auto"
+    legacy_revisions: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.size not in {"d3", "h"}:
+            raise ValueError(f"unsupported SAM 3D Body size pin: {self.size!r}")
+        if len(self.revision) != 40 or any(
+            char not in "0123456789abcdef" for char in self.revision
+        ):
+            raise ValueError(
+                f"SAM 3D Body revision must be a lowercase commit: {self.revision}"
+            )
+        names = tuple(file.path for file in self.files)
+        if names != _REMOTE_NAMES:
+            raise ValueError(
+                "SAM 3D Body snapshot pin must contain the exact remote tree"
+            )
+        if self.gated != "auto":
+            raise ValueError("SAM 3D Body mirrors must use the reviewed auto gate")
+        for revision in self.legacy_revisions:
+            if len(revision) != 40 or any(
+                char not in "0123456789abcdef" for char in revision
+            ):
+                raise ValueError(
+                    "legacy SAM 3D Body revisions must be lowercase commits"
+                )
+            if revision == self.revision:
+                raise ValueError("a legacy SAM 3D Body revision cannot be current")
+
+    @property
+    def by_name(self) -> Mapping[str, PinnedFile]:
+        return {file.path: file for file in self.files}
+
+    @property
+    def runtime_files(self) -> tuple[PinnedFile, ...]:
+        by_name = self.by_name
+        return tuple(by_name[name] for name in _RUNTIME_NAMES)
+
+
+@dataclass(frozen=True)
+class SAMSnapshotIdentity:
+    """Path-free reviewed identity plus the validated local root."""
+
+    root: Path
+    size: str
+    repo_id: str
+    revision: str
+    aggregate_sha256: str
+    files: tuple[FileIdentity, ...]
+
+
+_COMMON_ATTRIBUTES = PinnedFile(
+    path=".gitattributes",
+    size=1_519,
+    sha256="11ad7efa24975ee4b0c3c3a38ed18737f0658a5f75a0a96787b576a78a023361",
+)
+_COMMON_LICENSE = PinnedFile(
+    path="LICENSE",
+    size=8_204,
+    sha256="b3a5a0e2d973ab80e6610ccf1cffc40756050d0ace3cd4fec879b3ec290b2e9b",
+)
+
+SAM_SNAPSHOT_PINS: Mapping[str, SAMSnapshotPin] = {
+    "d3": SAMSnapshotPin(
+        size="d3",
+        repo_id="LibreYOLO/LibreSAM3DBodyd3-mesh",
+        revision="46e286e25347518d861ab0f21e1b2b5b630dc21f",
+        files=(
+            _COMMON_ATTRIBUTES,
+            _COMMON_LICENSE,
+            PinnedFile(
+                path="README.md",
+                size=3_982,
+                sha256="d1e195edb377518f095717bedf9663cad0286ff37e274fb0940da946e9928d3d",
+            ),
+            PinnedFile(
+                path="model.ckpt",
+                size=2_109_129_346,
+                sha256="b5a2f9d305dd02626b967aa2e86021fba07065df66ce7a7e00ffb9664f150abf",
+            ),
+            PinnedFile(
+                path="model_config.yaml",
+                size=1_488,
+                sha256="1012fc3f39cb5e90e3f8fbadf7bded31604bfafdce0321d17a7c1a2d3f08b88d",
+            ),
+        ),
+        legacy_revisions=(
+            "8e822540228d9de9bef1bf26414e27954044c242",
+            "4531d41c4b8349d272a9e7efb42b38a1a5f1d737",
+        ),
+    ),
+    "h": SAMSnapshotPin(
+        size="h",
+        repo_id="LibreYOLO/LibreSAM3DBodyh-mesh",
+        revision="a745fa6fcd5d71e16c4da921a28a6bb6f1ff9e3e",
+        files=(
+            _COMMON_ATTRIBUTES,
+            _COMMON_LICENSE,
+            PinnedFile(
+                path="README.md",
+                size=3_975,
+                sha256="71a09372eacd30fd850647884c9f7f91565e161ee2b2d6cb7c5be1613cc6cd3c",
+            ),
+            PinnedFile(
+                path="model.ckpt",
+                size=1_691_205_237,
+                sha256="3b1cb897f4bbd977bf81cbb0b30780a9582681ac642ee112865790ceb4d66056",
+            ),
+            PinnedFile(
+                path="model_config.yaml",
+                size=1_486,
+                sha256="d2e772e108b8727e9367681845fecb32806144acd0debc20868d100689470570",
+            ),
+        ),
+        legacy_revisions=(
+            "70a2c8ae1f43d6cff94105d83a8dd63d6eeba5ad",
+            "b3c59d31106cc69a8ab4cd6510bc289bccf258e9",
+        ),
+    ),
+}
+
+
+def _pin(size: str) -> SAMSnapshotPin:
+    try:
+        return SAM_SNAPSHOT_PINS[size]
+    except KeyError as exc:
+        raise ValueError(
+            f"unsupported SAM 3D Body size {size!r}; expected one of {sorted(SAM_SNAPSHOT_PINS)}"
+        ) from exc
+
+
+def default_sam_snapshot_root(size: str) -> Path:
+    """Return the revision-keyed managed snapshot path for ``size``."""
+
+    pin = _pin(size)
+    return Path.home() / ".cache" / "libreyolo" / "sam3dbody" / size / pin.revision
+
+
+def _marker_bytes(pin: SAMSnapshotPin, *, revision: str | None = None) -> bytes:
+    marker_revision = pin.revision if revision is None else revision
+    return canonical_json_bytes(
+        {
+            "schema": SNAPSHOT_SCHEMA,
+            "repo_id": pin.repo_id,
+            "revision": marker_revision,
+            "files": [
+                {
+                    "path": file.path,
+                    "size": file.size,
+                    "sha256": file.sha256,
+                }
+                for file in pin.runtime_files
+            ],
+        }
+    )
+
+
+def _is_link_or_reparse(path: Path, identity: os.stat_result) -> bool:
+    return stat.S_ISLNK(identity.st_mode) or bool(
+        getattr(identity, "st_file_attributes", 0) & _REPARSE_POINT
+    )
+
+
+def _inventory(root: Path) -> tuple[str, ...]:
+    require_unlinked_directory(root, label="SAM 3D Body snapshot root")
+    names: list[str] = []
+    folded: set[str] = set()
+    try:
+        entries = list(os.scandir(root))
+    except OSError as exc:
+        raise AssetIntegrityError(
+            f"could not inspect SAM 3D Body snapshot: {root}"
+        ) from exc
+    for entry in entries:
+        name = entry.name
+        folded_name = name.casefold()
+        if folded_name in folded:
+            raise AssetIntegrityError(
+                "SAM 3D Body snapshot contains case-insensitive duplicate names"
+            )
+        folded.add(folded_name)
+        path = root / name
+        try:
+            # Native Windows DirEntry.stat() can report st_nlink=0 for an
+            # ordinary file while lstat(path) correctly reports 1.
+            identity = os.lstat(path)
+        except OSError as exc:
+            raise AssetIntegrityError(
+                f"could not inspect snapshot entry {name}"
+            ) from exc
+        if (
+            entry.is_symlink()
+            or _is_link_or_reparse(path, identity)
+            or not stat.S_ISREG(identity.st_mode)
+            or getattr(identity, "st_nlink", 1) != 1
+        ):
+            raise AssetIntegrityError(
+                f"SAM 3D Body snapshot entry must be an unlinked regular file: {name}"
+            )
+        names.append(name)
+    return tuple(sorted(names, key=str.casefold))
+
+
+def _aggregate(pin: SAMSnapshotPin, files: tuple[FileIdentity, ...]) -> str:
+    payload = canonical_json_bytes(
+        {
+            "schema": SNAPSHOT_SCHEMA,
+            "size": pin.size,
+            "repo_id": pin.repo_id,
+            "revision": pin.revision,
+            "files": [
+                {"path": file.path, "size": file.size, "sha256": file.sha256}
+                for file in files
+            ],
+        }
+    )
+    return hashlib.sha256(payload).hexdigest()
+
+
+def inspect_sam_snapshot(
+    root: str | Path,
+    size: str,
+    *,
+    managed: bool | None = None,
+) -> SAMSnapshotIdentity:
+    """Strictly validate a local official checkpoint snapshot.
+
+    ``managed=True`` requires LibreYOLO's exact three-file runtime view and its
+    canonical revision marker.  Explicit user paths may contain either the
+    exact runtime view or the exact full five-file Hub tree, but no other file.
+    """
+
+    pin = _pin(size)
+    root_path = Path(root).absolute()
+    names = _inventory(root_path)
+    runtime = tuple(sorted(_RUNTIME_NAMES, key=str.casefold))
+    runtime_with_marker = tuple(
+        sorted((*_RUNTIME_NAMES, SNAPSHOT_MARKER), key=str.casefold)
+    )
+    remote = tuple(sorted(_REMOTE_NAMES, key=str.casefold))
+    if managed is True:
+        accepted = {runtime_with_marker}
+    elif managed is False:
+        accepted = {runtime, runtime_with_marker, remote}
+    else:
+        accepted = {runtime, runtime_with_marker, remote}
+    if names not in accepted:
+        expected = " or ".join(
+            ", ".join(group) for group in sorted(accepted, key=lambda group: len(group))
+        )
+        raise AssetIntegrityError(
+            "SAM 3D Body snapshot has an unexpected inventory; expected exactly "
+            f"{expected}, got {', '.join(names) or '<empty>'}"
+        )
+
+    by_name = pin.by_name
+    observed: list[FileIdentity] = []
+    for name in names:
+        if name == SNAPSHOT_MARKER:
+            payload = _marker_bytes(pin)
+            marker = PinnedFile(
+                path=SNAPSHOT_MARKER,
+                size=len(payload),
+                sha256=hashlib.sha256(payload).hexdigest(),
+            )
+            inspect_pinned_file(root_path / name, marker, label="snapshot marker")
+            continue
+        expected = by_name[name]
+        observed.append(
+            inspect_pinned_file(
+                root_path / name,
+                expected,
+                label=f"SAM 3D Body snapshot file {name}",
+            )
+        )
+    files = tuple(sorted(observed, key=lambda file: file.path.casefold()))
+    return SAMSnapshotIdentity(
+        root=root_path,
+        size=pin.size,
+        repo_id=pin.repo_id,
+        revision=pin.revision,
+        aggregate_sha256=_aggregate(pin, files),
+        files=files,
+    )
+
+
+def _offline_mode() -> bool:
+    truthy = {"1", "on", "true", "yes"}
+    return any(
+        os.environ.get(name, "").strip().casefold() in truthy
+        for name in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE")
+    )
+
+
+def _validated_legacy_sources(
+    parent: Path,
+    pin: SAMSnapshotPin,
+) -> dict[str, Path] | None:
+    """Adopt the former unversioned cache only when every byte is canonical."""
+
+    paths = {expected.path: parent / expected.path for expected in pin.runtime_files}
+    present = {name for name, path in paths.items() if os.path.lexists(path)}
+    if not present:
+        return None
+    if present != set(_RUNTIME_NAMES):
+        missing = sorted(set(_RUNTIME_NAMES) - present, key=str.casefold)
+        raise AssetIntegrityError(
+            "legacy SAM 3D Body cache is incomplete; missing " + ", ".join(missing)
+        )
+    for expected in pin.runtime_files:
+        inspect_pinned_file(
+            paths[expected.path],
+            expected,
+            label=f"legacy SAM 3D Body file {expected.path}",
+        )
+    return paths
+
+
+def _validated_previous_revision_sources(
+    parent: Path,
+    pin: SAMSnapshotPin,
+) -> dict[str, Path] | None:
+    """Adopt exact runtime bytes from a superseded card-only revision."""
+
+    for revision in pin.legacy_revisions:
+        root = parent / revision
+        if not os.path.lexists(root):
+            continue
+        names = _inventory(root)
+        expected_names = tuple(
+            sorted((*_RUNTIME_NAMES, SNAPSHOT_MARKER), key=str.casefold)
+        )
+        if names != expected_names:
+            raise AssetIntegrityError(
+                "legacy revision-keyed SAM 3D Body cache has an unexpected inventory"
+            )
+        marker_payload = _marker_bytes(pin, revision=revision)
+        inspect_pinned_file(
+            root / SNAPSHOT_MARKER,
+            PinnedFile(
+                path=SNAPSHOT_MARKER,
+                size=len(marker_payload),
+                sha256=hashlib.sha256(marker_payload).hexdigest(),
+            ),
+            label="legacy SAM 3D Body snapshot marker",
+        )
+        sources: dict[str, Path] = {}
+        for expected in pin.runtime_files:
+            source = root / expected.path
+            inspect_pinned_file(
+                source,
+                expected,
+                label=f"legacy SAM 3D Body file {expected.path}",
+            )
+            sources[expected.path] = source
+        return sources
+    return None
+
+
+def _remote_preflight(hub, pin: SAMSnapshotPin) -> None:
+    api = hub.HfApi()
+    info = api.model_info(
+        repo_id=pin.repo_id,
+        revision=pin.revision,
+        files_metadata=True,
+    )
+    if getattr(info, "sha", None) != pin.revision:
+        raise AssetIntegrityError(f"Hub resolved {pin.repo_id} to an unexpected commit")
+    if getattr(info, "gated", None) != pin.gated:
+        raise AssetIntegrityError(
+            f"{pin.repo_id}@{pin.revision} no longer has the reviewed {pin.gated!r} gate"
+        )
+    siblings = list(getattr(info, "siblings", ()) or ())
+    sibling_names = [getattr(item, "rfilename", None) for item in siblings]
+    if any(not isinstance(name, str) or not name for name in sibling_names):
+        raise AssetIntegrityError(
+            f"{pin.repo_id}@{pin.revision} returned malformed tree metadata"
+        )
+    remote_names = tuple(sorted(sibling_names, key=str.casefold))
+    if remote_names != tuple(sorted(_REMOTE_NAMES, key=str.casefold)):
+        raise AssetIntegrityError(
+            f"{pin.repo_id}@{pin.revision} no longer has the reviewed exact tree"
+        )
+    expected = pin.by_name
+    for item in siblings:
+        name = item.rfilename
+        size = getattr(item, "size", None)
+        if (
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or size != expected[name].size
+        ):
+            raise AssetIntegrityError(
+                f"Hub metadata size mismatch for {pin.repo_id}/{name}"
+            )
+        lfs = getattr(item, "lfs", None)
+        lfs_sha = (
+            lfs.get("sha256")
+            if isinstance(lfs, Mapping)
+            else getattr(lfs, "sha256", None)
+        )
+        if lfs_sha is not None and lfs_sha != expected[name].sha256:
+            raise AssetIntegrityError(
+                f"Hub LFS digest mismatch for {pin.repo_id}/{name}"
+            )
+
+
+def _download_metadata_preflight(hub, pin: SAMSnapshotPin, *, offline: bool) -> None:
+    """Validate every download leg's declared size before fetching any payload."""
+
+    expected_files = pin.runtime_files if offline else pin.files
+    for expected in expected_files:
+        try:
+            metadata = hub.hf_hub_download(
+                repo_id=pin.repo_id,
+                filename=expected.path,
+                revision=pin.revision,
+                local_files_only=offline,
+                dry_run=True,
+            )
+        except TypeError as exc:
+            if "dry_run" in str(exc):
+                raise RuntimeError(
+                    "SAM 3D Body secure downloads require huggingface_hub>=1.0 "
+                    "for dry-run byte metadata"
+                ) from exc
+            raise
+        size = getattr(metadata, "file_size", None)
+        if isinstance(size, bool) or not isinstance(size, int) or size != expected.size:
+            raise AssetIntegrityError(
+                f"Hub download metadata size mismatch for {pin.repo_id}/{expected.path}"
+            )
+        if getattr(metadata, "commit_hash", None) != pin.revision:
+            raise AssetIntegrityError(
+                f"Hub download metadata commit mismatch for {pin.repo_id}/{expected.path}"
+            )
+
+
+def acquire_sam_snapshot(
+    size: str,
+    *,
+    cache_root: str | Path | None = None,
+) -> SAMSnapshotIdentity:
+    """Return an exact local runtime view of a pinned gated Hub snapshot."""
+
+    pin = _pin(size)
+    destination = (
+        default_sam_snapshot_root(size)
+        if cache_root is None
+        else Path(cache_root).absolute() / pin.revision
+    )
+    if os.path.lexists(destination):
+        return inspect_sam_snapshot(destination, size, managed=True)
+
+    parent = destination.parent
+    ensure_unlinked_directory(parent, label="SAM 3D Body cache directory")
+    sources = _validated_legacy_sources(parent, pin)
+    if sources is None:
+        sources = _validated_previous_revision_sources(parent, pin)
+    if sources is None:
+        try:
+            import huggingface_hub as hub
+        except ImportError as exc:
+            raise ImportError(
+                "huggingface_hub>=1.0 is required to acquire SAM 3D Body weights"
+            ) from exc
+
+        offline = _offline_mode()
+        if not offline:
+            try:
+                _remote_preflight(hub, pin)
+            except Exception as exc:
+                if isinstance(exc, AssetIntegrityError):
+                    raise
+                raise RuntimeError(
+                    f"could not verify the gated snapshot {pin.repo_id}@{pin.revision}: {exc}"
+                ) from exc
+
+        try:
+            _download_metadata_preflight(hub, pin, offline=offline)
+        except Exception as exc:
+            if isinstance(exc, AssetIntegrityError):
+                raise
+            raise RuntimeError(
+                f"Could not preflight SAM 3D Body weights from "
+                f"{pin.repo_id}@{pin.revision}: {exc}"
+            ) from exc
+
+        sources = {}
+        try:
+            for expected in pin.runtime_files:
+                sources[expected.path] = Path(
+                    hub.hf_hub_download(
+                        repo_id=pin.repo_id,
+                        filename=expected.path,
+                        revision=pin.revision,
+                        local_files_only=offline,
+                    )
+                )
+        except Exception as exc:
+            raise RuntimeError(
+                f"Could not download SAM 3D Body weights from {pin.repo_id}@{pin.revision}.\n\n"
+                "These weights are redistributed under Meta's SAM License and the mirror "
+                "is gated. Accept its terms on the model page and authenticate with "
+                "`hf auth login`, or populate the exact pinned Hub cache before enabling "
+                f"offline mode.\n\nUnderlying error: {exc}"
+            ) from exc
+
+    stage, _ = make_private_stage(parent, prefix=f".{pin.revision}.staging-")
+    try:
+        for expected in pin.runtime_files:
+            copy_pinned_source(
+                sources[expected.path],
+                stage / expected.path,
+                expected,
+            )
+        write_create_only(
+            stage / SNAPSHOT_MARKER,
+            _marker_bytes(pin),
+            label="SAM 3D Body snapshot marker",
+        )
+        staged_identity = inspect_sam_snapshot(stage, size, managed=True)
+        stage_seal = require_unlinked_directory(
+            stage,
+            label="SAM 3D Body staging directory",
+        )
+        parent_seal = require_unlinked_directory(
+            parent,
+            label="SAM 3D Body cache directory",
+        )
+        atomic_rename_create_only(
+            stage,
+            destination,
+            expected_source=stage_seal,
+            expected_parent=parent_seal,
+        )
+        published = inspect_sam_snapshot(destination, size, managed=True)
+        if published != SAMSnapshotIdentity(
+            root=destination,
+            size=staged_identity.size,
+            repo_id=staged_identity.repo_id,
+            revision=staged_identity.revision,
+            aggregate_sha256=staged_identity.aggregate_sha256,
+            files=staged_identity.files,
+        ):
+            raise AssetIntegrityError(
+                "SAM 3D Body snapshot changed during create-only publication"
+            )
+        return published
+    except FileExistsError:
+        try:
+            winner = inspect_sam_snapshot(destination, size, managed=True)
+        except BaseException:
+            logger.warning(
+                "A concurrent SAM 3D Body publication produced an invalid winner; "
+                "the owned staging directory is recoverable at %s and the invalid "
+                "competing destination remains at %s; neither path was deleted",
+                stage,
+                destination,
+            )
+            raise
+        logger.warning(
+            "A concurrent SAM 3D Body download won publication; conservative cleanup "
+            "left the verified staging directory at %s",
+            stage,
+        )
+        return winner
+    except BaseException:
+        logger.warning(
+            "SAM 3D Body staging or post-publication validation failed; recovery "
+            "may be at staging path %s or destination path %s; neither path was "
+            "deleted because either pathname may have been concurrently replaced",
+            stage,
+            destination,
+        )
+        raise
+
+
+__all__ = [
+    "SAMSnapshotIdentity",
+    "SAMSnapshotPin",
+    "SAM_SNAPSHOT_PINS",
+    "SNAPSHOT_MARKER",
+    "acquire_sam_snapshot",
+    "default_sam_snapshot_root",
+    "inspect_sam_snapshot",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,7 +285,8 @@ dvc = [
 ]
 hf = [
     # Hugging Face Hub loading (LibreYOLO("owner/repo")) and push_to_hub.
-    "huggingface_hub>=0.34.0",
+    # v1 adds dry-run byte metadata used to bound gated model downloads.
+    "huggingface_hub>=1.0.0",
 ]
 all = [
     "libreyolo[stream]",

--- a/tests/unit/test_sam3dbody_assets.py
+++ b/tests/unit/test_sam3dbody_assets.py
@@ -1,0 +1,1071 @@
+"""Hermetic integrity tests for SAM 3D Body and MHR asset transport."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import os
+import subprocess
+import sys
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+import torch
+
+from libreyolo.models.sam3dbody import mhr_body
+from libreyolo.models.sam3dbody._assets import (
+    AssetIntegrityError,
+    FileSeal,
+    PinnedFile,
+    atomic_rename_create_only,
+    ensure_unlinked_directory,
+    inspect_pinned_file,
+    require_unlinked_directory,
+)
+from libreyolo.models.sam3dbody import snapshot
+
+
+pytestmark = pytest.mark.unit
+
+
+def _sha(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+class _Response(io.BytesIO):
+    def __init__(self, payload: bytes, declared: str | None = None):
+        super().__init__(payload)
+        self.read_calls = 0
+        self.headers = {}
+        if declared is not None:
+            self.headers["Content-Length"] = declared
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    def read(self, *args, **kwargs):
+        self.read_calls += 1
+        return super().read(*args, **kwargs)
+
+
+@pytest.fixture
+def tiny_mhr(monkeypatch):
+    model = b"reviewed-mhr-model-bytes"
+    license_bytes = b"license"
+    archive_stream = io.BytesIO()
+    with zipfile.ZipFile(
+        archive_stream, "w", compression=zipfile.ZIP_DEFLATED
+    ) as bundle:
+        bundle.writestr(mhr_body.MHR_ARCHIVE_MEMBER, model)
+        bundle.writestr(mhr_body.MHR_LICENSE_MEMBER, license_bytes)
+    archive = archive_stream.getvalue()
+    with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
+        entry = bundle.getinfo(mhr_body.MHR_ARCHIVE_MEMBER)
+
+    monkeypatch.setattr(
+        mhr_body,
+        "MHR_ARCHIVE",
+        PinnedFile("assets.zip", len(archive), _sha(archive)),
+    )
+    monkeypatch.setattr(
+        mhr_body,
+        "MHR_MODEL_FILE",
+        PinnedFile("mhr_model.pt", len(model), _sha(model)),
+    )
+    monkeypatch.setattr(mhr_body, "MHR_MEMBER_COMPRESSED_SIZE", entry.compress_size)
+    monkeypatch.setattr(mhr_body, "MHR_MEMBER_CRC32", entry.CRC)
+    monkeypatch.setattr(
+        mhr_body,
+        "MHR_LICENSE_FILE",
+        PinnedFile("LICENSE", len(license_bytes), _sha(license_bytes)),
+    )
+    return model, archive
+
+
+def test_mhr_download_extracts_only_the_exact_reviewed_member(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    model, archive = tiny_mhr
+    monkeypatch.setattr(
+        mhr_body.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(archive, str(len(archive))),
+    )
+    target = tmp_path / "cache" / "mhr_model.pt"
+
+    assert mhr_body.ensure_mhr_model(target) == target.absolute()
+    assert target.read_bytes() == model
+    inspect_pinned_file(target, mhr_body.MHR_MODEL_FILE, label="test MHR")
+
+
+def test_mhr_invalid_concurrent_winner_reports_owned_stage(
+    tmp_path, monkeypatch, caplog, tiny_mhr
+):
+    _model, archive = tiny_mhr
+    monkeypatch.setattr(
+        mhr_body.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(archive, str(len(archive))),
+    )
+    target = tmp_path / "cache" / "mhr_model.pt"
+
+    def lose_publication(_source, destination, **_kwargs):
+        destination.write_bytes(b"invalid concurrent winner")
+        raise FileExistsError("concurrent winner")
+
+    monkeypatch.setattr(mhr_body, "atomic_rename_create_only", lose_publication)
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(AssetIntegrityError, match="pinned|reviewed bytes"),
+    ):
+        mhr_body.ensure_mhr_model(target)
+
+    leaked = list(target.parent.glob(f".{target.name}.staging-*.tmp"))
+    assert len(leaked) == 1
+    assert str(leaked[0]) in caplog.text
+    assert str(target) in caplog.text
+    assert "invalid winner" in caplog.text
+
+
+def test_mhr_post_publication_failure_reports_both_possible_paths(
+    tmp_path, monkeypatch, caplog, tiny_mhr
+):
+    _model, archive = tiny_mhr
+    monkeypatch.setattr(
+        mhr_body.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(archive, str(len(archive))),
+    )
+    target = tmp_path / "cache" / "mhr_model.pt"
+    real_inspect = mhr_body.inspect_mhr_model
+
+    def fail_published(path):
+        path = Path(path).absolute()
+        if path == target.absolute() and os.path.lexists(target):
+            raise AssetIntegrityError("forced MHR post-publication failure")
+        return real_inspect(path)
+
+    monkeypatch.setattr(mhr_body, "inspect_mhr_model", fail_published)
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(AssetIntegrityError, match="post-publication"),
+    ):
+        mhr_body.ensure_mhr_model(target)
+
+    assert target.is_file()
+    assert "staging path" in caplog.text
+    assert str(target) in caplog.text
+    assert "neither path was deleted" in caplog.text
+
+
+def test_mhr_existing_tampered_file_rejects_before_network(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    target = tmp_path / "mhr_model.pt"
+    target.write_bytes(b"tampered")
+    called = False
+
+    def network(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network must not run")
+
+    monkeypatch.setattr(mhr_body.urllib.request, "urlopen", network)
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        mhr_body.ensure_mhr_model(target)
+    assert called is False
+
+
+def test_mhr_rejects_linked_cache_ancestor_before_network(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    real = tmp_path / "real"
+    real.mkdir()
+    linked = tmp_path / "linked"
+    try:
+        linked.symlink_to(real, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+
+    def network(*_args, **_kwargs):
+        raise AssertionError("network must not run for a linked cache path")
+
+    monkeypatch.setattr(mhr_body.urllib.request, "urlopen", network)
+    with pytest.raises(AssetIntegrityError, match="unlinked directories"):
+        mhr_body.ensure_mhr_model(linked / "mhr_model.pt")
+    assert not (real / "mhr_model.pt").exists()
+
+
+def test_mhr_loader_rejects_existing_file_under_linked_ancestor(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    model, _archive = tiny_mhr
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "mhr_model.pt").write_bytes(model)
+    linked = tmp_path / "linked"
+    try:
+        linked.symlink_to(real, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+
+    called = False
+
+    def unsafe_load(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("linked parent reached torch.jit.load")
+
+    monkeypatch.setattr(torch.jit, "load", unsafe_load)
+    with pytest.raises(AssetIntegrityError, match="unlinked directories"):
+        mhr_body.MHRBodyModel.from_file(linked / "mhr_model.pt")
+    assert called is False
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+def test_mhr_loader_rejects_existing_file_under_windows_junction(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    model, _archive = tiny_mhr
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "mhr_model.pt").write_bytes(model)
+    junction = tmp_path / "junction"
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(real)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"junction creation unavailable: {result.stderr or result.stdout}")
+
+    called = False
+
+    def unsafe_load(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("junction parent reached torch.jit.load")
+
+    monkeypatch.setattr(torch.jit, "load", unsafe_load)
+    try:
+        with pytest.raises(AssetIntegrityError, match="unlinked directories"):
+            mhr_body.MHRBodyModel.from_file(junction / "mhr_model.pt")
+        assert called is False
+    finally:
+        if os.path.lexists(junction):
+            junction.rmdir()
+
+
+def test_mhr_loader_never_deserializes_unreviewed_bytes(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    target = tmp_path / "mhr_model.pt"
+    target.write_bytes(b"not-the-reviewed-model")
+    called = False
+
+    def unsafe_load(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("unverified TorchScript reached torch.jit.load")
+
+    monkeypatch.setattr(torch.jit, "load", unsafe_load)
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        mhr_body.MHRBodyModel.from_file(target)
+    assert called is False
+
+
+def test_mhr_archive_content_length_mismatch_rejects_before_body_read(
+    monkeypatch, tiny_mhr
+):
+    _model, archive = tiny_mhr
+    response = _Response(archive, str(len(archive) + 1))
+    monkeypatch.setattr(
+        mhr_body.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: response,
+    )
+    with pytest.raises(RuntimeError, match="Content-Length"):
+        mhr_body._download_archive(io.BytesIO())
+    assert response.read_calls == 0
+
+
+def test_mhr_headerless_oversized_archive_is_bounded(monkeypatch, tiny_mhr):
+    _model, archive = tiny_mhr
+    monkeypatch.setattr(
+        mhr_body.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(archive + b"x"),
+    )
+    with pytest.raises(RuntimeError, match="exceeded"):
+        mhr_body._download_archive(io.BytesIO())
+
+
+def test_mhr_duplicate_exact_member_is_rejected(monkeypatch, tiny_mhr):
+    model, _archive = tiny_mhr
+    stream = io.BytesIO()
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with zipfile.ZipFile(stream, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+            bundle.writestr(mhr_body.MHR_LICENSE_MEMBER, b"license")
+            bundle.writestr(mhr_body.MHR_ARCHIVE_MEMBER, model)
+            bundle.writestr(mhr_body.MHR_ARCHIVE_MEMBER, model)
+    stream.seek(0)
+    with pytest.raises(RuntimeError, match="exactly one"):
+        mhr_body._extract_model(stream, io.BytesIO())
+
+
+def test_mhr_wrong_member_metadata_is_rejected(monkeypatch, tiny_mhr):
+    model, _archive = tiny_mhr
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w", compression=zipfile.ZIP_STORED) as bundle:
+        bundle.writestr(mhr_body.MHR_LICENSE_MEMBER, b"license")
+        bundle.writestr(mhr_body.MHR_ARCHIVE_MEMBER, model)
+    stream.seek(0)
+    with pytest.raises(RuntimeError, match="metadata"):
+        mhr_body._extract_model(stream, io.BytesIO())
+
+
+def test_mhr_wrong_embedded_license_is_rejected(monkeypatch, tiny_mhr):
+    model, _archive = tiny_mhr
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        bundle.writestr(mhr_body.MHR_LICENSE_MEMBER, b"forged!")
+        bundle.writestr(mhr_body.MHR_ARCHIVE_MEMBER, model)
+    stream.seek(0)
+    with pytest.raises(RuntimeError, match="archive license"):
+        mhr_body._extract_model(stream, io.BytesIO())
+
+
+def test_mhr_hardlink_is_rejected_before_torchscript_load(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    model, _archive = tiny_mhr
+    source = tmp_path / "source"
+    source.write_bytes(model)
+    target = tmp_path / "mhr_model.pt"
+    os.link(source, target)
+    called = False
+
+    def unsafe_load(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(torch.jit, "load", unsafe_load)
+    with pytest.raises(AssetIntegrityError, match="unlinked regular file"):
+        mhr_body.MHRBodyModel.from_file(target)
+    assert called is False
+
+
+def test_descriptor_redirection_is_rejected(tmp_path, monkeypatch):
+    from libreyolo.models.sam3dbody import _assets
+
+    expected_bytes = b"expected"
+    alternate_bytes = b"attacker"
+    source = tmp_path / "source"
+    alternate = tmp_path / "alternate"
+    source.write_bytes(expected_bytes)
+    alternate.write_bytes(alternate_bytes)
+    expected = PinnedFile("source", len(expected_bytes), _sha(expected_bytes))
+    real_open = _assets.os.open
+
+    def redirected_open(path, flags, *args, **kwargs):
+        if os.fspath(path) == os.fspath(source):
+            return real_open(alternate, flags, *args, **kwargs)
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(_assets.os, "open", redirected_open)
+    with pytest.raises(AssetIntegrityError, match="changed while it was opened"):
+        inspect_pinned_file(source, expected, label="redirected source")
+
+
+def test_create_only_publication_preserves_existing_destination(tmp_path):
+    ensure_unlinked_directory(tmp_path, label="test parent")
+    source = tmp_path / "staged"
+    source.write_bytes(b"new")
+    # Build the seal from a stable helper without depending on private stat layout.
+    info = os.lstat(source)
+    source_seal = FileSeal(
+        info.st_dev,
+        info.st_ino,
+        info.st_mode,
+        info.st_size,
+        info.st_mtime_ns,
+        info.st_nlink,
+    )
+    destination = tmp_path / "final"
+    destination.write_bytes(b"valuable")
+    parent = require_unlinked_directory(tmp_path, label="test parent")
+    with pytest.raises(FileExistsError):
+        atomic_rename_create_only(
+            source,
+            destination,
+            expected_source=source_seal,
+            expected_parent=parent,
+        )
+    assert destination.read_bytes() == b"valuable"
+    assert source.read_bytes() == b"new"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="exercises the Windows rename branch")
+def test_publication_detects_source_swap_inside_rename(tmp_path, monkeypatch):
+    from libreyolo.models.sam3dbody import _assets
+
+    source = tmp_path / "staged"
+    source.write_bytes(b"reviewed")
+    before = os.lstat(source)
+    seal = FileSeal(
+        before.st_dev,
+        before.st_ino,
+        before.st_mode,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_nlink,
+    )
+    parent = require_unlinked_directory(tmp_path, label="test parent")
+    destination = tmp_path / "final"
+    displaced = tmp_path / "displaced"
+    real_rename = _assets.os.rename
+
+    def racing_rename(_source, target):
+        real_rename(source, displaced)
+        source.write_bytes(b"attacker")
+        real_rename(source, target)
+
+    monkeypatch.setattr(_assets.os, "rename", racing_rename)
+    with pytest.raises(AssetIntegrityError, match="identity changed"):
+        atomic_rename_create_only(
+            source,
+            destination,
+            expected_source=seal,
+            expected_parent=parent,
+        )
+    assert destination.read_bytes() == b"attacker"
+    assert displaced.read_bytes() == b"reviewed"
+
+
+@pytest.fixture
+def tiny_sam_pin(monkeypatch):
+    payloads = {
+        ".gitattributes": b"*.ckpt filter=lfs\n",
+        "LICENSE": b"sam license\n",
+        "README.md": b"reviewed card\n",
+        "model.ckpt": b"reviewed pickle bytes",
+        "model_config.yaml": b"MODEL:\n  IMAGE_SIZE: 512\n",
+    }
+    files = tuple(
+        PinnedFile(name, len(payloads[name]), _sha(payloads[name]))
+        for name in snapshot._REMOTE_NAMES
+    )
+    pin = snapshot.SAMSnapshotPin(
+        size="d3",
+        repo_id="LibreYOLO/TestSAM3DBodyd3-mesh",
+        revision="a" * 40,
+        files=files,
+        legacy_revisions=("b" * 40, "c" * 40),
+    )
+    monkeypatch.setattr(snapshot, "SAM_SNAPSHOT_PINS", {"d3": pin})
+    return pin, payloads
+
+
+def _write_explicit_snapshot(root: Path, payloads: dict[str, bytes], *, full=False):
+    root.mkdir()
+    names = snapshot._REMOTE_NAMES if full else snapshot._RUNTIME_NAMES
+    for name in names:
+        (root / name).write_bytes(payloads[name])
+
+
+def test_explicit_runtime_snapshot_is_strictly_validated(tmp_path, tiny_sam_pin):
+    pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    identity = snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+    assert identity.repo_id == pin.repo_id
+    assert identity.revision == pin.revision
+    assert {file.path for file in identity.files} == set(snapshot._RUNTIME_NAMES)
+
+
+def test_exact_full_hub_tree_is_accepted_for_explicit_path(tmp_path, tiny_sam_pin):
+    _pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads, full=True)
+    identity = snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+    assert {file.path for file in identity.files} == set(snapshot._REMOTE_NAMES)
+
+
+def test_snapshot_extra_file_is_rejected(tmp_path, tiny_sam_pin):
+    _pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    (root / "unexpected.py").write_text("raise RuntimeError", encoding="utf-8")
+    with pytest.raises(AssetIntegrityError, match="unexpected inventory"):
+        snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+
+
+def test_snapshot_tampered_pickle_is_rejected(tmp_path, tiny_sam_pin):
+    _pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    (root / "model.ckpt").write_bytes(b"forged pickle bytes")
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+
+
+def test_snapshot_tampered_marker_is_rejected(tmp_path, tiny_sam_pin):
+    pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    root.mkdir()
+    for expected in pin.runtime_files:
+        (root / expected.path).write_bytes(payloads[expected.path])
+    (root / snapshot.SNAPSHOT_MARKER).write_bytes(
+        snapshot._marker_bytes(pin).replace(pin.revision.encode(), b"b" * 40)
+    )
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        snapshot.inspect_sam_snapshot(root, "d3", managed=True)
+
+
+def test_snapshot_hardlinked_file_is_rejected(tmp_path, tiny_sam_pin):
+    _pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    external = tmp_path / "external"
+    external.write_bytes(payloads["LICENSE"])
+    (root / "LICENSE").unlink()
+    os.link(external, root / "LICENSE")
+    with pytest.raises(AssetIntegrityError, match="unlinked regular file"):
+        snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+
+
+def test_snapshot_symlinked_file_is_rejected(tmp_path, tiny_sam_pin):
+    _pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    external = tmp_path / "external"
+    external.write_bytes(payloads["LICENSE"])
+    (root / "LICENSE").unlink()
+    try:
+        (root / "LICENSE").symlink_to(external)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    with pytest.raises(AssetIntegrityError, match="unlinked regular file"):
+        snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+
+
+class _Sibling:
+    def __init__(self, file: PinnedFile):
+        self.rfilename = file.path
+        self.size = file.size
+        self.lfs = {"sha256": file.sha256} if file.path == "model.ckpt" else None
+
+
+def _fake_hub(
+    pin,
+    sources,
+    calls,
+    *,
+    remote_sha=None,
+    extra=False,
+    gated="auto",
+    dry_run_sizes=None,
+    dry_run_commits=None,
+):
+    siblings = [_Sibling(file) for file in pin.files]
+    if extra:
+        siblings.append(
+            types.SimpleNamespace(rfilename="unexpected.py", size=1, lfs=None)
+        )
+
+    class HfApi:
+        def model_info(self, **kwargs):
+            calls.append(("model_info", kwargs))
+            return types.SimpleNamespace(
+                sha=pin.revision if remote_sha is None else remote_sha,
+                siblings=siblings,
+                gated=gated,
+            )
+
+    def download(**kwargs):
+        if kwargs.get("dry_run"):
+            calls.append(("dry_run", kwargs))
+            expected = pin.by_name[kwargs["filename"]]
+            sizes = dry_run_sizes or {}
+            commits = dry_run_commits or {}
+            return types.SimpleNamespace(
+                file_size=sizes.get(expected.path, expected.size),
+                commit_hash=commits.get(
+                    expected.path,
+                    pin.revision,
+                ),
+            )
+        calls.append(("download", kwargs))
+        return str(sources / kwargs["filename"])
+
+    return types.SimpleNamespace(HfApi=HfApi, hf_hub_download=download)
+
+
+def test_acquire_uses_exact_revision_and_publishes_allowlisted_view(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    for name, payload in payloads.items():
+        (sources / name).write_bytes(payload)
+    calls = []
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(pin, sources, calls))
+
+    identity = snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+    assert identity.root.name == pin.revision
+    assert set(path.name for path in identity.root.iterdir()) == {
+        *snapshot._RUNTIME_NAMES,
+        snapshot.SNAPSHOT_MARKER,
+    }
+    downloads = [kwargs for kind, kwargs in calls if kind == "download"]
+    dry_runs = [kwargs for kind, kwargs in calls if kind == "dry_run"]
+    assert {call["filename"] for call in dry_runs} == set(snapshot._REMOTE_NAMES)
+    assert {call["filename"] for call in downloads} == set(snapshot._RUNTIME_NAMES)
+    assert all(call["revision"] == pin.revision for call in dry_runs)
+    assert all(call["local_files_only"] is False for call in dry_runs)
+    dry_run_indices = [
+        i for i, (kind, _kwargs) in enumerate(calls) if kind == "dry_run"
+    ]
+    download_indices = [
+        i for i, (kind, _kwargs) in enumerate(calls) if kind == "download"
+    ]
+    assert max(dry_run_indices) < min(download_indices)
+    assert all(call["revision"] == pin.revision for call in downloads)
+    assert all(call["local_files_only"] is False for call in downloads)
+
+
+def test_invalid_concurrent_snapshot_winner_reports_owned_stage(
+    tmp_path, monkeypatch, caplog, tiny_sam_pin
+):
+    pin, payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    for name, payload in payloads.items():
+        (sources / name).write_bytes(payload)
+    calls = []
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(pin, sources, calls))
+
+    def lose_publication(_source, destination, **_kwargs):
+        destination.mkdir()
+        (destination / "model.ckpt").write_bytes(b"invalid concurrent winner")
+        raise FileExistsError("concurrent winner")
+
+    monkeypatch.setattr(snapshot, "atomic_rename_create_only", lose_publication)
+    cache = tmp_path / "managed"
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(AssetIntegrityError, match="unexpected inventory"),
+    ):
+        snapshot.acquire_sam_snapshot("d3", cache_root=cache)
+
+    leaked = list(cache.glob(f".{pin.revision}.staging-*"))
+    assert len(leaked) == 1
+    assert str(leaked[0]) in caplog.text
+    assert str(cache / pin.revision) in caplog.text
+    assert "invalid winner" in caplog.text
+
+
+def test_post_publication_validation_failure_reports_both_possible_paths(
+    tmp_path, monkeypatch, caplog, tiny_sam_pin
+):
+    pin, payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    for name, payload in payloads.items():
+        (sources / name).write_bytes(payload)
+    calls = []
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(pin, sources, calls))
+    cache = tmp_path / "managed"
+    destination = cache / pin.revision
+    real_inspect = snapshot.inspect_sam_snapshot
+
+    def fail_published(root, size, *, managed=None):
+        root_path = Path(root).absolute()
+        if root_path == destination.absolute() and os.path.lexists(destination):
+            raise AssetIntegrityError("forced post-publication validation failure")
+        return real_inspect(root, size, managed=managed)
+
+    monkeypatch.setattr(snapshot, "inspect_sam_snapshot", fail_published)
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(AssetIntegrityError, match="post-publication"),
+    ):
+        snapshot.acquire_sam_snapshot("d3", cache_root=cache)
+
+    assert destination.is_dir()
+    assert "staging path" in caplog.text
+    assert str(destination) in caplog.text
+    assert "neither path was deleted" in caplog.text
+
+
+def test_transport_urls_and_revisions_are_immutable():
+    assert "/latest/" not in mhr_body.MHR_ASSETS_URL
+    assert "/main/" not in mhr_body.MHR_ASSETS_URL
+    assert mhr_body.MHR_RELEASE in mhr_body.MHR_ASSETS_URL
+    for pin in snapshot.SAM_SNAPSHOT_PINS.values():
+        assert len(pin.revision) == 40
+        assert all(char in "0123456789abcdef" for char in pin.revision)
+        assert pin.gated == "auto"
+
+    assert snapshot.SAM_SNAPSHOT_PINS["d3"].revision == (
+        "46e286e25347518d861ab0f21e1b2b5b630dc21f"
+    )
+    assert snapshot.SAM_SNAPSHOT_PINS["h"].revision == (
+        "a745fa6fcd5d71e16c4da921a28a6bb6f1ff9e3e"
+    )
+    d3_card = snapshot.SAM_SNAPSHOT_PINS["d3"].by_name["README.md"]
+    h_card = snapshot.SAM_SNAPSHOT_PINS["h"].by_name["README.md"]
+    assert (d3_card.size, d3_card.sha256) == (
+        3_982,
+        "d1e195edb377518f095717bedf9663cad0286ff37e274fb0940da946e9928d3d",
+    )
+    assert (h_card.size, h_card.sha256) == (
+        3_975,
+        "71a09372eacd30fd850647884c9f7f91565e161ee2b2d6cb7c5be1613cc6cd3c",
+    )
+    assert snapshot.SAM_SNAPSHOT_PINS["d3"].legacy_revisions == (
+        "8e822540228d9de9bef1bf26414e27954044c242",
+        "4531d41c4b8349d272a9e7efb42b38a1a5f1d737",
+    )
+    assert snapshot.SAM_SNAPSHOT_PINS["h"].legacy_revisions == (
+        "70a2c8ae1f43d6cff94105d83a8dd63d6eeba5ad",
+        "b3c59d31106cc69a8ab4cd6510bc289bccf258e9",
+    )
+
+
+def test_acquire_rejects_remote_tree_drift_before_payload_fetch(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, _payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    calls = []
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        _fake_hub(pin, sources, calls, extra=True),
+    )
+    with pytest.raises(AssetIntegrityError, match="exact tree"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+    assert not any(kind == "download" for kind, _kwargs in calls)
+
+
+def test_acquire_rejects_remote_commit_drift_before_payload_fetch(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, _payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    calls = []
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        _fake_hub(pin, sources, calls, remote_sha="b" * 40),
+    )
+    with pytest.raises(AssetIntegrityError, match="unexpected commit"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+    assert not any(kind == "download" for kind, _kwargs in calls)
+
+
+@pytest.mark.parametrize("gated", [False, True, "manual", None])
+def test_acquire_rejects_remote_gate_drift_before_payload_fetch(
+    tmp_path, monkeypatch, tiny_sam_pin, gated
+):
+    pin, _payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    calls = []
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        _fake_hub(pin, sources, calls, gated=gated),
+    )
+    with pytest.raises(AssetIntegrityError, match="reviewed.*gate"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+    assert not any(kind in {"dry_run", "download"} for kind, _kwargs in calls)
+
+
+def test_acquire_rejects_download_leg_size_drift_before_any_payload_fetch(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, _payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    calls = []
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        _fake_hub(
+            pin,
+            sources,
+            calls,
+            dry_run_sizes={"README.md": pin.by_name["README.md"].size + 1},
+        ),
+    )
+    with pytest.raises(AssetIntegrityError, match="download metadata size mismatch"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+    assert any(
+        kind == "dry_run" and kwargs["filename"] == "README.md"
+        for kind, kwargs in calls
+    )
+    assert not any(kind == "download" for kind, _kwargs in calls)
+
+
+def test_acquire_rejects_download_leg_commit_drift_before_any_payload_fetch(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, _payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    calls = []
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        _fake_hub(
+            pin,
+            sources,
+            calls,
+            dry_run_commits={"README.md": "d" * 40},
+        ),
+    )
+    with pytest.raises(AssetIntegrityError, match="download metadata commit mismatch"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+    assert any(
+        kind == "dry_run" and kwargs["filename"] == "README.md"
+        for kind, kwargs in calls
+    )
+    assert not any(kind == "download" for kind, _kwargs in calls)
+
+
+def test_acquire_offline_skips_api_and_requests_only_cached_commit(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    for name, payload in payloads.items():
+        (sources / name).write_bytes(payload)
+    calls = []
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(pin, sources, calls))
+    snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+    assert not any(kind == "model_info" for kind, _kwargs in calls)
+    downloads = [kwargs for kind, kwargs in calls if kind == "download"]
+    dry_runs = [kwargs for kind, kwargs in calls if kind == "dry_run"]
+    assert {call["filename"] for call in dry_runs} == set(snapshot._RUNTIME_NAMES)
+    assert all(call["local_files_only"] is True for call in dry_runs)
+    assert downloads and all(call["local_files_only"] is True for call in downloads)
+
+
+def test_invalid_existing_managed_cache_rejects_before_hub_import(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, _payloads = tiny_sam_pin
+    root = tmp_path / "managed" / pin.revision
+    root.mkdir(parents=True)
+    (root / "model.ckpt").write_bytes(b"bad")
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+    with pytest.raises(AssetIntegrityError, match="unexpected inventory"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+
+
+def test_exact_legacy_cache_is_adopted_without_network(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, payloads = tiny_sam_pin
+    legacy = tmp_path / "managed"
+    legacy.mkdir()
+    for expected in pin.runtime_files:
+        (legacy / expected.path).write_bytes(payloads[expected.path])
+    (legacy / ".cache").mkdir()
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+    identity = snapshot.acquire_sam_snapshot("d3", cache_root=legacy)
+    assert identity.root == legacy / pin.revision
+    assert (identity.root / snapshot.SNAPSHOT_MARKER).is_file()
+
+
+@pytest.mark.parametrize("legacy_index", [0, 1])
+def test_exact_card_only_revision_cache_is_adopted_without_network(
+    tmp_path, monkeypatch, tiny_sam_pin, legacy_index
+):
+    pin, payloads = tiny_sam_pin
+    cache = tmp_path / "managed"
+    cache.mkdir()
+    previous_revision = pin.legacy_revisions[legacy_index]
+    previous = cache / previous_revision
+    _write_explicit_snapshot(previous, payloads)
+    (previous / snapshot.SNAPSHOT_MARKER).write_bytes(
+        snapshot._marker_bytes(pin, revision=previous_revision)
+    )
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    identity = snapshot.acquire_sam_snapshot("d3", cache_root=cache)
+
+    assert identity.root == cache / pin.revision
+    assert identity.revision == pin.revision
+    assert previous.is_dir()
+    assert (identity.root / snapshot.SNAPSHOT_MARKER).is_file()
+
+
+def test_partial_legacy_cache_fails_before_network(tmp_path, monkeypatch, tiny_sam_pin):
+    _pin, payloads = tiny_sam_pin
+    legacy = tmp_path / "managed"
+    legacy.mkdir()
+    (legacy / "model.ckpt").write_bytes(payloads["model.ckpt"])
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+    with pytest.raises(AssetIntegrityError, match="legacy.*incomplete"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=legacy)
+
+
+def test_model_explicit_path_records_strict_identity(tmp_path, tiny_sam_pin):
+    _pin, payloads = tiny_sam_pin
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    from libreyolo.models.sam3dbody.model import LibreSAM3DBody
+
+    model = LibreSAM3DBody.__new__(LibreSAM3DBody)
+    checkpoint = model._resolve_checkpoint(root, "d3")
+    assert checkpoint == root.absolute() / "model.ckpt"
+    assert model._checkpoint_snapshot_identity.root == root.absolute()
+
+
+def _bare_sam_model(root: Path, identity, *, mhr_path: Path | None = None):
+    from libreyolo.models.sam3dbody.model import LibreSAM3DBody
+
+    model = LibreSAM3DBody.__new__(LibreSAM3DBody)
+    model._checkpoint_snapshot_identity = identity
+    model._ckpt_path = root / "model.ckpt"
+    model._mhr_path = mhr_path or root.parent / "mhr_model.pt"
+    model.size = "d3"
+    model.device = torch.device("cpu")
+    return model
+
+
+def test_model_rejects_persistent_checkpoint_mutation_before_upstream_load(
+    tmp_path, monkeypatch, tiny_sam_pin, tiny_mhr
+):
+    _pin, payloads = tiny_sam_pin
+    mhr_bytes, _archive = tiny_mhr
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    (tmp_path / "mhr_model.pt").write_bytes(mhr_bytes)
+    identity = snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+    model = _bare_sam_model(root, identity)
+    (root / "model.ckpt").write_bytes(b"forged")
+    called = False
+
+    def load(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return object(), object()
+
+    upstream = types.ModuleType("sam_3d_body")
+    upstream.load_sam_3d_body = load
+    monkeypatch.setitem(sys.modules, "sam_3d_body", upstream)
+    monkeypatch.setattr(model, "_import_upstream", lambda: upstream)
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        model._init_model()
+    assert called is False
+
+
+def test_model_rejects_checkpoint_mutation_during_upstream_load(
+    tmp_path, monkeypatch, tiny_sam_pin, tiny_mhr
+):
+    _pin, payloads = tiny_sam_pin
+    mhr_bytes, _archive = tiny_mhr
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    (tmp_path / "mhr_model.pt").write_bytes(mhr_bytes)
+    identity = snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+    model = _bare_sam_model(root, identity)
+
+    def load(*_args, **_kwargs):
+        (root / "model_config.yaml").write_bytes(b"forged")
+        return object(), object()
+
+    upstream = types.ModuleType("sam_3d_body")
+    upstream.load_sam_3d_body = load
+    monkeypatch.setitem(sys.modules, "sam_3d_body", upstream)
+    monkeypatch.setattr(model, "_import_upstream", lambda: upstream)
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        model._init_model()
+
+
+def test_upstream_path_only_trust_boundary_is_explicit():
+    from libreyolo.models.sam3dbody import model as model_module
+
+    boundary = model_module.UPSTREAM_PATH_TRUST_BOUNDARY
+    assert "trusted, quiescent" in boundary
+    assert "same-user local filesystem" in boundary
+    assert "path-only" in boundary
+
+
+@pytest.mark.parametrize("explicit", [True, False])
+def test_model_validates_explicit_and_default_mhr_before_upstream_load(
+    tmp_path, monkeypatch, tiny_sam_pin, tiny_mhr, explicit
+):
+    from libreyolo.models.sam3dbody import model as model_module
+
+    _pin, payloads = tiny_sam_pin
+    _mhr_bytes, _archive = tiny_mhr
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    mhr_path = tmp_path / "mhr_model.pt"
+    mhr_path.write_bytes(b"unreviewed MHR")
+    identity = snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+    model = _bare_sam_model(root, identity, mhr_path=mhr_path)
+    if not explicit:
+        model._mhr_path = None
+        monkeypatch.setattr(model_module, "ensure_mhr_model", lambda: mhr_path)
+    called = False
+
+    def load(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return object(), object()
+
+    upstream = types.ModuleType("sam_3d_body")
+    upstream.load_sam_3d_body = load
+    monkeypatch.setitem(sys.modules, "sam_3d_body", upstream)
+    monkeypatch.setattr(model, "_import_upstream", lambda: upstream)
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        model._init_model()
+    assert called is False
+
+
+@pytest.mark.parametrize("explicit", [True, False])
+def test_model_rehashes_explicit_and_default_mhr_after_upstream_load(
+    tmp_path, monkeypatch, tiny_sam_pin, tiny_mhr, explicit
+):
+    from libreyolo.models.sam3dbody import model as model_module
+
+    _pin, payloads = tiny_sam_pin
+    mhr_bytes, _archive = tiny_mhr
+    root = tmp_path / "snapshot"
+    _write_explicit_snapshot(root, payloads)
+    mhr_path = tmp_path / "mhr_model.pt"
+    mhr_path.write_bytes(mhr_bytes)
+    identity = snapshot.inspect_sam_snapshot(root, "d3", managed=False)
+    model = _bare_sam_model(root, identity, mhr_path=mhr_path)
+    if not explicit:
+        model._mhr_path = None
+        monkeypatch.setattr(model_module, "ensure_mhr_model", lambda: mhr_path)
+
+    def load(*_args, **_kwargs):
+        mhr_path.write_bytes(b"persistent MHR mutation")
+        return object(), object()
+
+    upstream = types.ModuleType("sam_3d_body")
+    upstream.load_sam_3d_body = load
+    monkeypatch.setitem(sys.modules, "sam_3d_body", upstream)
+    monkeypatch.setattr(model, "_import_upstream", lambda: upstream)
+    with pytest.raises(AssetIntegrityError, match="reviewed bytes"):
+        model._init_model()

--- a/tests/unit/test_sam3dbody_assets.py
+++ b/tests/unit/test_sam3dbody_assets.py
@@ -21,8 +21,11 @@ from libreyolo.models.sam3dbody._assets import (
     FileSeal,
     PinnedFile,
     atomic_rename_create_only,
+    cleanup_private_file,
+    cleanup_private_tree,
     ensure_unlinked_directory,
     inspect_pinned_file,
+    make_private_stage,
     require_unlinked_directory,
 )
 from libreyolo.models.sam3dbody import snapshot
@@ -131,6 +134,60 @@ def test_mhr_invalid_concurrent_winner_reports_owned_stage(
     assert str(leaked[0]) in caplog.text
     assert str(target) in caplog.text
     assert "invalid winner" in caplog.text
+
+
+def test_mhr_valid_concurrent_winner_cleans_losing_stage(
+    tmp_path, monkeypatch, tiny_mhr
+):
+    model, archive = tiny_mhr
+    monkeypatch.setattr(
+        mhr_body.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(archive, str(len(archive))),
+    )
+    target = tmp_path / "cache" / "mhr_model.pt"
+
+    def lose_publication(_source, destination, **_kwargs):
+        destination.write_bytes(model)
+        raise FileExistsError("concurrent winner")
+
+    monkeypatch.setattr(mhr_body, "atomic_rename_create_only", lose_publication)
+    assert mhr_body.ensure_mhr_model(target) == target.absolute()
+    assert not list(target.parent.glob(f".{target.name}.staging-*.tmp"))
+
+
+def test_mhr_refuses_stale_recovery_before_network(tmp_path, monkeypatch, tiny_mhr):
+    target = tmp_path / "cache" / "mhr_model.pt"
+    target.parent.mkdir()
+    recovery = target.parent / f".{target.name}.staging-recovery.tmp"
+    recovery.write_bytes(b"partial")
+
+    def network(*_args, **_kwargs):
+        raise AssertionError("network must not run while recovery data exists")
+
+    monkeypatch.setattr(mhr_body.urllib.request, "urlopen", network)
+    with pytest.raises(AssetIntegrityError, match="recovery data.*cannot accumulate"):
+        mhr_body.ensure_mhr_model(target)
+
+
+def test_mhr_partial_stage_is_cleaned(tmp_path, tiny_mhr):
+    model, _archive = tiny_mhr
+    target = tmp_path / "mhr_model.pt"
+
+    class FailingSource(io.BytesIO):
+        def __init__(self, payload):
+            super().__init__(payload)
+            self._reads = 0
+
+        def read(self, size=-1):
+            self._reads += 1
+            if self._reads > 1:
+                raise OSError("forced staging failure")
+            return super().read(max(1, min(size, len(model) // 2)))
+
+    with pytest.raises(OSError, match="forced staging failure"):
+        mhr_body._stage_model(FailingSource(model), target)
+    assert not list(tmp_path.glob(f".{target.name}.staging-*.tmp"))
 
 
 def test_mhr_post_publication_failure_reports_both_possible_paths(
@@ -384,6 +441,63 @@ def test_descriptor_redirection_is_rejected(tmp_path, monkeypatch):
         inspect_pinned_file(source, expected, label="redirected source")
 
 
+def test_private_tree_cleanup_removes_only_owned_tree(tmp_path):
+    stage, seal = make_private_stage(tmp_path, prefix=".cleanup-")
+    nested = stage / ".cache" / "metadata"
+    nested.mkdir(parents=True)
+    (stage / "model.ckpt").write_bytes(b"model")
+    (nested / "record").write_bytes(b"metadata")
+
+    assert cleanup_private_tree(
+        stage,
+        expected_object=seal,
+        label="test private tree",
+    )
+    assert not os.path.lexists(stage)
+
+
+def test_private_tree_cleanup_rejects_replaced_root(tmp_path):
+    stage, seal = make_private_stage(tmp_path, prefix=".cleanup-")
+    displaced = tmp_path / "displaced"
+    stage.rename(displaced)
+    stage.mkdir()
+    valuable = stage / "valuable"
+    valuable.write_bytes(b"user data")
+
+    with pytest.raises(AssetIntegrityError, match="replaced"):
+        cleanup_private_tree(
+            stage,
+            expected_object=seal,
+            label="test private tree",
+        )
+    assert valuable.read_bytes() == b"user data"
+
+
+def test_private_file_cleanup_rejects_replaced_path(tmp_path):
+    stage = tmp_path / ".staging-file"
+    stage.write_bytes(b"owned")
+    before = os.lstat(stage)
+    seal = FileSeal(
+        before.st_dev,
+        before.st_ino,
+        before.st_mode,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_nlink,
+    )
+    displaced = tmp_path / "displaced"
+    stage.rename(displaced)
+    stage.write_bytes(b"user data")
+
+    with pytest.raises(AssetIntegrityError, match="replaced"):
+        cleanup_private_file(
+            stage,
+            expected_object=seal,
+            label="test private file",
+        )
+    assert stage.read_bytes() == b"user data"
+
+
 def test_create_only_publication_preserves_existing_destination(tmp_path):
     ensure_unlinked_directory(tmp_path, label="test parent")
     source = tmp_path / "staged"
@@ -603,6 +717,16 @@ def _fake_hub(
                 ),
             )
         calls.append(("download", kwargs))
+        if kwargs.get("local_dir") is not None:
+            destination = Path(kwargs["local_dir"]) / kwargs["filename"]
+            destination.write_bytes((sources / kwargs["filename"]).read_bytes())
+            metadata = Path(kwargs["local_dir"]) / ".cache" / "huggingface"
+            metadata.mkdir(parents=True, exist_ok=True)
+            (metadata / f"{kwargs['filename']}.metadata").write_text(
+                "test metadata",
+                encoding="utf-8",
+            )
+            return str(destination)
         return str(sources / kwargs["filename"])
 
     return types.SimpleNamespace(HfApi=HfApi, hf_hub_download=download)
@@ -640,6 +764,10 @@ def test_acquire_uses_exact_revision_and_publishes_allowlisted_view(
     assert max(dry_run_indices) < min(download_indices)
     assert all(call["revision"] == pin.revision for call in downloads)
     assert all(call["local_files_only"] is False for call in downloads)
+    assert all(
+        Path(call["local_dir"]).parent == identity.root.parent for call in downloads
+    )
+    assert not (identity.root / ".cache").exists()
 
 
 def test_invalid_concurrent_snapshot_winner_reports_owned_stage(
@@ -673,6 +801,79 @@ def test_invalid_concurrent_snapshot_winner_reports_owned_stage(
     assert "invalid winner" in caplog.text
 
 
+def test_valid_concurrent_snapshot_winner_cleans_losing_stage(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    for name, payload in payloads.items():
+        (sources / name).write_bytes(payload)
+    calls = []
+    monkeypatch.setitem(sys.modules, "huggingface_hub", _fake_hub(pin, sources, calls))
+
+    def lose_publication(source, destination, **_kwargs):
+        destination.mkdir()
+        for entry in source.iterdir():
+            (destination / entry.name).write_bytes(entry.read_bytes())
+        raise FileExistsError("concurrent winner")
+
+    monkeypatch.setattr(snapshot, "atomic_rename_create_only", lose_publication)
+    cache = tmp_path / "managed"
+    identity = snapshot.acquire_sam_snapshot("d3", cache_root=cache)
+
+    assert identity.root == cache / pin.revision
+    assert not list(cache.glob(f".{pin.revision}.staging-*"))
+
+
+def test_snapshot_refuses_stale_recovery_before_hub_import(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, _payloads = tiny_sam_pin
+    cache = tmp_path / "managed"
+    cache.mkdir()
+    recovery = cache / f".{pin.revision}.staging-recovery"
+    recovery.mkdir()
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    with pytest.raises(AssetIntegrityError, match="recovery data.*cannot accumulate"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=cache)
+
+
+def test_snapshot_failed_download_cleans_private_stage(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    pin, payloads = tiny_sam_pin
+    sources = tmp_path / "hub-cache"
+    sources.mkdir()
+    for name, payload in payloads.items():
+        (sources / name).write_bytes(payload)
+    calls = []
+    hub = _fake_hub(pin, sources, calls)
+    real_download = hub.hf_hub_download
+
+    def fail_model(**kwargs):
+        if not kwargs.get("dry_run") and kwargs["filename"] == "model.ckpt":
+            raise OSError("forced download failure")
+        return real_download(**kwargs)
+
+    hub.hf_hub_download = fail_model
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    cache = tmp_path / "managed"
+
+    with pytest.raises(RuntimeError, match="forced download failure"):
+        snapshot.acquire_sam_snapshot("d3", cache_root=cache)
+    assert not list(cache.glob(f".{pin.revision}.staging-*"))
+
+
+def test_snapshot_missing_hub_dependency_has_install_command(
+    tmp_path, monkeypatch, tiny_sam_pin
+):
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+    with pytest.raises(ImportError, match=r'pip install "libreyolo\[hf\]"'):
+        snapshot.acquire_sam_snapshot("d3", cache_root=tmp_path / "managed")
+
+
 def test_post_publication_validation_failure_reports_both_possible_paths(
     tmp_path, monkeypatch, caplog, tiny_sam_pin
 ):
@@ -703,7 +904,7 @@ def test_post_publication_validation_failure_reports_both_possible_paths(
     assert destination.is_dir()
     assert "staging path" in caplog.text
     assert str(destination) in caplog.text
-    assert "neither path was deleted" in caplog.text
+    assert "verified recovery" in caplog.text
 
 
 def test_transport_urls_and_revisions_are_immutable():

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -567,9 +567,11 @@ project the weights were derived from. Per-family summary:
              are passed through, so the checkpoints are mirrored
              byte-identically at LibreYOLO/LibreSAM3DBodyd3-mesh and
              LibreYOLO/LibreSAM3DBodyh-mesh, each carrying the SAM License
-             text and an access gate recording acceptance. Mirroring does
-             not change the license: the weights remain SAM-licensed, not
-             MIT, and are NOT covered by LibreYOLO's permissive license.
+             text and an automatic access gate recording license acceptance
+             plus self-attested identity and jurisdiction. The gate is not
+             manual approval or screening by Meta. Mirroring does not change
+             the license: the weights remain SAM-licensed, not MIT, and are
+             NOT covered by LibreYOLO's permissive license.
              No upstream code is ported; libreyolo/models/sam3dbody/ is
              LibreYOLO's own MIT wrapper around the optional upstream
              package. See THIRD_PARTY_NOTICES.txt for the full description.


### PR DESCRIPTION
- Pin SAM 3D Body mirror snapshots and the MHR v1.0.1 asset to reviewed revisions, sizes, and SHA-256 identities.
- Add exact online/offline acquisition, legacy-cache migration, link rejection, and create-only publication checks.
- Download online snapshots into private revision staging and bound cleanup/recovery so multi-gigabyte copies cannot silently accumulate.
- Add the supported `libreyolo[hf]` install guidance for automatic acquisition.
- Verified: 204 relevant tests passed, 5 platform/data skips, 9 deselected; cached MHR CPU contract and D3 offline migration passed; Ruff, format, diff-check, and Greptile 5/5 passed.
- Not verified locally: the full xdist unit matrix, live upstream SAM inference, H checkpoint load, GPU inference, or live Linux/macOS publication. CI is authoritative for the full matrix.

## Code provenance

- New implementation, tests, and documentation are original LibreYOLO code.
- MHR asset metadata and its parameter contract reference facebookresearch/MHR commit 4998cec385b1aaa07abdefba71bfba2f83c7db32 (Apache-2.0); no upstream code is copied.
- SAM 3D Body repository metadata and byte-identical weights reference facebookresearch/sam-3d-body commit b5c765a0d89d789985e186d396315e7590887b94 under the custom SAM License. No SAM 3D Body implementation code is copied, adapted, or ported.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR pins the SAM 3D Body and MHR assets to reviewed revisions and byte identities, then adds strict acquisition, migration, staging, publication, and loading checks.
- Adds shared filesystem and byte-integrity helpers for model assets.
- Introduces revision-keyed SAM snapshot acquisition with online, offline, and legacy-cache paths.
- Pins and validates the MHR release archive, extracted model, and license.
- Updates dependency metadata, tests, licensing notices, and the mesh-task contract.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/sam3dbody/_assets.py | Adds descriptor-based hashing, link rejection, private staging, guarded cleanup, and create-only atomic publication primitives. |
| libreyolo/models/sam3dbody/snapshot.py | Implements pinned SAM snapshot acquisition, offline loading, legacy migration, exact inventory validation, and recovery handling. |
| libreyolo/models/sam3dbody/mhr_body.py | Pins the MHR release and validates the archive, model member, cache publication, and TorchScript loading boundary. |
| libreyolo/models/sam3dbody/model.py | Integrates verified snapshot and MHR identities around the upstream path-only constructor and adds actionable optional-dependency guidance. |
| pyproject.toml | Raises the Hugging Face optional dependency floor to the version required for dry-run byte metadata. |
| tests/unit/test_sam3dbody_assets.py | Adds focused coverage for integrity checks, acquisition modes, migration, link rejection, recovery, and dependency errors. |
| docs/adr/0013-mesh-task-contract.md | Documents the pinned transport, cache lifecycle, gate behavior, and trusted-filesystem boundary. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Start[Initialize SAM 3D Body] --> Cache{Pinned private snapshot exists?}
  Cache -->|Yes| Verify[Verify inventory, sizes, and SHA-256]
  Cache -->|No| Legacy{Verified legacy cache available?}
  Legacy -->|Yes| Stage[Copy into private revision-keyed stage]
  Legacy -->|No| Mode{Offline mode?}
  Mode -->|Yes| HubCache[Read reviewed runtime objects from Hub cache]
  Mode -->|No| Preflight[Verify gate, revision, tree, and declared sizes]
  Preflight --> Download[Download reviewed files]
  HubCache --> Stage
  Download --> Stage
  Stage --> Publish[Create-only atomic publication]
  Publish --> Verify
  Verify --> Load[Pass verified paths to upstream loader]
  Load --> Recheck[Rehash checkpoint, config, license, and MHR]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Bound SAM3DBody asset staging"](https://github.com/libreyolo/libreyolo/commit/ff4e12afff9db3e27ba96a22634549262bdce592) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53814475)</sub>

**Context used:**

- Knowledge Base — [Model zoo, architectures, and inference backends](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/model-zoo.md)
- Knowledge Base — [Specialist inference tasks: embeddings and body meshes](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/specialist-inference-tasks.md)

<!-- /greptile_comment -->