### PR TITLE
Quiet the H.264 fallback when saving video

### DIFF
--- a/docs/predict_sources.md
+++ b/docs/predict_sources.md
@@ -104,3 +104,14 @@ ffmpeg -re -stream_loop -1 -i clip.mp4 -c copy -rtsp_transport tcp -f rtsp rtsp:
 
 Then consume `rtsp://127.0.0.1:8554/camera`. OpenCV must have the corresponding
 video backend enabled; the standard `opencv-python` wheels include FFmpeg.
+
+## Saving video output
+
+Saved videos are written as MP4. LibreYOLO tries the H.264 encoder (`avc1`)
+first and falls back to `mp4v` when the OpenCV build has no H.264 encoder,
+which is the case for the standard Linux `opencv-python` wheels. During that
+probe, OpenCV's FFmpeg backend may print lines such as
+`h264_v4l2m2m` or `Failed to initialize VideoWriter` directly to stderr. These
+come from OpenCV, not LibreYOLO, and do not indicate a failure: the output
+file is still written in full. The probe runs once per process, so the
+messages appear at most once per run.

--- a/docs/predict_sources.md
+++ b/docs/predict_sources.md
@@ -112,6 +112,18 @@ first and falls back to `mp4v` when the OpenCV build has no H.264 encoder,
 which is the case for the standard Linux `opencv-python` wheels. During that
 probe, OpenCV's FFmpeg backend may print lines such as
 `h264_v4l2m2m` or `Failed to initialize VideoWriter` directly to stderr. These
-come from OpenCV, not LibreYOLO, and do not indicate a failure: the output
-file is still written in full. The probe runs once per process, so the
-messages appear at most once per run.
+come from OpenCV and FFmpeg, not LibreYOLO, and do not indicate a failure:
+the output file is still written in full. Some carry an `[ERROR:...]` prefix
+because that is OpenCV's own severity for a codec it could not open, not
+LibreYOLO's. The probe runs once per frame size per process, so the messages
+appear at most once per run.
+
+To silence them, set both variables before OpenCV is imported:
+
+```bash
+export OPENCV_LOG_LEVEL=SILENT      # OpenCV's own [ERROR:...] lines
+export OPENCV_FFMPEG_LOGLEVEL=-8    # FFmpeg's h264/libopenh264 lines
+```
+
+These are process-global and mute all OpenCV and FFmpeg logging, including
+genuine errors, so LibreYOLO does not set them for you.

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -13,6 +13,12 @@ logger = logging.getLogger(__name__)
 
 MP4_CODEC_CANDIDATES = ("avc1", "mp4v")
 
+# Codecs that failed to open in this process. OpenCV's FFmpeg backend prints
+# its own errors to stderr while probing (for example ``h264_v4l2m2m`` or
+# ``Failed to initialize VideoWriter``), so probe each codec once per process
+# rather than once per video.
+_UNAVAILABLE_CODECS: set = set()
+
 # Video extensions supported via OpenCV's VideoCapture
 VIDEO_EXTENSIONS = {
     ".asf",
@@ -223,7 +229,11 @@ class VideoWriter:
 
         self.codec = None
         self._writer = None
-        for codec in _codec_candidates(self._path):
+        candidates = _codec_candidates(self._path)
+        failed = []
+        for codec in candidates:
+            if codec in _UNAVAILABLE_CODECS and codec != candidates[-1]:
+                continue
             fourcc = cv2.VideoWriter_fourcc(*codec)
             writer = cv2.VideoWriter(self._path, fourcc, fps, (width, height))
             if writer.isOpened():
@@ -231,15 +241,22 @@ class VideoWriter:
                 self._writer = writer
                 break
             writer.release()
+            failed.append(codec)
 
         if self._writer is None:
             raise ValueError(f"Cannot open video writer for: {self._path}")
+        # Only remember failures once a later codec proved the path itself is
+        # writable, so a bad output path does not poison the cache.
+        _UNAVAILABLE_CODECS.update(failed)
 
-        if self.codec != "avc1" and Path(self._path).suffix.lower() == ".mp4":
-            logger.warning(
-                "Could not open H.264 video writer; falling back to %s for %s",
-                self.codec,
+        if self.codec != candidates[0]:
+            # Expected on most Linux OpenCV wheels, which ship without an H.264
+            # encoder. The output is still a valid MP4, so this is not a warning.
+            logger.info(
+                "H.264 encoder not available in this OpenCV build; saving %s with %s. "
+                "Any FFmpeg errors printed above come from that probe and can be ignored.",
                 self._path,
+                self.codec,
             )
 
     # ------------------------------------------------------------------

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -13,10 +13,12 @@ logger = logging.getLogger(__name__)
 
 MP4_CODEC_CANDIDATES = ("avc1", "mp4v")
 
-# Codecs that failed to open in this process. OpenCV's FFmpeg backend prints
-# its own errors to stderr while probing (for example ``h264_v4l2m2m`` or
-# ``Failed to initialize VideoWriter``), so probe each codec once per process
-# rather than once per video.
+# ``(codec, width, height)`` combinations that failed to open in this process.
+# OpenCV's FFmpeg backend prints its own errors to stderr while probing (for
+# example ``h264_v4l2m2m`` or ``Failed to initialize VideoWriter``), so probe
+# once per process rather than once per video. The frame size is part of the
+# key because some H.264 encoders reject odd dimensions that ``mp4v`` accepts,
+# and one such video must not disable H.264 for every later one.
 _UNAVAILABLE_CODECS: set = set()
 
 # Video extensions supported via OpenCV's VideoCapture
@@ -231,8 +233,10 @@ class VideoWriter:
         self._writer = None
         candidates = _codec_candidates(self._path)
         failed = []
+        last_resort = candidates[-1]
         for codec in candidates:
-            if codec in _UNAVAILABLE_CODECS and codec != candidates[-1]:
+            key = (codec, width, height)
+            if key in _UNAVAILABLE_CODECS and codec != last_resort:
                 continue
             fourcc = cv2.VideoWriter_fourcc(*codec)
             writer = cv2.VideoWriter(self._path, fourcc, fps, (width, height))
@@ -241,7 +245,7 @@ class VideoWriter:
                 self._writer = writer
                 break
             writer.release()
-            failed.append(codec)
+            failed.append(key)
 
         if self._writer is None:
             raise ValueError(f"Cannot open video writer for: {self._path}")

--- a/tests/unit/test_video.py
+++ b/tests/unit/test_video.py
@@ -241,7 +241,14 @@ class TestVideoWriter:
         VideoWriter(tmp_path / "b.mp4", fps=10.0, width=32, height=32).release()
 
         # avc1 probed once, then skipped; mp4v opened for both files.
-        assert calls == [cv2.VideoWriter_fourcc(*"avc1"), mp4v, mp4v]
+        avc1 = cv2.VideoWriter_fourcc(*"avc1")
+        assert calls == [avc1, mp4v, mp4v]
+
+        # A different frame size is probed again: an H.264 encoder may reject
+        # only certain dimensions.
+        calls.clear()
+        VideoWriter(tmp_path / "c.mp4", fps=10.0, width=64, height=64).release()
+        assert calls == [avc1, mp4v]
 
     def test_write_and_read_back(self, tmp_path):
         out_path = str(tmp_path / "output.mp4")

--- a/tests/unit/test_video.py
+++ b/tests/unit/test_video.py
@@ -149,6 +149,9 @@ class TestVideoSource:
 
 class TestVideoWriter:
     def test_mp4_prefers_h264_codec(self, tmp_path, monkeypatch):
+        from libreyolo.utils import video as video_mod
+
+        monkeypatch.setattr(video_mod, "_UNAVAILABLE_CODECS", set())
         assert _codec_candidates("output.mp4")[0] == "avc1"
 
         calls = []
@@ -178,6 +181,10 @@ class TestVideoWriter:
         assert calls == [avc1]
 
     def test_mp4_falls_back_to_mp4v(self, tmp_path, monkeypatch, caplog):
+        from libreyolo.utils import video as video_mod
+
+        monkeypatch.setattr(video_mod, "_UNAVAILABLE_CODECS", set())
+        caplog.set_level("INFO", logger="libreyolo.utils.video")
         calls = []
         avc1 = cv2.VideoWriter_fourcc(*"avc1")
         mp4v = cv2.VideoWriter_fourcc(*"mp4v")
@@ -204,7 +211,37 @@ class TestVideoWriter:
 
         assert writer.codec == "mp4v"
         assert calls == [avc1, mp4v]
-        assert "falling back to mp4v" in caplog.text
+        assert "saving" in caplog.text and "mp4v" in caplog.text
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_h264_probe_cached_per_process(self, tmp_path, monkeypatch):
+        from libreyolo.utils import video as video_mod
+
+        monkeypatch.setattr(video_mod, "_UNAVAILABLE_CODECS", set())
+        calls = []
+        mp4v = cv2.VideoWriter_fourcc(*"mp4v")
+
+        class FakeWriter:
+            def __init__(self, opened):
+                self.opened = opened
+
+            def isOpened(self):
+                return self.opened
+
+            def release(self):
+                pass
+
+        def fake_video_writer(path, fourcc, fps, size):
+            calls.append(fourcc)
+            return FakeWriter(opened=fourcc == mp4v)
+
+        monkeypatch.setattr(cv2, "VideoWriter", fake_video_writer)
+
+        VideoWriter(tmp_path / "a.mp4", fps=10.0, width=32, height=32).release()
+        VideoWriter(tmp_path / "b.mp4", fps=10.0, width=32, height=32).release()
+
+        # avc1 probed once, then skipped; mp4v opened for both files.
+        assert calls == [cv2.VideoWriter_fourcc(*"avc1"), mp4v, mp4v]
 
     def test_write_and_read_back(self, tmp_path):
         out_path = str(tmp_path / "output.mp4")


### PR DESCRIPTION
Fixes #809.

On Linux \`opencv-python\` wheels the H.264 probe fails, OpenCV prints FFmpeg errors to stderr, and we logged a WARNING on top even though the mp4v output is fine.

- fallback log is now INFO and says the FFmpeg lines above can be ignored
- H.264 probed once per process, not once per video
- docs note in predict_sources.md
- codec order unchanged: avc1 first, mp4v fallback

## Code provenance

Original code written for this PR.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces expected H.264 fallback noise, caches failed codec probes by frame size, documents OpenCV/FFmpeg stderr behavior, and adds fallback-cache tests. The cache refinement remains incomplete because same-size outputs with different frame rates or runtime conditions still share one permanent failure entry.

- Changes fallback logging from warning to informational.
- Caches unsuccessful codec probes by codec and dimensions.
- Documents expected Linux OpenCV H.264 probe messages and suppression options.
- Adds tests for fallback logging and frame-size-aware caching.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a failed H.264 probe can still permanently force later viable same-size outputs onto mp4v.

The cache key includes dimensions but omits frame rate and transient writer conditions, while production callers can create same-size outputs with source-specific frame rates; the first failure therefore suppresses later H.264 probes that may succeed.

**Files Needing Attention:** libreyolo/utils/video.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/utils/video.py | Adds process-wide frame-size-aware codec failure caching and quieter fallback logging, but the cache remains overbroad for same-size writers with different parameters or conditions. |
| tests/unit/test_video.py | Covers logging severity and dimension-based cache reuse, but codifies the incomplete same-size cache behavior without testing differing frame rates. |
| docs/predict_sources.md | Documents expected H.264 probe failures, fallback behavior, and process-global OpenCV logging controls. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create MP4 writer] --> B{codec, width, height cached?}
  B -->|Yes| C[Skip avc1 probe]
  B -->|No| D[Try avc1]
  D -->|Opens| E[Write H.264]
  D -->|Fails| F[Try mp4v]
  F -->|Opens| G[Cache failed avc1 key]
  G --> H[Write mp4v]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20libreyolo%2Flibreyolo%20PR%20%23811%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=811&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Futils%2Fvideo.py%3A238-239%0A**Codec%20failures%20remain%20overcached**%0A%0AWhen%20two%20outputs%20have%20the%20same%20dimensions%20but%20different%20frame%20rates%2C%20destinations%2C%20or%20backend%20conditions%2C%20a%20failed%20%60avc1%60%20probe%20for%20the%20first%20output%20causes%20the%20process-wide%20cache%20to%20skip%20H.264%20for%20the%20second%2C%20producing%20%60mp4v%60%20output%20even%20when%20that%20writer%20could%20open%20with%20%60avc1%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=811&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22libreyolo%2Flibreyolo%22%20on%20the%20existing%20branch%20%22809-video-writer-fallback-log%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22809-video-writer-fallback-log%22.%0A%0A%23%23%23%20Issue%201%0Alibreyolo%2Futils%2Fvideo.py%3A238-239%0A**Codec%20failures%20remain%20overcached**%0A%0AWhen%20two%20outputs%20have%20the%20same%20dimensions%20but%20different%20frame%20rates%2C%20destinations%2C%20or%20backend%20conditions%2C%20a%20failed%20%60avc1%60%20probe%20for%20the%20first%20output%20causes%20the%20process-wide%20cache%20to%20skip%20H.264%20for%20the%20second%2C%20producing%20%60mp4v%60%20output%20even%20when%20that%20writer%20could%20open%20with%20%60avc1%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=libreyolo%2Flibreyolo&pr=811&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Document env vars that silence the OpenC..."](https://github.com/libreyolo/libreyolo/commit/337814ab45b7b2abb6fc28de25e2f2adcc823dd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55236159)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->