### PR TITLE
Add single-class detection training (single_cls) for G0/G1

### DIFF
--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -503,6 +503,29 @@ def train_cmd(
 
     model_path = resolve_model_or_exit(out, model)
     family = detect_family_from_model_ref(model, model_path, inspect_checkpoint=dry_run)
+
+    if single_cls:
+        # Gate before the model is constructed: building it can fetch weights
+        # (an explicit task derives a task-suffixed checkpoint name), and a
+        # rejected combination must not pay for a download first.
+        from libreyolo.models.registry import group_of
+
+        selected_task = normalized_task
+        model_cls = get_model_class(family) if family is not None else None
+        if selected_task is None and model_cls is not None:
+            selected_task = (
+                model_cls.detect_task_from_filename(Path(model_path).name)
+                or model_cls.DEFAULT_TASK
+            )
+        group = group_of(family) if family is not None else None
+        if group not in {"g0", "g1"} or selected_task != "detect":
+            exit_with_error(
+                out,
+                "config_unsupported",
+                "single_cls=True is supported only for G0/G1 detection models; "
+                f"got family={family!r} ({group}), task={selected_task!r}.",
+            )
+
     loaded_model = None
     train_pretrained = pretrained
     if family is None and not dry_run:
@@ -658,25 +681,6 @@ def train_cmd(
                 "RT-DETR v1/v2/v4, EC, ConvNeXt) or remove --lora."
             ),
         )
-
-    if params["single_cls"]:
-        from libreyolo.models.registry import group_of
-
-        selected_task = normalized_task or getattr(loaded_model, "task", None)
-        model_cls = get_model_class(family) if family is not None else None
-        if selected_task is None and model_cls is not None:
-            selected_task = (
-                model_cls.detect_task_from_filename(Path(model_path).name)
-                or model_cls.DEFAULT_TASK
-            )
-        group = group_of(family) if family is not None else None
-        if group not in {"g0", "g1"} or selected_task != "detect":
-            exit_with_error(
-                out,
-                "config_unsupported",
-                "single_cls=True is supported only for G0/G1 detection models; "
-                f"got family={family!r} ({group}), task={selected_task!r}.",
-            )
 
     # Warn when explicitly-set params are ignored by the selected family
     # (spec-driven; see libreyolo/data/augment/spec.py).

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -303,6 +303,11 @@ def train_cmd(
         help="LVIS-style repeat-factor sampling for long-tailed datasets "
         "(default: off)",
     ),
+    single_cls: bool = typer.Option(
+        False,
+        "--single-cls/--no-single-cls",
+        help="Train a G0/G1 detector with every label remapped to class 0",
+    ),
     average_best: int = typer.Option(
         0,
         help="Uniform-average the N best checkpoints by the watched metric "
@@ -589,6 +594,7 @@ def train_cmd(
         "cache": cache_val,
         "min_samples": min_samples,
         "class_balanced": class_balanced,
+        "single_cls": single_cls,
         "average_best": average_best,
         "export_check": export_check,
         "precise_bn": precise_bn,
@@ -653,6 +659,25 @@ def train_cmd(
             ),
         )
 
+    if params["single_cls"]:
+        from libreyolo.models.registry import group_of
+
+        selected_task = normalized_task or getattr(loaded_model, "task", None)
+        model_cls = get_model_class(family) if family is not None else None
+        if selected_task is None and model_cls is not None:
+            selected_task = (
+                model_cls.detect_task_from_filename(Path(model_path).name)
+                or model_cls.DEFAULT_TASK
+            )
+        group = group_of(family) if family is not None else None
+        if group not in {"g0", "g1"} or selected_task != "detect":
+            exit_with_error(
+                out,
+                "config_unsupported",
+                "single_cls=True is supported only for G0/G1 detection models; "
+                f"got family={family!r} ({group}), task={selected_task!r}.",
+            )
+
     # Warn when explicitly-set params are ignored by the selected family
     # (spec-driven; see libreyolo/data/augment/spec.py).
     ignored_warnings = []
@@ -701,6 +726,7 @@ def train_cmd(
             "amp_dtype": params["amp_dtype"],
             "max_det": params["max_det"],
             "class_balanced": params["class_balanced"],
+            "single_cls": params["single_cls"],
             "average_best": params["average_best"],
             "export_check": params["export_check"],
             "precise_bn": params["precise_bn"],
@@ -736,6 +762,7 @@ def train_cmd(
                 "save_period": params["save_period"],
                 "lora": params["lora"],
                 "class_balanced": params["class_balanced"],
+                "single_cls": params["single_cls"],
                 "average_best": params["average_best"],
                 "export_check": params["export_check"],
                 "precise_bn": params["precise_bn"],

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -448,6 +448,7 @@ def _build_rfdetr_train_kwargs(
         "log_interval": "log_interval",
         "cache": "cache",
         "class_balanced": "class_balanced",
+        "single_cls": "single_cls",
         "average_best": "average_best",
         "export_check": "export_check",
         "precise_bn": "precise_bn",

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -253,6 +253,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
         load_segments: bool = False,
         load_obb: bool = False,
         num_classes: int | None = None,
+        single_cls: bool = False,
     ):
         """
         Initialize YOLO dataset.
@@ -265,6 +266,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
             img_files: List of image paths (for file list mode).
             label_files: List of label paths (optional, inferred if not provided).
             num_classes: Optional class-count bound used for OBB label validation.
+            single_cls: Remap every non-negative class id to class 0.
         """
         self.img_size = imgsz_to_hw(img_size, name="img_size")
         self.preproc = preproc
@@ -272,6 +274,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
         self.load_segments = load_segments
         self.load_obb = load_obb
         self.num_classes = num_classes
+        self.single_cls = bool(single_cls)
         if self.load_segments and self.load_obb:
             raise ValueError("YOLODataset cannot load segmentation and OBB labels together")
 
@@ -454,9 +457,13 @@ class YOLODataset(ImageCacheMixin, Dataset):
                             skipped_obb_rows += 1
                             first_obb_error = first_obb_error or f"{label_file.name}: {exc}"
                             continue
+                        if self.single_cls:
+                            cls_id = 0
                         labels.append([*proxy.tolist(), cls_id, float(xywhr[4])])
                     elif len(parts) >= 5:
                         cls_id = int(parts[0])
+                        if self.single_cls and cls_id >= 0:
+                            cls_id = 0
 
                         if len(parts) > 5:
                             # Segmentation format: derive bbox from polygon vertices
@@ -612,6 +619,7 @@ class COCODataset(ImageCacheMixin, Dataset):
         load_obb: bool = False,
         num_classes: int | None = None,
         names=None,
+        single_cls: bool = False,
     ):
         """
         Initialize COCO dataset.
@@ -622,6 +630,8 @@ class COCODataset(ImageCacheMixin, Dataset):
             name: Image folder name (e.g., 'train2017')
             img_size: Target image size (height, width)
             preproc: Preprocessing transform
+            single_cls: Remap emitted annotations to class 0 after resolving
+                the original COCO category mapping.
         """
         if load_segments and load_obb:
             raise ValueError("COCODataset cannot load segmentation and OBB labels together")
@@ -643,6 +653,7 @@ class COCODataset(ImageCacheMixin, Dataset):
         self.load_obb = load_obb
         self.num_classes = num_classes
         self.names = names
+        self.single_cls = bool(single_cls)
 
         # Load COCO annotations
         ann_file = self._annotation_path()
@@ -658,7 +669,9 @@ class COCODataset(ImageCacheMixin, Dataset):
         self.category_id_to_label, self.label_to_category_id = (
             self._build_category_mappings()
         )
-        if self.names is None:
+        if self.single_cls:
+            self._classes = ("object",)
+        elif self.names is None:
             self._classes = tuple([c["name"] for c in self.cats])
         else:
             class_names = self._normalized_class_names()
@@ -717,7 +730,7 @@ class COCODataset(ImageCacheMixin, Dataset):
                     )
                 category_to_label[int(category["id"])] = name_to_label[category_name]
 
-        if self.num_classes is not None:
+        if self.num_classes is not None and not self.single_cls:
             for category_id, label in category_to_label.items():
                 if label < 0 or label >= self.num_classes:
                     raise ValueError(
@@ -733,6 +746,9 @@ class COCODataset(ImageCacheMixin, Dataset):
                     "dataset YAML names must be unique."
                 )
             label_to_category[label] = category_id
+        if self.single_cls:
+            collapsed_category_id = self.class_ids[0] if self.class_ids else 0
+            label_to_category = {0: collapsed_category_id}
         return category_to_label, label_to_category
 
     def _remove_useless_info(self):
@@ -829,11 +845,15 @@ class COCODataset(ImageCacheMixin, Dataset):
             if self.load_obb:
                 coco_obj, proxy, angle = obj
                 cls = self.category_id_to_label[coco_obj["category_id"]]
+                if self.single_cls:
+                    cls = 0
                 res[ix, 0:4] = proxy
                 res[ix, 4] = cls
                 res[ix, 5] = angle
             else:
                 cls = self.category_id_to_label[obj["category_id"]]
+                if self.single_cls:
+                    cls = 0
                 res[ix, 0:4] = obj["clean_bbox"]
                 res[ix, 4] = cls
 

--- a/libreyolo/data/utils.py
+++ b/libreyolo/data/utils.py
@@ -232,7 +232,11 @@ def img2label_paths(img_paths: List[Path]) -> List[Path]:
 
 
 def load_data_config(
-    data: str, autodownload: bool = True, allow_scripts: bool = False
+    data: str,
+    autodownload: bool = True,
+    allow_scripts: bool = False,
+    *,
+    single_cls: bool = False,
 ) -> Dict:
     """
     Load dataset configuration from YAML file.
@@ -251,6 +255,8 @@ def load_data_config(
         allow_scripts: Whether to allow execution of Python download scripts
             embedded in YAML configs. When False, only URL-based downloads are
             permitted and script-based downloads are skipped with a warning.
+        single_cls: Return a one-class detection view while retaining the source
+            class names privately for native COCO category mapping.
 
     Returns:
         Dictionary with dataset configuration including:
@@ -315,6 +321,12 @@ def load_data_config(
 
     # Keep 'root' for backward compatibility
     config["root"] = str(dataset_path)
+
+    if single_cls:
+        config["_original_names"] = config.get("names")
+        config["_original_nc"] = config.get("nc")
+        config["nc"] = 1
+        config["names"] = {0: "object"}
 
     return config
 

--- a/libreyolo/data/yolo_coco_api.py
+++ b/libreyolo/data/yolo_coco_api.py
@@ -28,6 +28,7 @@ def parse_yolo_label_line(
     num_classes: int,
     label_path: Optional[Path] = None,
     return_segment: bool = False,
+    single_cls: bool = False,
 ) -> Optional[Tuple]:
     """
     Parse a single line from a YOLO label file.
@@ -38,6 +39,7 @@ def parse_yolo_label_line(
         img_h: Image height in pixels
         num_classes: Total number of classes
         label_path: Path to label file (for warnings)
+        single_cls: Remap non-negative class ids to class 0 before validation.
 
     Returns:
         Tuple of (class_id, x1, y1, x2, y2, area) in pixel coordinates,
@@ -84,6 +86,9 @@ def parse_yolo_label_line(
                 f"Invalid label format in {label_path}: '{line[:50]}...' - {e}"
             )
         return None
+
+    if single_cls and class_id >= 0:
+        class_id = 0
 
     # Validate class ID
     if class_id < 0 or class_id >= num_classes:
@@ -148,6 +153,7 @@ class YOLOCocoAPI:
         load_segments: bool = False,
         image_files: List[Path] | None = None,
         label_files: List[Path] | None = None,
+        single_cls: bool = False,
     ):
         """
         Initialize COCO API for a YOLO dataset.
@@ -156,11 +162,13 @@ class YOLOCocoAPI:
             images_dir: Directory containing images
             labels_dir: Directory containing .txt label files
             class_names: List of class names (from data.yaml)
+            single_cls: Remap all non-negative ground-truth classes to class 0.
         """
         self.images_dir = Path(images_dir) if images_dir is not None else None
         self.labels_dir = Path(labels_dir) if labels_dir is not None else None
         self.class_names = class_names
         self.load_segments = load_segments
+        self.single_cls = bool(single_cls)
         num_classes = len(class_names)
 
         # Build COCO-style data structures
@@ -232,6 +240,7 @@ class YOLOCocoAPI:
                             num_classes,
                             label_path,
                             return_segment=load_segments,
+                            single_cls=self.single_cls,
                         )
                         if parsed is None:
                             continue
@@ -476,7 +485,11 @@ class YOLOCocoAPI:
 
 
 def create_yolo_coco_api(
-    data_yaml_path: str, split: str = "val", load_segments: bool = False
+    data_yaml_path: str,
+    split: str = "val",
+    load_segments: bool = False,
+    *,
+    single_cls: bool = False,
 ) -> YOLOCocoAPI:
     """
     Create YOLOCocoAPI from a data.yaml file.
@@ -484,6 +497,7 @@ def create_yolo_coco_api(
     Args:
         data_yaml_path: Path to data.yaml file
         split: Dataset split ('train', 'val', or 'test')
+        single_cls: Build a one-class ground-truth view.
 
     Returns:
         YOLOCocoAPI instance
@@ -496,7 +510,11 @@ def create_yolo_coco_api(
 
     # Reuse the same YAML alias and dataset-root resolution logic as the main
     # loader so COCO evaluation works for dataset names like "coco128.yaml".
-    data = load_data_config(data_yaml_path, autodownload=False)
+    data = load_data_config(
+        data_yaml_path,
+        autodownload=False,
+        single_cls=single_cls,
+    )
     root = Path(data["path"])
 
     # Get class names
@@ -520,6 +538,7 @@ def create_yolo_coco_api(
             load_segments=load_segments,
             image_files=img_files,
             label_files=data.get(f"{split_key}_label_files"),
+            single_cls=single_cls,
         )
 
     images_subpath = data.get(split_key, f"images/{split_key}")
@@ -557,4 +576,5 @@ def create_yolo_coco_api(
         labels_dir=labels_dir,
         class_names=class_names,
         load_segments=load_segments,
+        single_cls=single_cls,
     )

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -93,6 +93,28 @@ def _wrap_train_with_cfg(train_fn: Callable) -> Callable:
             merged = {k: v for k, v in cfg_kwargs.items() if k not in consumed}
             merged.update(user_kwargs)
 
+        resume = merged.get("resume", False)
+        if resume and not merged.get("single_cls", False):
+            resume_source = (
+                resume
+                if isinstance(resume, (str, Path)) and not isinstance(resume, bool)
+                else None
+            )
+            checkpoint_config = self._checkpoint_train_config(resume_source)
+            if bool(checkpoint_config.get("single_cls", False)):
+                merged["single_cls"] = True
+
+        if merged.get("single_cls"):
+            from ..registry import group_of
+
+            group = group_of(self.FAMILY)
+            task = getattr(self, "task", "detect")
+            if group not in {"g0", "g1"} or task != "detect":
+                raise ValueError(
+                    "single_cls=True is supported only for G0/G1 detection "
+                    f"models; got family={self.FAMILY!r} ({group}), task={task!r}."
+                )
+
         if merged.get("pretrained") is False:
             from ..registry import group_of
 
@@ -257,6 +279,7 @@ class BaseModel(ABC):
         self.size = size
         self.nb_classes = nb_classes
         self.input_size = self._get_task_input_sizes()[size]
+        self._loaded_checkpoint_train_config: dict[str, Any] | None = None
         # Built lazily on the first cuda_graph=True call so models that never
         # ask for capture pay nothing.
         self._graph_runner: Optional["GraphRunner"] = None
@@ -290,6 +313,7 @@ class BaseModel(ABC):
             self.model_path = None
         elif isinstance(model_path, dict):
             self.model_path = None
+            self._cache_checkpoint_train_config(model_path)
             state_dict = self._prepare_state_dict(self._strip_ddp_prefix(model_path))
             self._validate_loaded_state_dict_for_task(state_dict, model_path)
             self._prepare_model_for_state_dict(state_dict)
@@ -597,6 +621,42 @@ class BaseModel(ABC):
         """
         return state_dict
 
+    def _checkpoint_train_config(
+        self, source: str | Path | dict | None = None
+    ) -> dict[str, Any]:
+        """Return the saved training config for a checkpoint, if available."""
+        if source is None:
+            cached = getattr(self, "_loaded_checkpoint_train_config", None)
+            if cached is not None:
+                return dict(cached)
+            source = getattr(self, "model_path", None) or getattr(
+                self, "_weight_source", None
+            )
+        if source is None:
+            return {}
+        if isinstance(source, dict):
+            checkpoint = source
+        else:
+            path = Path(source)
+            if not path.exists():
+                return {}
+            try:
+                checkpoint = load_untrusted_torch_file(
+                    path,
+                    map_location="cpu",
+                    context="checkpoint training-config probe",
+                )
+            except Exception:
+                return {}
+        return self._cache_checkpoint_train_config(checkpoint)
+
+    def _cache_checkpoint_train_config(self, checkpoint: Any) -> dict[str, Any]:
+        """Cache and return checkpoint training config metadata."""
+        config = checkpoint.get("config") if isinstance(checkpoint, dict) else None
+        cached = dict(config) if isinstance(config, dict) else {}
+        self._loaded_checkpoint_train_config = cached
+        return dict(cached)
+
     def _adapt_checkpoint_num_classes(
         self,
         ckpt_nc: int | None,
@@ -860,6 +920,7 @@ class BaseModel(ABC):
                 map_location="cpu",
                 context="model weights",
             )
+            self._cache_checkpoint_train_config(loaded)
 
             if isinstance(loaded, dict):
                 metadata_keys = set(REQUIRED_CHECKPOINT_METADATA_KEYS) - {"model"}

--- a/libreyolo/models/deim/model.py
+++ b/libreyolo/models/deim/model.py
@@ -113,6 +113,7 @@ class LibreDEIM(BaseModel):
         device: str = "auto",
         **kwargs,
     ):
+        checkpoint = model_path if isinstance(model_path, dict) else None
         if isinstance(model_path, dict):
             model_path = unwrap_deim_checkpoint(model_path)
         super().__init__(
@@ -122,6 +123,8 @@ class LibreDEIM(BaseModel):
             device=device,
             **kwargs,
         )
+        if checkpoint is not None:
+            self._cache_checkpoint_train_config(checkpoint)
         if isinstance(model_path, str):
             self._load_weights(model_path)
 
@@ -242,7 +245,11 @@ class LibreDEIM(BaseModel):
         from .trainer import DEIMTrainer
 
         try:
-            data_config = load_data_config(data, autodownload=True)
+            data_config = load_data_config(
+                data,
+                autodownload=True,
+                single_cls=bool(kwargs.get("single_cls", False)),
+            )
             data = data_config.get("yaml_file", data)
         except Exception as e:
             raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")
@@ -337,6 +344,7 @@ class LibreDEIM(BaseModel):
 
         try:
             loaded = torch.load(model_path, map_location="cpu", weights_only=False)
+            self._cache_checkpoint_train_config(loaded)
             state_dict = unwrap_deim_checkpoint(loaded)
             state_dict = self._strip_ddp_prefix(dict(state_dict))
 

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -360,7 +360,10 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
         preproc, MosaicDatasetClass = self.create_transforms()
 
         if self.config.data:
-            data_cfg = load_data_config(self.config.data)
+            data_cfg = load_data_config(
+                self.config.data,
+                single_cls=self.config.single_cls,
+            )
             data_dir = data_cfg["root"]
             self.num_classes = data_cfg.get("nc", self.config.num_classes)
 
@@ -377,7 +380,8 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     num_classes=int(self.num_classes),
-                    names=data_cfg.get("names"),
+                    names=data_cfg.get("_original_names", data_cfg.get("names")),
+                    single_cls=self.config.single_cls,
                 )
             elif img_files:
                 train_dataset = YOLODataset(
@@ -385,6 +389,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     label_files=label_files,
                     img_size=img_size,
                     preproc=preproc,
+                    single_cls=self.config.single_cls,
                 )
             elif ann_file.exists():
                 train_dataset = COCODataset(
@@ -394,7 +399,8 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     num_classes=int(self.num_classes),
-                    names=data_cfg.get("names"),
+                    names=data_cfg.get("_original_names", data_cfg.get("names")),
+                    single_cls=self.config.single_cls,
                 )
             else:
                 train_path = data_cfg.get("train", "images/train")
@@ -410,10 +416,11 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     label_files=label_files,
                     img_size=img_size,
                     preproc=preproc,
+                    single_cls=self.config.single_cls,
                 )
         elif self.config.data_dir:
             data_dir = self.config.data_dir
-            self.num_classes = self.config.num_classes
+            self.num_classes = 1 if self.config.single_cls else self.config.num_classes
             if (Path(data_dir) / "annotations").exists():
                 train_dataset = COCODataset(
                     data_dir=data_dir,
@@ -422,6 +429,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     num_classes=int(self.num_classes),
+                    single_cls=self.config.single_cls,
                 )
             else:
                 train_dataset = YOLODataset(
@@ -429,6 +437,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     split="train",
                     img_size=img_size,
                     preproc=preproc,
+                    single_cls=self.config.single_cls,
                 )
         else:
             raise ValueError("Either 'data' or 'data_dir' must be specified")

--- a/libreyolo/models/deimv2/model.py
+++ b/libreyolo/models/deimv2/model.py
@@ -136,6 +136,7 @@ class LibreDEIMv2(BaseModel):
         **kwargs,
     ):
         size = normalize_size(size)
+        checkpoint = model_path if isinstance(model_path, dict) else None
         pending_state_dict = None
         if isinstance(model_path, dict):
             pending_state_dict = self._prepare_state_dict(
@@ -149,6 +150,8 @@ class LibreDEIMv2(BaseModel):
             device=device,
             **kwargs,
         )
+        if checkpoint is not None:
+            self._cache_checkpoint_train_config(checkpoint)
         if pending_state_dict is not None:
             self._load_state_dict_checked(pending_state_dict)
             self.model.eval()
@@ -277,7 +280,11 @@ class LibreDEIMv2(BaseModel):
             imgsz = self._validate_imgsz(imgsz, context="DEIMv2 training imgsz")
 
         try:
-            data_config = load_data_config(data, autodownload=True)
+            data_config = load_data_config(
+                data,
+                autodownload=True,
+                single_cls=bool(kwargs.get("single_cls", False)),
+            )
             data = data_config.get("yaml_file", data)
         except Exception as e:
             raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")
@@ -459,6 +466,7 @@ class LibreDEIMv2(BaseModel):
 
         try:
             if Path(model_path).suffix == ".safetensors":
+                self._cache_checkpoint_train_config({})
                 self._load_safetensors_weights(model_path)
                 return
 
@@ -467,6 +475,7 @@ class LibreDEIMv2(BaseModel):
                 map_location="cpu",
                 context="DEIMv2 model weights",
             )
+            self._cache_checkpoint_train_config(loaded)
             state_dict = unwrap_deim_checkpoint(loaded)
             state_dict = self._prepare_state_dict(state_dict, self.size)
 

--- a/libreyolo/models/dfine/model.py
+++ b/libreyolo/models/dfine/model.py
@@ -154,6 +154,7 @@ class LibreDFINE(BaseModel):
         # Must be set before super().__init__ — weight loading (and its task
         # validation hook) runs inside the base constructor.
         self._allow_detect_to_segment_transfer = bool(allow_detect_to_segment_transfer)
+        checkpoint = model_path if isinstance(model_path, dict) else None
         if isinstance(model_path, dict):
             model_path = unwrap_dfine_checkpoint(model_path)
         super().__init__(
@@ -164,6 +165,8 @@ class LibreDFINE(BaseModel):
             task=task,
             **kwargs,
         )
+        if checkpoint is not None:
+            self._cache_checkpoint_train_config(checkpoint)
         if isinstance(model_path, str):
             self._load_weights(model_path)
 
@@ -334,7 +337,11 @@ class LibreDFINE(BaseModel):
         from .trainer import DFINETrainer
 
         try:
-            data_config = load_data_config(data, autodownload=True)
+            data_config = load_data_config(
+                data,
+                autodownload=True,
+                single_cls=bool(kwargs.get("single_cls", False)),
+            )
             data = data_config.get("yaml_file", data)
         except Exception as e:
             raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")
@@ -429,6 +436,7 @@ class LibreDFINE(BaseModel):
 
         try:
             loaded = torch.load(model_path, map_location="cpu", weights_only=False)
+            self._cache_checkpoint_train_config(loaded)
             state_dict = unwrap_dfine_checkpoint(loaded)
             state_dict = self._strip_ddp_prefix(dict(state_dict))
             self._validate_loaded_state_dict_for_task(

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -414,7 +414,10 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
         load_segments = self._is_segment()
 
         if self.config.data:
-            data_cfg = load_data_config(self.config.data)
+            data_cfg = load_data_config(
+                self.config.data,
+                single_cls=self.config.single_cls,
+            )
             data_dir = data_cfg["root"]
             self.num_classes = data_cfg.get("nc", self.config.num_classes)
 
@@ -431,8 +434,9 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     num_classes=int(self.num_classes),
-                    names=data_cfg.get("names"),
+                    names=data_cfg.get("_original_names", data_cfg.get("names")),
                     load_segments=load_segments,
+                    single_cls=self.config.single_cls,
                 )
             elif img_files:
                 train_dataset = YOLODataset(
@@ -441,6 +445,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     load_segments=load_segments,
+                    single_cls=self.config.single_cls,
                 )
             elif ann_file.exists():
                 train_dataset = COCODataset(
@@ -450,8 +455,9 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     num_classes=int(self.num_classes),
-                    names=data_cfg.get("names"),
+                    names=data_cfg.get("_original_names", data_cfg.get("names")),
                     load_segments=load_segments,
+                    single_cls=self.config.single_cls,
                 )
             else:
                 train_path = data_cfg.get("train", "images/train")
@@ -468,10 +474,11 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     load_segments=load_segments,
+                    single_cls=self.config.single_cls,
                 )
         elif self.config.data_dir:
             data_dir = self.config.data_dir
-            self.num_classes = self.config.num_classes
+            self.num_classes = 1 if self.config.single_cls else self.config.num_classes
             if (Path(data_dir) / "annotations").exists():
                 train_dataset = COCODataset(
                     data_dir=data_dir,
@@ -481,6 +488,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     preproc=preproc,
                     num_classes=int(self.num_classes),
                     load_segments=load_segments,
+                    single_cls=self.config.single_cls,
                 )
             else:
                 train_dataset = YOLODataset(
@@ -489,6 +497,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     load_segments=load_segments,
+                    single_cls=self.config.single_cls,
                 )
         else:
             raise ValueError("Either 'data' or 'data_dir' must be specified")

--- a/libreyolo/models/ec/model.py
+++ b/libreyolo/models/ec/model.py
@@ -162,6 +162,7 @@ class LibreEC(BaseModel):
         task: str | None = None,
         **kwargs,
     ):
+        checkpoint = model_path if isinstance(model_path, dict) else None
         if isinstance(model_path, dict):
             model_path = unwrap_ec_checkpoint(model_path)
         resolved_task = normalize_task(task) if task is not None else None
@@ -179,6 +180,8 @@ class LibreEC(BaseModel):
             task=resolved_task,
             **kwargs,
         )
+        if checkpoint is not None:
+            self._cache_checkpoint_train_config(checkpoint)
         if self.task == "pose":
             self.names = {0: "person"}
         if isinstance(model_path, str):
@@ -359,7 +362,11 @@ class LibreEC(BaseModel):
             )
 
         try:
-            data_config = load_data_config(data, autodownload=True)
+            data_config = load_data_config(
+                data,
+                autodownload=True,
+                single_cls=bool(kwargs.get("single_cls", False)),
+            )
             data = data_config.get("yaml_file", data)
         except Exception as e:
             raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")
@@ -599,6 +606,7 @@ class LibreEC(BaseModel):
 
         try:
             loaded = torch.load(model_path, map_location="cpu", weights_only=False)
+            self._cache_checkpoint_train_config(loaded)
             state_dict = unwrap_ec_checkpoint(loaded)
             state_dict = self._strip_ddp_prefix(dict(state_dict))
 

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -907,6 +907,7 @@ class LibreRFDETR(BaseModel):
 
             if not isinstance(loaded, dict):
                 raise TypeError("RF-DETR checkpoints must be dictionaries")
+            self._cache_checkpoint_train_config(loaded)
 
             ckpt_family = loaded.get("model_family", "")
             if ckpt_family and ckpt_family != self.FAMILY:
@@ -1330,6 +1331,10 @@ class LibreRFDETR(BaseModel):
         resume_path = None
         if resume:
             resume_path = run_dir / "weights" / "last.pt" if resume is True else resume
+            if not train_kwargs.get("single_cls", False):
+                checkpoint_config = self._checkpoint_train_config(resume_path)
+                if bool(checkpoint_config.get("single_cls", False)):
+                    train_kwargs["single_cls"] = True
             if not train_kwargs.get(
                 "lora", False
             ) and self._resume_checkpoint_uses_lora(resume_path):

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -99,6 +99,7 @@ class RFDETRTrainer(BaseTrainer):
             data_cfg = load_data_config(
                 self.config.data,
                 allow_scripts=self.config.allow_download_scripts,
+                single_cls=self.config.single_cls,
             )
             names = data_cfg.get("names")
             data_nc = data_cfg.get("nc")
@@ -107,6 +108,8 @@ class RFDETRTrainer(BaseTrainer):
             self.config.num_classes = int(
                 data_nc if data_nc is not None else self.config.num_classes
             )
+            if self.config.single_cls:
+                self.config.num_classes = 1
             if isinstance(names, dict):
                 self._class_names = {int(k): str(v) for k, v in names.items()}
             elif isinstance(names, (list, tuple)):
@@ -675,7 +678,9 @@ class RFDETRTrainer(BaseTrainer):
 
         if self.wrapper_model is not None:
             self.wrapper_model.nb_classes = self.config.num_classes
-            if self._class_names:
+            if self.config.single_cls:
+                self.wrapper_model.names = {0: "object"}
+            elif self._class_names:
                 self.wrapper_model.names = self.wrapper_model._sanitize_names(
                     self._class_names,
                     self.config.num_classes,

--- a/libreyolo/models/rtdetr/model.py
+++ b/libreyolo/models/rtdetr/model.py
@@ -556,6 +556,7 @@ class LibreRTDETR(BaseModel):
                 data,
                 autodownload=True,
                 allow_scripts=allow_download_scripts,
+                single_cls=bool(kwargs.get("single_cls", False)),
             )
             data = data_config.get("yaml_file", data)
         except Exception as e:

--- a/libreyolo/models/rtdetrv4/model.py
+++ b/libreyolo/models/rtdetrv4/model.py
@@ -123,7 +123,11 @@ class LibreRTDETRv4(LibreDFINE):
         from .trainer import RTDETRv4Trainer
 
         try:
-            data_config = load_data_config(data, autodownload=True)
+            data_config = load_data_config(
+                data,
+                autodownload=True,
+                single_cls=bool(kwargs.get("single_cls", False)),
+            )
             data = data_config.get("yaml_file", data)
         except Exception as e:
             raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")

--- a/libreyolo/models/tinyformer/model.py
+++ b/libreyolo/models/tinyformer/model.py
@@ -130,6 +130,7 @@ class LibreTinyFormer(BaseModel):
         **kwargs,
     ):
         size = normalize_size(size)
+        checkpoint = model_path if isinstance(model_path, dict) else None
         pending_state_dict = None
         if isinstance(model_path, dict):
             pending_state_dict = self._strip_ddp_prefix(
@@ -143,6 +144,8 @@ class LibreTinyFormer(BaseModel):
             device=device,
             **kwargs,
         )
+        if checkpoint is not None:
+            self._cache_checkpoint_train_config(checkpoint)
         if pending_state_dict is not None:
             self._load_state_dict_checked(pending_state_dict)
             self.model.eval()
@@ -260,6 +263,7 @@ class LibreTinyFormer(BaseModel):
                 map_location="cpu",
                 context="TinyFormer model weights",
             )
+            self._cache_checkpoint_train_config(loaded)
             state_dict = self._strip_ddp_prefix(unwrap_deim_checkpoint(loaded))
 
             if isinstance(loaded, dict):
@@ -338,7 +342,11 @@ class LibreTinyFormer(BaseModel):
             imgsz = self._validate_imgsz(imgsz, context="TinyFormer training imgsz")
 
         try:
-            data_config = load_data_config(data, autodownload=True)
+            data_config = load_data_config(
+                data,
+                autodownload=True,
+                single_cls=bool(kwargs.get("single_cls", False)),
+            )
             data = data_config.get("yaml_file", data)
         except Exception as e:
             raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -677,6 +677,7 @@ class LibreYOLO9(BaseModel):
                 data,
                 autodownload=True,
                 allow_scripts=allow_download_scripts,
+                single_cls=bool(kwargs.get("single_cls", False)),
             )
             data = data_config.get("yaml_file", data)
         except Exception as e:

--- a/libreyolo/models/yolo9_e2e/model.py
+++ b/libreyolo/models/yolo9_e2e/model.py
@@ -224,7 +224,10 @@ class LibreYOLO9E2E(LibreYOLO9):
 
         try:
             data_config = load_data_config(
-                data, autodownload=True, allow_scripts=allow_download_scripts
+                data,
+                autodownload=True,
+                allow_scripts=allow_download_scripts,
+                single_cls=bool(kwargs.get("single_cls", False)),
             )
             data = data_config.get("yaml_file", data)
         except Exception as e:

--- a/libreyolo/models/yolonas/model.py
+++ b/libreyolo/models/yolonas/model.py
@@ -243,6 +243,7 @@ class LibreYOLONAS(BaseModel):
         # before model construction or from dataset kpt_shape in train().
         self.num_keypoints = self.POSE_NUM_KEYPOINTS
         self.keypoint_dim = self.KEYPOINT_DIM
+        checkpoint = model_path if isinstance(model_path, dict) else None
         if isinstance(model_path, dict):
             model_path = unwrap_yolonas_checkpoint(model_path)
             if resolved_task == "pose":
@@ -270,6 +271,8 @@ class LibreYOLONAS(BaseModel):
             task=resolved_task,
             **kwargs,
         )
+        if checkpoint is not None:
+            self._cache_checkpoint_train_config(checkpoint)
         if self.task == "pose":
             # Placeholder names; overridden by checkpoint metadata in
             # _load_weights or by the dataset yaml at train() time.
@@ -556,6 +559,7 @@ class LibreYOLONAS(BaseModel):
 
         try:
             loaded = torch.load(model_path, map_location="cpu", weights_only=False)
+            self._cache_checkpoint_train_config(loaded)
             state_dict = unwrap_yolonas_checkpoint(loaded)
             state_dict = self._strip_ddp_prefix(dict(state_dict))
             state_dict = self._prepare_state_dict(state_dict)
@@ -733,7 +737,11 @@ class LibreYOLONAS(BaseModel):
         from .trainer import YOLONASTrainer
 
         try:
-            data_config = load_data_config(data, autodownload=True)
+            data_config = load_data_config(
+                data,
+                autodownload=True,
+                single_cls=bool(kwargs.get("single_cls", False)),
+            )
             data = data_config.get("yaml_file", data)
         except Exception as e:
             raise FileNotFoundError(f"Failed to load dataset config '{data}': {e}")

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -51,6 +51,10 @@ class TrainConfig:
     data: Optional[str] = None
     data_dir: Optional[str] = None
     imgsz: Union[int, Tuple[int, int], List[int], str] = 640
+    # Train every detection label as class 0 without changing source annotations.
+    # Supported by G0/G1 detection families only; shared API/CLI gates reject
+    # unsupported families and tasks before a trainer is built.
+    single_cls: bool = False
 
     # Training
     epochs: int = 300
@@ -278,6 +282,7 @@ class TrainConfig:
         self.precise_bn = int(self.precise_bn)
         if self.precise_bn < 0:
             raise ValueError(f"precise_bn must be >= 0, got {self.precise_bn}")
+        self.single_cls = bool(self.single_cls)
         self.class_balanced = bool(self.class_balanced)
         self.export_check = bool(self.export_check)
 

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -163,6 +163,11 @@ class BaseTrainer(ABC):
         **kwargs,
     ):
         self.config = self._config_class().from_kwargs(**kwargs)
+        if self.config.single_cls and self.config.class_balanced and is_main_process():
+            logger.warning(
+                "class_balanced=True has no effect with single_cls=True; all labels "
+                "belong to the same class, so sampling remains uniform."
+            )
         self.config.amp_dtype = normalize_amp_dtype(
             getattr(self.config, "amp_dtype", "float16")
         )
@@ -789,6 +794,7 @@ class BaseTrainer(ABC):
             data_cfg = load_data_config(
                 self.config.data,
                 allow_scripts=self.config.allow_download_scripts,
+                single_cls=self.config.single_cls,
             )
             data_dir = data_cfg["root"]
             data_nc = data_cfg.get("nc")
@@ -820,7 +826,8 @@ class BaseTrainer(ABC):
                     load_segments=load_segments,
                     load_obb=load_obb,
                     num_classes=self.num_classes,
-                    names=data_cfg.get("names"),
+                    names=data_cfg.get("_original_names", data_cfg.get("names")),
+                    single_cls=self.config.single_cls,
                 )
             elif img_files:
                 train_dataset = YOLODataset(
@@ -831,6 +838,7 @@ class BaseTrainer(ABC):
                     load_segments=load_segments,
                     load_obb=load_obb,
                     num_classes=self.num_classes if load_obb else None,
+                    single_cls=self.config.single_cls,
                 )
             elif ann_file.exists():
                 train_dataset = COCODataset(
@@ -846,7 +854,8 @@ class BaseTrainer(ABC):
                     load_segments=load_segments,
                     load_obb=load_obb,
                     num_classes=self.num_classes,
-                    names=data_cfg.get("names"),
+                    names=data_cfg.get("_original_names", data_cfg.get("names")),
+                    single_cls=self.config.single_cls,
                 )
             else:
                 train_path = data_cfg.get("train", "images/train")
@@ -872,10 +881,11 @@ class BaseTrainer(ABC):
                     load_segments=load_segments,
                     load_obb=load_obb,
                     num_classes=self.num_classes if load_obb else None,
+                    single_cls=self.config.single_cls,
                 )
         elif self.config.data_dir:
             data_dir = self.config.data_dir
-            self.num_classes = self.config.num_classes
+            self.num_classes = 1 if self.config.single_cls else self.config.num_classes
 
             if (Path(data_dir) / "annotations").exists():
                 train_dataset = COCODataset(
@@ -891,6 +901,7 @@ class BaseTrainer(ABC):
                     load_segments=load_segments,
                     load_obb=load_obb,
                     num_classes=self.num_classes,
+                    single_cls=self.config.single_cls,
                 )
             else:
                 train_dataset = YOLODataset(
@@ -901,6 +912,7 @@ class BaseTrainer(ABC):
                     load_segments=load_segments,
                     load_obb=load_obb,
                     num_classes=self.num_classes if load_obb else None,
+                    single_cls=self.config.single_cls,
                 )
         else:
             raise ValueError("Either 'data' or 'data_dir' must be specified")
@@ -1379,7 +1391,7 @@ class BaseTrainer(ABC):
 
     def _resolve_num_classes_from_data_config(self) -> int:
         """Resolve dataset class count before criterion construction."""
-        resolved = int(self.config.num_classes)
+        resolved = 1 if self.config.single_cls else int(self.config.num_classes)
         if self.config.data:
             # Only the YAML's class count is needed here; the dataset itself is
             # downloaded later in _setup_data.
@@ -1387,6 +1399,7 @@ class BaseTrainer(ABC):
                 self.config.data,
                 autodownload=False,
                 allow_scripts=self.config.allow_download_scripts,
+                single_cls=self.config.single_cls,
             )
             resolved = int(data_cfg.get("nc", resolved))
 
@@ -1418,6 +1431,8 @@ class BaseTrainer(ABC):
         )
 
         if not needs_rebuild:
+            if wrapper is not None and self.config.single_cls:
+                wrapper.names = {0: "object"}
             return
 
         if wrapper is None or not hasattr(wrapper, "_rebuild_for_new_classes"):
@@ -1438,6 +1453,8 @@ class BaseTrainer(ABC):
                 f"{self.get_model_family()} wrapper rebuild did not sync the model "
                 f"head to num_classes={num_classes}; got {rebuilt_nc}."
             )
+        if self.config.single_cls:
+            wrapper.names = {0: "object"}
 
     # =========================================================================
     # Setup / train / epoch
@@ -2795,6 +2812,7 @@ class BaseTrainer(ABC):
 
             val_config = ValidationConfig(
                 data=self.config.data,
+                single_cls=getattr(self.config, "single_cls", False),
                 batch_size=max(1, self.config.batch // max(getattr(self, "world_size", 1), 1)),
                 imgsz=self.config.imgsz,
                 conf_thres=0.001,

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -18,6 +18,7 @@ class ValidationConfig:
         data: Path to data.yaml file containing dataset configuration.
         data_dir: Direct path to dataset directory (alternative to data).
         split: Dataset split to validate on ("val" or "test").
+        single_cls: Evaluate every detection category as class 0.
         batch_size: Batch size for validation.
         imgsz: Image size for validation. Accepts an int (square) or (height, width) tuple.
         conf_thres: Confidence threshold. Use 0.0 or a low value for mAP calculation.
@@ -50,6 +51,7 @@ class ValidationConfig:
     data: Optional[str] = None
     data_dir: Optional[str] = None
     split: str = "val"
+    single_cls: bool = field(default=False, kw_only=True)
 
     # Inference
     batch_size: int = 16
@@ -135,6 +137,7 @@ class ValidationConfig:
 
     def __post_init__(self) -> None:
         self.amp_dtype = normalize_amp_dtype(self.amp_dtype)
+        self.single_cls = bool(self.single_cls)
 
         if self.data is None and self.data_dir is None and self.keypoints_json is None:
             raise ValueError(

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -1,6 +1,7 @@
 """Detection validator for LibreYOLO."""
 
 import logging
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
@@ -20,6 +21,23 @@ _N_VAL_SAMPLES = 8  # maximum sample images stored for visualisation
 BEST_CONF_KEY = "metrics/best_conf"
 BEST_CONF_F1_KEY = "metrics/best_conf_f1"
 BEST_CONF_PER_CLASS_KEY = "metrics/best_conf_per_class"
+
+
+def _collapse_coco_ground_truth(coco_api, category_id: int):
+    """Return an independent COCO API with every GT category collapsed."""
+    from pycocotools.coco import COCO
+
+    dataset = deepcopy(coco_api.dataset)
+    dataset["categories"] = [
+        {"id": int(category_id), "name": "object", "supercategory": "object"}
+    ]
+    for annotation in dataset.get("annotations", []):
+        annotation["category_id"] = int(category_id)
+    collapsed = COCO()
+    collapsed.dataset = dataset
+    collapsed.createIndex()
+    return collapsed
+
 
 if TYPE_CHECKING:
     from libreyolo.models.base import BaseModel
@@ -50,6 +68,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
     # Class-level default so instances built without __init__ (a pattern the
     # test suite uses for narrow-scope validators) still resolve it.
     _gt_coco_api = None
+    _single_cls_clip_warning_emitted = False
 
     def __init__(
         self,
@@ -65,6 +84,11 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
         self.class_names: Optional[List[str]] = None
         self.iou_thresholds = torch.tensor(self.config.iou_thresholds)
         self.nc = model.nb_classes
+        checkpoint_probe = getattr(model, "_checkpoint_train_config", None)
+        checkpoint_config = checkpoint_probe() if callable(checkpoint_probe) else {}
+        self._checkpoint_single_cls = bool(checkpoint_config.get("single_cls", False))
+        if self._checkpoint_single_cls:
+            self.config = self.config.update(single_cls=True)
         self.val_preproc = None  # set in _setup_dataloader
         self._coco_annotation_file: Optional[Path] = None
         self._coco_label_to_category_id: Optional[Dict[int, int]] = None
@@ -85,6 +109,9 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
 
     def _coco_api_kwargs(self) -> Dict[str, Any]:
         return {}
+
+    def _single_cls_enabled(self) -> bool:
+        return bool(getattr(self.config, "single_cls", False))
 
     def _resolve_imgsz(self) -> int | tuple[int, int]:
         """Return the validation image size, falling back to the model native size."""
@@ -137,9 +164,32 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
             data_cfg = load_data_config(
                 self.config.data,
                 allow_scripts=self.config.allow_download_scripts,
+                single_cls=self._single_cls_enabled(),
             )
             data_dir = data_cfg["root"]
+            model_nc = int(self.nc)
             self.nc = int(data_cfg.get("nc", self.nc))
+
+            original_nc = data_cfg.get("_original_nc")
+            original_names = data_cfg.get("_original_names")
+            if original_nc is None and original_names is not None:
+                original_nc = len(original_names)
+            if getattr(self, "_checkpoint_single_cls", False) and original_nc not in (
+                None,
+                1,
+            ):
+                logger.info(
+                    "Checkpoint config has single_cls=True; collapsing %s dataset "
+                    "classes to one validation class.",
+                    original_nc,
+                )
+            elif not self._single_cls_enabled() and model_nc != self.nc:
+                logger.warning(
+                    "Checkpoint/model class count (%d) differs from dataset class "
+                    "count (%d). Validation will continue, but metrics may be invalid.",
+                    model_nc,
+                    self.nc,
+                )
 
             names = data_cfg.get("names", None)
             if isinstance(names, dict):
@@ -236,7 +286,12 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 img_size=img_size,
                 preproc=self.val_preproc,
                 num_classes=int(self.nc),
-                names=data_cfg.get("names") if data_cfg is not None else None,
+                names=(
+                    data_cfg.get("_original_names", data_cfg.get("names"))
+                    if data_cfg is not None
+                    else None
+                ),
+                single_cls=self._single_cls_enabled(),
                 **dataset_kwargs,
             )
             self._coco_annotation_file = coco_annotation_file
@@ -251,6 +306,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 img_size=img_size,
                 preproc=self.val_preproc,
                 num_classes=int(self.nc),
+                single_cls=self._single_cls_enabled(),
                 **dataset_kwargs,
             )
         elif (data_path / "annotations").exists():
@@ -272,7 +328,12 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 img_size=img_size,
                 preproc=self.val_preproc,
                 num_classes=int(self.nc),
-                names=data_cfg.get("names") if data_cfg is not None else None,
+                names=(
+                    data_cfg.get("_original_names", data_cfg.get("names"))
+                    if data_cfg is not None
+                    else None
+                ),
+                single_cls=self._single_cls_enabled(),
                 **dataset_kwargs,
             )
         else:
@@ -282,6 +343,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 split=split_name,
                 img_size=img_size,
                 preproc=self.val_preproc,
+                single_cls=self._single_cls_enabled(),
                 **dataset_kwargs,
             )
 
@@ -386,6 +448,13 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
             coco_api = self._gt_coco_api
             if coco_api is None:
                 coco_api = COCO(str(self._coco_annotation_file))
+                if self._single_cls_enabled():
+                    category_id = next(
+                        iter((self._coco_label_to_category_id or {}).values()),
+                        0,
+                    )
+                    coco_api = _collapse_coco_ground_truth(coco_api, category_id)
+                    self._coco_label_to_category_id = {0: int(category_id)}
                 self._gt_coco_api = coco_api
             self.coco_evaluator = COCOEvaluator(
                 coco_api,
@@ -415,6 +484,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
         data_cfg = load_data_config(
             self.config.data,
             allow_scripts=self.config.allow_download_scripts,
+            single_cls=self._single_cls_enabled(),
         )
         split = self.config.split
         img_files = data_cfg.get(f"{split}_img_files")
@@ -457,6 +527,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 class_names=class_names,
                 image_files=image_files,
                 label_files=yolo_label_files,
+                single_cls=self._single_cls_enabled(),
                 **self._coco_api_kwargs(),
             )
             self._gt_coco_api = coco_api
@@ -766,7 +837,9 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 gt[:, [0, 2]] /= sx  # x1, x2
                 gt[:, [1, 3]] /= sy  # y1, y2
                 gt_boxes = gt.astype(np.float32)
-            gt_classes = np.clip(vgt_xyxy[:, 4].astype(int), 0, self.nc - 1)
+            raw_classes = vgt_xyxy[:, 4].astype(int)
+            self._warn_single_cls_nonzero_gt(raw_classes)
+            gt_classes = np.clip(raw_classes, 0, self.nc - 1)
             return gt_boxes, gt_classes
 
         # If any value in columns 1-4 exceeds 1.5 the coords must be pixels
@@ -801,7 +874,9 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 gt[:, [0, 2]] /= sx  # x1, x2
                 gt[:, [1, 3]] /= sy  # y1, y2
                 gt_boxes = gt.astype(np.float32)
-            gt_classes = np.clip(vgt[:, 4].astype(int), 0, self.nc - 1)
+            raw_classes = vgt[:, 4].astype(int)
+            self._warn_single_cls_nonzero_gt(raw_classes)
+            gt_classes = np.clip(raw_classes, 0, self.nc - 1)
         else:
             # YOLO [cls, cx_norm, cy_norm, w_norm, h_norm]
             valid = (arr[:, 3] > 0) & (arr[:, 4] > 0)
@@ -813,9 +888,24 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
             bw = vgt[:, 3] * orig_w
             bh = vgt[:, 4] * orig_h
             gt_boxes = np.stack([cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2], axis=1).astype(np.float32)
-            gt_classes = np.clip(vgt[:, 0].astype(int), 0, self.nc - 1)
+            raw_classes = vgt[:, 0].astype(int)
+            self._warn_single_cls_nonzero_gt(raw_classes)
+            gt_classes = np.clip(raw_classes, 0, self.nc - 1)
 
         return gt_boxes, gt_classes
+
+    def _warn_single_cls_nonzero_gt(self, class_ids: np.ndarray) -> None:
+        """Warn once if clipping would hide a broken single-class GT remap."""
+        if (
+            getattr(getattr(self, "config", None), "single_cls", False)
+            and not getattr(self, "_single_cls_clip_warning_emitted", False)
+            and np.any(np.asarray(class_ids) != 0)
+        ):
+            logger.warning(
+                "single_cls validation received non-zero ground-truth class ids "
+                "before clipping. The dataset/evaluator remap may have regressed."
+            )
+            self._single_cls_clip_warning_emitted = True
 
     def _track_plots_data(
         self,

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -194,6 +194,45 @@ def test_train_dry_run_rfdetr_lora_flag_is_visible():
     assert data["resolved_config"]["lora"] is True
 
 
+@pytest.mark.parametrize("model", ["LibreYOLO9t.pt", "LibreRFDETRn.pt"])
+def test_train_dry_run_single_cls_is_visible_for_g0_detectors(model):
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        [
+            "data=coco8.yaml",
+            f"model={model}",
+            "single_cls=true",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["resolved_config"]["single_cls"] is True
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["model=LibreYOLOXn.pt", "single_cls=true"],
+        ["model=LibreRFDETRn-seg.pt", "single_cls=true"],
+    ],
+)
+def test_train_dry_run_rejects_single_cls_outside_g0_g1_detection(args):
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        ["data=coco8.yaml", *args, "--dry-run", "--json"],
+    )
+
+    assert result.exit_code == 2
+    data = json.loads(result.stdout)
+    assert data["error"] == "config_unsupported"
+    assert "G0/G1 detection" in data["message"]
+
+
 def test_train_dry_run_rfdetr_freeze_flag_is_visible():
     app = _make_app()
     result = runner.invoke(
@@ -523,6 +562,44 @@ def test_train_rfdetr_lora_flag_reaches_trainer(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert captured["kwargs"]["lora"] is True
     assert "ignores these parameters" not in result.output
+
+
+def test_train_rfdetr_single_cls_reaches_trainer(monkeypatch, tmp_path):
+    app = _make_app()
+    captured = {}
+
+    class _RFDETRLike:
+        FAMILY = "rfdetr"
+        DEFAULT_TASK = "detect"
+        device = "cpu"
+
+        @classmethod
+        def detect_task_from_filename(cls, filename):
+            return None
+
+        def train(self, data, **kwargs):
+            captured["kwargs"] = kwargs
+            return {"output_dir": str(tmp_path / "rfdetr_exp")}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda out, model, model_path, device: _RFDETRLike(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "data=dummy.yaml",
+            "model=LibreRFDETRm.pt",
+            "single_cls=true",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["single_cls"] is True
 
 
 def test_train_rfdetr_lr_drop_override_reaches_trainer(monkeypatch, tmp_path):

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -216,8 +216,11 @@ def test_train_dry_run_single_cls_is_visible_for_g0_detectors(model):
 @pytest.mark.parametrize(
     "args",
     [
+        # Unsupported family (G2), detect task.
         ["model=LibreYOLOXn.pt", "single_cls=true"],
-        ["model=LibreRFDETRn-seg.pt", "single_cls=true"],
+        # Supported family, unsupported task. Uses a published checkpoint plus
+        # an explicit task so the PR gate never needs to fetch weights.
+        ["model=LibreRFDETRm.pt", "task=segment", "single_cls=true"],
     ],
 )
 def test_train_dry_run_rejects_single_cls_outside_g0_g1_detection(args):

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -309,6 +309,19 @@ class TestBuildTrainKwargs:
         assert "val" not in kwargs
         assert "unknown" not in kwargs
 
+    def test_rfdetr_direct_mapping_keeps_single_cls(self, tmp_path):
+        kwargs = cli_config._build_rfdetr_train_kwargs(
+            {
+                "project": str(tmp_path),
+                "name": "single-cls",
+                "exist_ok": True,
+                "single_cls": True,
+            },
+            user_provided={"single_cls"},
+        )
+
+        assert kwargs["single_cls"] is True
+
 
 class TestGetCfgDefaults:
     """Test that cfg defaults are fully derived from dataclasses."""

--- a/tests/unit/test_single_cls.py
+++ b/tests/unit/test_single_cls.py
@@ -1,0 +1,472 @@
+"""Single-class detection training and validation contracts."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from PIL import Image
+
+from libreyolo.data.dataset import COCODataset, YOLODataset
+from libreyolo.data.utils import load_data_config
+from libreyolo.data.yolo_coco_api import YOLOCocoAPI
+from libreyolo.models.base.model import _wrap_train_with_cfg
+from libreyolo.models.base.model import BaseModel
+from libreyolo.models.registry import families_in
+from libreyolo.training.config import TrainConfig
+from libreyolo.training.trainer import BaseTrainer
+from libreyolo.validation.config import ValidationConfig
+from libreyolo.validation.detection_validator import (
+    DetectionValidator,
+    _collapse_coco_ground_truth,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _rng_state_equal(left, right) -> bool:
+    return (
+        left[0] == right[0]
+        and np.array_equal(left[1], right[1])
+        and left[2:] == right[2:]
+    )
+
+
+def _write_yolo_sample(tmp_path: Path) -> tuple[list[Path], list[Path]]:
+    image_path = tmp_path / "sample.jpg"
+    label_path = tmp_path / "sample.txt"
+    Image.new("RGB", (64, 48), color="white").save(image_path)
+    label_path.write_text(
+        "0 0.25 0.25 0.2 0.2\n2 0.75 0.75 0.2 0.2\n",
+        encoding="utf-8",
+    )
+    return [image_path], [label_path]
+
+
+def _write_coco_sample(tmp_path: Path) -> None:
+    image_dir = tmp_path / "images" / "train"
+    annotation_dir = tmp_path / "annotations"
+    image_dir.mkdir(parents=True)
+    annotation_dir.mkdir()
+    Image.new("RGB", (64, 48), color="white").save(image_dir / "sample.jpg")
+    (annotation_dir / "train.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {
+                        "id": 1,
+                        "file_name": "sample.jpg",
+                        "width": 64,
+                        "height": 48,
+                    }
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 3,
+                        "bbox": [4, 4, 12, 12],
+                        "area": 144,
+                        "iscrowd": 0,
+                    },
+                    {
+                        "id": 2,
+                        "image_id": 1,
+                        "category_id": 7,
+                        "bbox": [32, 24, 12, 12],
+                        "area": 144,
+                        "iscrowd": 0,
+                    },
+                ],
+                "categories": [
+                    {"id": 3, "name": "cat"},
+                    {"id": 7, "name": "dog"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_yolo_data_yaml(tmp_path: Path) -> Path:
+    dataset_root = tmp_path / "dataset"
+    image_dir = dataset_root / "images" / "val"
+    label_dir = dataset_root / "labels" / "val"
+    image_dir.mkdir(parents=True)
+    label_dir.mkdir(parents=True)
+    Image.new("RGB", (64, 48), color="white").save(image_dir / "sample.jpg")
+    (label_dir / "sample.txt").write_text(
+        "0 0.25 0.25 0.2 0.2\n2 0.75 0.75 0.2 0.2\n",
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(dataset_root),
+                "train": "images/val",
+                "val": "images/val",
+                "nc": 3,
+                "names": ["cat", "dog", "bird"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return yaml_path
+
+
+def test_single_cls_defaults_off_and_serializes_when_enabled():
+    assert TrainConfig().single_cls is False
+    assert ValidationConfig(data="unused.yaml").single_cls is False
+    assert TrainConfig(single_cls=True).to_dict()["single_cls"] is True
+
+
+def test_load_data_config_single_cls_is_an_opt_in_view(tmp_path):
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path / "dataset"),
+                "train": "images/train",
+                "val": "images/val",
+                "nc": 3,
+                "names": ["cat", "dog", "bird"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    omitted = load_data_config(str(yaml_path), autodownload=False)
+    explicit_false = load_data_config(
+        str(yaml_path), autodownload=False, single_cls=False
+    )
+    collapsed = load_data_config(str(yaml_path), autodownload=False, single_cls=True)
+
+    assert omitted == explicit_false
+    assert "_original_names" not in omitted
+    assert collapsed["nc"] == 1
+    assert collapsed["names"] == {0: "object"}
+    assert collapsed["_original_nc"] == 3
+    assert collapsed["_original_names"] == ["cat", "dog", "bird"]
+
+
+def test_base_trainer_resolves_one_class_and_stamps_object_name(tmp_path):
+    class _Trainer(BaseTrainer):
+        def get_model_family(self):
+            return "test"
+
+        def get_model_tag(self):
+            return "test"
+
+        def create_transforms(self):
+            return None, None
+
+        def create_scheduler(self, iters_per_epoch):
+            return None
+
+        def get_loss_components(self, outputs):
+            return {}
+
+    yaml_path = tmp_path / "data.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path / "dataset"),
+                "train": "images/train",
+                "val": "images/val",
+                "nc": 3,
+                "names": ["cat", "dog", "bird"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    trainer = _Trainer.__new__(_Trainer)
+    trainer.config = TrainConfig(
+        data=str(yaml_path),
+        num_classes=80,
+        single_cls=True,
+    )
+    trainer.model = SimpleNamespace(num_classes=1)
+    trainer.wrapper_model = SimpleNamespace(
+        nb_classes=1,
+        names={0: "class_0"},
+    )
+
+    resolved = trainer._resolve_num_classes_from_data_config()
+    trainer._sync_wrapped_model_num_classes(resolved)
+
+    assert resolved == trainer.num_classes == trainer.config.num_classes == 1
+    assert trainer.wrapper_model.names == {0: "object"}
+
+
+def test_yolo_dataset_default_is_bit_identical_and_rng_neutral(tmp_path):
+    image_files, label_files = _write_yolo_sample(tmp_path)
+
+    np.random.seed(810)
+    rng_before = np.random.get_state()
+    omitted = YOLODataset(
+        img_files=image_files,
+        label_files=label_files,
+        img_size=(64, 64),
+    )
+    rng_after_omitted = np.random.get_state()
+
+    np.random.seed(810)
+    explicit_false = YOLODataset(
+        img_files=image_files,
+        label_files=label_files,
+        img_size=(64, 64),
+        single_cls=False,
+    )
+    rng_after_false = np.random.get_state()
+
+    assert _rng_state_equal(rng_before, rng_after_omitted)
+    assert _rng_state_equal(rng_after_omitted, rng_after_false)
+    np.testing.assert_array_equal(
+        omitted.annotations[0][0], explicit_false.annotations[0][0]
+    )
+
+
+def test_yolo_dataset_single_cls_remaps_every_positive_class(tmp_path):
+    image_files, label_files = _write_yolo_sample(tmp_path)
+
+    dataset = YOLODataset(
+        img_files=image_files,
+        label_files=label_files,
+        img_size=(64, 64),
+        single_cls=True,
+    )
+
+    labels = dataset.annotations[0][0]
+    assert labels.shape == (2, 5)
+    np.testing.assert_array_equal(labels[:, 4], np.zeros(2))
+
+
+def test_coco_dataset_single_cls_keeps_original_mapping_then_collapses(tmp_path):
+    pytest.importorskip("pycocotools")
+    _write_coco_sample(tmp_path)
+
+    omitted = COCODataset(
+        data_dir=str(tmp_path),
+        json_file="annotations/train.json",
+        name="images/train",
+        img_size=(64, 64),
+        num_classes=2,
+        names={0: "cat", 1: "dog"},
+    )
+    explicit_false = COCODataset(
+        data_dir=str(tmp_path),
+        json_file="annotations/train.json",
+        name="images/train",
+        img_size=(64, 64),
+        num_classes=2,
+        names={0: "cat", 1: "dog"},
+        single_cls=False,
+    )
+    collapsed = COCODataset(
+        data_dir=str(tmp_path),
+        json_file="annotations/train.json",
+        name="images/train",
+        img_size=(64, 64),
+        num_classes=1,
+        names={0: "cat", 1: "dog"},
+        single_cls=True,
+    )
+
+    np.testing.assert_array_equal(
+        omitted.annotations[0][0], explicit_false.annotations[0][0]
+    )
+    assert collapsed.category_id_to_label == {3: 0, 7: 1}
+    assert collapsed.label_to_category_id == {0: 3}
+    assert collapsed._classes == ("object",)
+    np.testing.assert_array_equal(collapsed.annotations[0][0][:, 4], np.zeros(2))
+
+
+def test_yolo_coco_api_single_cls_keeps_nonzero_ground_truth(tmp_path):
+    image_files, label_files = _write_yolo_sample(tmp_path)
+
+    api = YOLOCocoAPI(
+        None,
+        None,
+        ["object"],
+        image_files=image_files,
+        label_files=label_files,
+        single_cls=True,
+    )
+
+    annotations = api.loadAnns()
+    assert len(annotations) == 2
+    assert {annotation["category_id"] for annotation in annotations} == {0}
+
+
+def test_native_coco_ground_truth_collapse_is_independent(tmp_path):
+    pytest.importorskip("pycocotools")
+    from pycocotools.coco import COCO
+
+    _write_coco_sample(tmp_path)
+    original = COCO(str(tmp_path / "annotations" / "train.json"))
+
+    collapsed = _collapse_coco_ground_truth(original, category_id=3)
+
+    assert set(original.getCatIds()) == {3, 7}
+    assert set(collapsed.getCatIds()) == {3}
+    assert {ann["category_id"] for ann in collapsed.anns.values()} == {3}
+
+
+def test_single_cls_native_coco_validation_scores_all_collapsed_gt(tmp_path):
+    pytest.importorskip("pycocotools")
+    from pycocotools.coco import COCO
+
+    from libreyolo.validation import COCOEvaluator
+
+    _write_coco_sample(tmp_path)
+    original = COCO(str(tmp_path / "annotations" / "train.json"))
+    collapsed = _collapse_coco_ground_truth(original, category_id=3)
+    evaluator = COCOEvaluator(collapsed, label_to_category_id={0: 3})
+    evaluator.update(
+        {
+            "boxes": [[4, 4, 16, 16], [32, 24, 44, 36]],
+            "scores": [0.99, 0.98],
+            "classes": [0, 0],
+        },
+        image_id=1,
+    )
+
+    metrics = evaluator.compute()
+
+    assert metrics["mAP"] == pytest.approx(1.0)
+
+
+def test_validator_auto_enables_single_cls_from_checkpoint_config():
+    model = SimpleNamespace(
+        nb_classes=1,
+        _checkpoint_train_config=lambda: {"single_cls": True},
+    )
+    config = ValidationConfig(data="unused.yaml", device="cpu")
+
+    validator = DetectionValidator(model, config)
+
+    assert validator.config.single_cls is True
+    assert config.single_cls is False
+    assert validator._checkpoint_single_cls is True
+
+
+def test_validator_warns_but_continues_on_generic_nc_mismatch(tmp_path, caplog):
+    yaml_path = _write_yolo_data_yaml(tmp_path)
+    model = SimpleNamespace(
+        nb_classes=80,
+        _checkpoint_train_config=lambda: {},
+        _get_val_preprocessor=lambda img_size: None,
+    )
+    config = ValidationConfig(
+        data=str(yaml_path),
+        batch_size=1,
+        num_workers=0,
+        device="cpu",
+    )
+    validator = DetectionValidator(model, config)
+
+    with caplog.at_level(logging.WARNING):
+        dataloader = validator._setup_dataloader()
+
+    assert validator.nc == 3
+    assert len(dataloader.dataset) == 1
+    assert "class count (80) differs from dataset class count (3)" in caplog.text
+
+
+def test_checkpoint_single_cls_collapses_validator_dataset(tmp_path):
+    yaml_path = _write_yolo_data_yaml(tmp_path)
+    model = SimpleNamespace(
+        nb_classes=1,
+        _checkpoint_train_config=lambda: {"single_cls": True},
+        _get_val_preprocessor=lambda img_size: None,
+    )
+    config = ValidationConfig(
+        data=str(yaml_path),
+        batch_size=1,
+        num_workers=0,
+        device="cpu",
+    )
+    validator = DetectionValidator(model, config)
+
+    dataloader = validator._setup_dataloader()
+
+    assert validator.nc == 1
+    assert validator.class_names == ["object"]
+    np.testing.assert_array_equal(
+        dataloader.dataset.annotations[0][0][:, 4], np.zeros(2)
+    )
+
+
+def test_validator_warns_once_before_single_cls_clip(caplog):
+    validator = DetectionValidator.__new__(DetectionValidator)
+    validator.config = SimpleNamespace(single_cls=True)
+
+    with caplog.at_level(logging.WARNING):
+        validator._warn_single_cls_nonzero_gt(np.array([0, 2]))
+        validator._warn_single_cls_nonzero_gt(np.array([3]))
+
+    assert caplog.text.count("non-zero ground-truth class ids") == 1
+
+
+def test_python_gate_accepts_every_g0_g1_detection_family():
+    def train(self, data, **kwargs):
+        return kwargs
+
+    wrapped = _wrap_train_with_cfg(train)
+    supported = families_in("g0") + families_in("g1")
+    assert len(supported) == 13
+
+    for family in supported:
+        wrapper = SimpleNamespace(FAMILY=family, task="detect")
+        assert wrapped(wrapper, "data.yaml", single_cls=True)["single_cls"] is True
+
+
+@pytest.mark.parametrize(
+    ("family", "task"),
+    [("yolox", "detect"), ("dfine", "segment")],
+)
+def test_python_gate_rejects_unsupported_family_or_task(family, task):
+    def train(self, data, **kwargs):
+        return kwargs
+
+    wrapped = _wrap_train_with_cfg(train)
+    wrapper = SimpleNamespace(FAMILY=family, task=task)
+
+    with pytest.raises(ValueError, match="G0/G1 detection"):
+        wrapped(wrapper, "data.yaml", single_cls=True)
+
+
+def test_resume_inherits_single_cls_from_checkpoint_probe():
+    def train(self, data, *, resume=False, **kwargs):
+        return kwargs
+
+    wrapped = _wrap_train_with_cfg(train)
+    wrapper = SimpleNamespace(
+        FAMILY="yolo9",
+        task="detect",
+        model_path="last.pt",
+        _checkpoint_train_config=lambda source=None: {"single_cls": source is None},
+    )
+
+    result = wrapped(wrapper, "data.yaml", resume=True)
+
+    assert result["single_cls"] is True
+
+
+def test_checkpoint_config_probe_reads_saved_single_cls(tmp_path):
+    class _Probe:
+        _cache_checkpoint_train_config = BaseModel._cache_checkpoint_train_config
+
+    checkpoint_path = tmp_path / "last.pt"
+    torch.save({"model": {}, "config": {"single_cls": True}}, checkpoint_path)
+
+    config = BaseModel._checkpoint_train_config(_Probe(), checkpoint_path)
+
+    assert config["single_cls"] is True


### PR DESCRIPTION
Closes part 1 of #810.

Adds `single_cls` train arg: train a multi-class dataset as a one-class detector without editing annotations. Scoped to G0/G1 detection families (13 families, 3 trainer lineages).

## What

- `single_cls: bool = False` on `TrainConfig`. Flows to CLI, `cfg=` yaml, `train_config.yaml`, and `checkpoint["config"]`.
- `load_data_config(..., single_cls=True)` returns a one-class view (`nc=1`, `names={0: "object"}`) and keeps source names under a private key for COCO category mapping.
- Dataset remap at parse time in `YOLODataset` and `COCODataset`. COCO builds its category mapping from the original names first, then collapses at emit, so `_build_category_mappings` validation still runs.
- Validator parity: `ValidationConfig.single_cls`, GT collapse in both the `YOLOCocoAPI` and native-COCO paths.
- `names` stamped to `{0: "object"}` after head rebuild so checkpoints, exports, and HF cards do not get `class_0`.
- Resume probes `checkpoint["config"]["single_cls"]`, so resuming without re-passing the flag does not crash on head mismatch.
- Hard gate on non-G0/G1 families and non-detect tasks, on both the Python and CLI paths. Without it the flag was a silent no-op.
- `libreyolo val` auto-collapses GT when the checkpoint says `single_cls`.

## No label cache to invalidate

LibreYOLO caches image pixels only, not labels. Labels re-parse every run, so a parse-time remap is idempotent and needs no cache invalidation.

## Pre-existing bug fixed on the way

Validating a checkpoint whose `nc` differs from the dataset yaml was checked nowhere: `detection_validator.py` overrode model `nc` with the yaml value and scored every prediction against the wrong categories, silently. Now warns. Deliberately a warning and not an error, because promoting it would change behavior for users who never touch `single_cls`. Error-tier can be a follow-up PR.

## Default-path regression evidence

Every change sits behind `if single_cls:`. No statement reordering, no extra RNG draws.

Step-0 loss and full flattened-gradient hash, seeded, CPU, this commit vs base `9eacad7c`:

```
yolo9-t  base   loss=1.160903358459e+01  grad_sha256=5d268db3f0610157ed697db2ba3a9354cfce9dae104e08c7cb89fd9d2f8e4354
yolo9-t  branch loss=1.160903358459e+01  grad_sha256=5d268db3f0610157ed697db2ba3a9354cfce9dae104e08c7cb89fd9d2f8e4354
dfine-n  base   loss=-2.175588281250e+05 grad_sha256=fba497304442e1b34194a479e7a5b96667506c6bf7816d31108804a85533afbf
dfine-n  branch loss=-2.175588281250e+05 grad_sha256=fba497304442e1b34194a479e7a5b96667506c6bf7816d31108804a85533afbf
```

Bit-identical on both lineages.

Tests: new `tests/unit/test_single_cls.py` (18), including a flag-absent-vs-False bit-identical dataset check that also asserts the off path consumes zero RNG draws.

Full `tests/unit` sweep on this branch: 6752 passed, 148 skipped, 7 xfailed, 4 failed. All 4 failures reproduce on base `9eacad7c` or are flaky, none caused by this branch:

- `test_darknet_edge_export_matrix::test_darknet_edge_raw_parity[openvino-LibreYOLO4]` fails on base
- `test_darknet_edge_export_matrix::test_darknet_edge_raw_parity[ncnn-LibreYOLO2]` fails on base
- `test_detr_cpu_export_matrix::test_detr_detect_raw_parity[openvino-LibreDEIM]` fails on base
- `test_pidnet::test_exported_semantic_parity[ncnn]` flaky, 2 pass 1 fail on identical code

Those four deserve their own issue.

## Known degeneracies, documented not blocked

- D-FINE/DEIM CDN denoising label noise degenerates at `nc=1`. Accuracy note, not a crash.
- `class_balanced=True` with `single_cls` is uniform sampling. Warns.
- RF-DETR head shrink keeps row 0 of the class embedding, so fine-tuning from COCO starts the "object" logit as the "person" row.

## Out of scope

Docs land in a follow-up PR. Issue #810 part 2 (polygon labels to boxes for detection) needs its own plan.

## Code provenance

Original implementation written for this repository. No third-party code copied or adapted.

Upstream survey found nothing to borrow: MultimediaTechLab YOLO (MIT) has no equivalent, RF-DETR upstream (Apache-2.0) has none, SuperGradients (Apache-2.0) has `class_inclusion_list` which filters and reindexes rather than merges. No AGPL sources were read.

In-repo prior art reused for vocabulary and approach only: `libreyolo/label/assist.py` `map_all_to_zero`, and the class-collapse trick already in `libreyolo/models/dfine/loss.py`.

No license or notice files changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds single-class detection training and validation for G0/G1 model families while preserving original category metadata for COCO mapping.
- Threads `single_cls` through CLI, YAML configuration, checkpoints, resume handling, trainers, datasets, and validators.
- Collapses YOLO and native-COCO labels to one class while keeping evaluator category mappings consistent.
- Adds capability gates, class-head/name synchronization, and focused regression tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libreyolo/models/base/model.py | Restores single-class configuration from resumed checkpoints and enforces the supported family/task boundary. |
| libreyolo/training/trainer.py | Propagates one-class configuration through data setup, head synchronization, validation, and checkpoint metadata. |
| libreyolo/data/dataset.py | Adds parse-time class collapse for YOLO and COCO datasets while retaining original COCO category resolution. |
| libreyolo/data/utils.py | Produces a one-class dataset configuration view while preserving original names and class count privately. |
| libreyolo/validation/detection_validator.py | Collapses validation ground truth and aligns native-COCO prediction mappings with the selected collapsed category. |
| libreyolo/cli/commands/train.py | Exposes the CLI flag, propagates it to training, and rejects unsupported model-family or task combinations. |
| tests/unit/test_single_cls.py | Adds focused coverage for configuration, remapping, validation, resume behavior, and unchanged default paths. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[CLI or Python train config] --> B{G0/G1 detect model?}
    B -->|No| C[Reject single_cls]
    B -->|Yes| D[Load source dataset metadata]
    D --> E[Preserve original names]
    E --> F[Expose nc=1 and object name]
    F --> G[Collapse parsed labels to class 0]
    G --> H[Rebuild one-class model head]
    H --> I[Train and checkpoint config]
    I --> J[Validation]
    J --> K[Collapse ground truth]
    K --> L[COCO evaluation with aligned category mapping]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Gate single\_cls before model constructio..."](https://github.com/libreyolo/libreyolo/commit/54592fa33814f5652b162858c490bef35073457a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55299070)</sub>

<!-- /greptile_comment -->