### PR TITLE
Align YOLO txt boxes in training and validation

### DIFF
--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -22,7 +22,7 @@ from PIL import Image, UnidentifiedImageError
 from tqdm import tqdm
 
 from .cache import ImageCacheMixin
-from .utils import polygon_to_cxcywh
+from .yolo_coco_api import parse_yolo_label_line
 from .obb import (
     canonicalize_xywhr,
     corners_to_xywhr,
@@ -35,28 +35,12 @@ from libreyolo.utils.image_size import imgsz_to_hw
 logger = logging.getLogger(__name__)
 
 
-def _yolo_coords_to_rings(
-    coords: List[float], width: int, height: int
-) -> List[np.ndarray]:
-    """Convert one normalized YOLO polygon row to the shared ring contract."""
-    ring = np.array(coords, dtype=np.float32).reshape(-1, 2)
-    ring[:, 0] *= width
-    ring[:, 1] *= height
-    return [ring]
-
-
-def _yolo_box_to_ring(cx: float, cy: float, w: float, h: float, width: int, height: int) -> List[np.ndarray]:
-    """Convert one normalized YOLO bbox row to a rectangular ring."""
-    x1 = (cx - w / 2) * width
-    y1 = (cy - h / 2) * height
-    x2 = (cx + w / 2) * width
-    y2 = (cy + h / 2) * height
+def _xyxy_to_ring(x1: float, y1: float, x2: float, y2: float) -> List[np.ndarray]:
+    """Convert one pixel-space box to the shared ring contract."""
     ring = np.array(
         [[x1, y1], [x2, y1], [x2, y2], [x1, y2]],
         dtype=np.float32,
     )
-    ring[:, 0] = np.clip(ring[:, 0], 0.0, float(width))
-    ring[:, 1] = np.clip(ring[:, 1], 0.0, float(height))
     return [ring]
 
 
@@ -460,43 +444,36 @@ class YOLODataset(ImageCacheMixin, Dataset):
                         if self.single_cls:
                             cls_id = 0
                         labels.append([*proxy.tolist(), cls_id, float(xywhr[4])])
-                    elif len(parts) >= 5:
-                        cls_id = int(parts[0])
-                        if self.single_cls and cls_id >= 0:
-                            cls_id = 0
-
-                        if len(parts) > 5:
-                            # Segmentation format: derive bbox from polygon vertices
-                            coords = [float(p) for p in parts[1:]]
-                            cx, cy, w, h = polygon_to_cxcywh(coords)
-                            if self.load_segments:
-                                segments.append(_yolo_coords_to_rings(coords, width, height))
-                        else:
-                            cx, cy, w, h = map(float, parts[1:5])
-                            if self.load_segments:
-                                segments.append(_yolo_box_to_ring(cx, cy, w, h, width, height))
-
-                        # Convert normalized xywh to pixel xyxy, then clamp to
-                        # the image. Labels can extend past the border: a
-                        # polygon tracing an object cut off at the frame edge,
-                        # or simply an out-of-range box row. The pixels outside
-                        # do not exist, so the visible extent is the honest
-                        # target. The COCO branch below and the validation
-                        # parser (data/yolo_coco_api.py) both already clamp and
-                        # drop empties; keeping this path consistent means
-                        # training and evaluation score the same box (#814).
-                        x1 = max(0.0, (cx - w / 2) * width)
-                        y1 = max(0.0, (cy - h / 2) * height)
-                        x2 = min(float(width), (cx + w / 2) * width)
-                        y2 = min(float(height), (cy + h / 2) * height)
-
-                        if x2 <= x1 or y2 <= y1:
-                            # Entirely outside the image, or degenerate. Drop
-                            # the paired segment too, or segments and labels
-                            # fall out of step for every later row.
-                            if self.load_segments and segments:
-                                segments.pop()
+                    else:
+                        # Use the validation parser as the single source of
+                        # truth for YOLO boxes and polygons. It derives polygon
+                        # extents, rejects malformed/non-finite rows, clips both
+                        # endpoints to the image, and drops boxes with no
+                        # visible area. Training and scoring therefore consume
+                        # identical geometry (#814).
+                        parsed = parse_yolo_label_line(
+                            line,
+                            width,
+                            height,
+                            self.num_classes,
+                            label_file,
+                            return_segment=self.load_segments,
+                            single_cls=self.single_cls,
+                        )
+                        if parsed is None:
                             continue
+
+                        if self.load_segments:
+                            cls_id, x1, y1, x2, y2, _, segment = parsed
+                            if segment:
+                                ring = np.asarray(segment, dtype=np.float32).reshape(
+                                    -1, 2
+                                )
+                                segments.append([ring])
+                            else:
+                                segments.append(_xyxy_to_ring(x1, y1, x2, y2))
+                        else:
+                            cls_id, x1, y1, x2, y2, _ = parsed
 
                         labels.append([x1, y1, x2, y2, cls_id])
 

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -476,11 +476,27 @@ class YOLODataset(ImageCacheMixin, Dataset):
                             if self.load_segments:
                                 segments.append(_yolo_box_to_ring(cx, cy, w, h, width, height))
 
-                        # Convert normalized xywh to pixel xyxy
-                        x1 = (cx - w / 2) * width
-                        y1 = (cy - h / 2) * height
-                        x2 = (cx + w / 2) * width
-                        y2 = (cy + h / 2) * height
+                        # Convert normalized xywh to pixel xyxy, then clamp to
+                        # the image. Labels can extend past the border: a
+                        # polygon tracing an object cut off at the frame edge,
+                        # or simply an out-of-range box row. The pixels outside
+                        # do not exist, so the visible extent is the honest
+                        # target. The COCO branch below and the validation
+                        # parser (data/yolo_coco_api.py) both already clamp and
+                        # drop empties; keeping this path consistent means
+                        # training and evaluation score the same box (#814).
+                        x1 = max(0.0, (cx - w / 2) * width)
+                        y1 = max(0.0, (cy - h / 2) * height)
+                        x2 = min(float(width), (cx + w / 2) * width)
+                        y2 = min(float(height), (cy + h / 2) * height)
+
+                        if x2 <= x1 or y2 <= y1:
+                            # Entirely outside the image, or degenerate. Drop
+                            # the paired segment too, or segments and labels
+                            # fall out of step for every later row.
+                            if self.load_segments and segments:
+                                segments.pop()
+                            continue
 
                         labels.append([x1, y1, x2, y2, cls_id])
 

--- a/libreyolo/data/yolo_coco_api.py
+++ b/libreyolo/data/yolo_coco_api.py
@@ -25,7 +25,7 @@ def parse_yolo_label_line(
     line: str,
     img_w: int,
     img_h: int,
-    num_classes: int,
+    num_classes: Optional[int],
     label_path: Optional[Path] = None,
     return_segment: bool = False,
     single_cls: bool = False,
@@ -37,7 +37,8 @@ def parse_yolo_label_line(
         line: Label line from .txt file
         img_w: Image width in pixels
         img_h: Image height in pixels
-        num_classes: Total number of classes
+        num_classes: Total number of classes, or ``None`` when the caller does
+            not have the dataset class count available.
         label_path: Path to label file (for warnings)
         single_cls: Remap non-negative class ids to class 0 before validation.
 
@@ -64,8 +65,12 @@ def parse_yolo_label_line(
         if len(parts) > 5:
             # Segmentation format: derive bbox from polygon vertices.
             coords = [float(p) for p in parts[1:]]
+            if len(coords) < 6 or len(coords) % 2:
+                raise ValueError("polygon rows require at least 3 coordinate pairs")
+            if not np.isfinite(coords).all():
+                raise ValueError("label coordinates must be finite")
             cx, cy, bw, bh = polygon_to_cxcywh(coords)
-            if return_segment and len(coords) >= 6:
+            if return_segment:
                 segment = []
                 for x, y in zip(coords[0::2], coords[1::2]):
                     segment.extend(
@@ -80,6 +85,8 @@ def parse_yolo_label_line(
             cy = float(parts[2])
             bw = float(parts[3])
             bh = float(parts[4])
+            if not np.isfinite((cx, cy, bw, bh)).all():
+                raise ValueError("label coordinates must be finite")
     except ValueError as e:
         if label_path:
             warnings.warn(
@@ -91,9 +98,12 @@ def parse_yolo_label_line(
         class_id = 0
 
     # Validate class ID
-    if class_id < 0 or class_id >= num_classes:
+    if class_id < 0 or (num_classes is not None and class_id >= num_classes):
+        valid_range = (
+            f"[0, {num_classes - 1}]" if num_classes is not None else "non-negative"
+        )
         warnings.warn(
-            f"Class ID {class_id} out of range [0, {num_classes - 1}] in {label_path}. Skipping."
+            f"Class ID {class_id} out of range {valid_range} in {label_path}. Skipping."
         )
         return None
 

--- a/tests/unit/test_gt_box_clamping.py
+++ b/tests/unit/test_gt_box_clamping.py
@@ -1,0 +1,124 @@
+"""Ground-truth boxes must be clamped identically in training and validation (#814).
+
+The validation parser (``data/yolo_coco_api.py``) has always clamped boxes to
+the image and dropped the ones left with no area. The YOLO txt training parser
+did not, so a label crossing the border produced one box for training and a
+different one for scoring. The COCO training branch already clamped, which made
+the txt path the odd one out among all three.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+
+from libreyolo.data.dataset import YOLODataset
+from libreyolo.data.yolo_coco_api import create_yolo_coco_api
+
+pytestmark = pytest.mark.unit
+
+IMG = 160
+
+
+def _make_dataset(tmp_path, rows, nc=1):
+    for split in ("train", "val"):
+        (tmp_path / "images" / split).mkdir(parents=True)
+        (tmp_path / "labels" / split).mkdir(parents=True)
+        cv2.imwrite(
+            str(tmp_path / "images" / split / "0.jpg"),
+            np.full((IMG, IMG, 3), 40, np.uint8),
+        )
+        (tmp_path / "labels" / split / "0.txt").write_text("\n".join(rows) + "\n")
+    names = "\n".join(f"  {i}: c{i}" for i in range(nc))
+    (tmp_path / "data.yaml").write_text(
+        f"path: {tmp_path}\ntrain: images/train\nval: images/val\nnc: {nc}\nnames:\n{names}\n"
+    )
+    return tmp_path / "data.yaml"
+
+
+def _train_boxes(root, **kwargs):
+    ds = YOLODataset(data_dir=str(root), split="train", img_size=(IMG, IMG), **kwargs)
+    return np.asarray(ds.load_anno(0))
+
+
+def _val_boxes(yaml_path):
+    api = create_yolo_coco_api(str(yaml_path), split="val")
+    out = []
+    for ann in api.anns.values():
+        x, y, w, h = ann["bbox"]
+        out.append([x, y, x + w, y + h])
+    return np.asarray(sorted(out, key=lambda b: (b[0], b[1])), dtype=np.float32)
+
+
+@pytest.mark.parametrize(
+    "row,label",
+    [
+        # Polygon running off the left and top edges.
+        ("0 -0.12 -0.05 0.30 -0.02 0.34 0.40 -0.08 0.36", "polygon"),
+        # Plain box row whose extent crosses the right edge. Not polygon
+        # specific: any out-of-range label hit this.
+        ("0 0.95 0.50 0.30 0.40", "box"),
+    ],
+)
+def test_border_crossing_label_matches_between_train_and_val(tmp_path, row, label):
+    yaml_path = _make_dataset(tmp_path, [row])
+
+    train = _train_boxes(tmp_path)[:, :4]
+    val = _val_boxes(yaml_path)
+
+    assert train.shape == (1, 4), f"{label}: expected one training box"
+    np.testing.assert_allclose(train, val, atol=1e-4)
+    assert train.min() >= 0.0
+    assert train[:, [0, 2]].max() <= IMG
+    assert train[:, [1, 3]].max() <= IMG
+
+
+def test_label_entirely_outside_the_image_is_dropped_by_both_paths(tmp_path):
+    yaml_path = _make_dataset(tmp_path, ["0 -0.50 0.50 0.20 0.20"])
+
+    assert len(_train_boxes(tmp_path)) == 0
+    assert len(_val_boxes(yaml_path)) == 0
+
+
+def test_in_frame_labels_are_untouched(tmp_path):
+    """Regression guard: clamping must not perturb ordinary labels."""
+    yaml_path = _make_dataset(tmp_path, ["0 0.50 0.50 0.40 0.30"])
+
+    train = _train_boxes(tmp_path)[:, :4]
+    expected = np.array([[0.30 * IMG, 0.35 * IMG, 0.70 * IMG, 0.65 * IMG]], np.float32)
+
+    np.testing.assert_allclose(train, expected, atol=1e-4)
+    np.testing.assert_allclose(train, _val_boxes(yaml_path), atol=1e-4)
+
+
+def test_dropping_a_row_keeps_segments_aligned_with_labels(tmp_path):
+    """A dropped label must drop its segment, or every later row desyncs."""
+    _make_dataset(
+        tmp_path,
+        [
+            "0 -0.50 0.50 0.20 0.20",  # fully outside, dropped
+            "0 0.30 0.30 0.20 0.20",   # kept
+            "0 0.70 0.70 0.20 0.20",   # kept
+        ],
+    )
+
+    ds = YOLODataset(
+        data_dir=str(tmp_path), split="train", img_size=(IMG, IMG), load_segments=True
+    )
+    boxes = np.asarray(ds.load_anno(0))
+    segments = ds.load_segments_for_index(0) if hasattr(
+        ds, "load_segments_for_index"
+    ) else ds.segments[0]
+
+    assert len(boxes) == 2
+    assert len(segments) == len(boxes)
+
+    # Each surviving segment must sit inside its own box, which is only true
+    # if the pairing did not shift when the first row was dropped.
+    for box, seg in zip(boxes, segments):
+        ring = np.asarray(seg[0], dtype=np.float32).reshape(-1, 2)
+        assert ring[:, 0].min() >= box[0] - 1e-3
+        assert ring[:, 1].min() >= box[1] - 1e-3
+        assert ring[:, 0].max() <= box[2] + 1e-3
+        assert ring[:, 1].max() <= box[3] + 1e-3

--- a/tests/unit/test_gt_box_clamping.py
+++ b/tests/unit/test_gt_box_clamping.py
@@ -1,10 +1,9 @@
-"""Ground-truth boxes must be clamped identically in training and validation (#814).
+"""YOLO ground-truth geometry must match in training and validation (#814).
 
 The validation parser (``data/yolo_coco_api.py``) has always clamped boxes to
 the image and dropped the ones left with no area. The YOLO txt training parser
 did not, so a label crossing the border produced one box for training and a
-different one for scoring. The COCO training branch already clamped, which made
-the txt path the odd one out among all three.
+different one for scoring.
 """
 
 from __future__ import annotations
@@ -97,9 +96,9 @@ def test_dropping_a_row_keeps_segments_aligned_with_labels(tmp_path):
     _make_dataset(
         tmp_path,
         [
-            "0 -0.50 0.50 0.20 0.20",  # fully outside, dropped
-            "0 0.30 0.30 0.20 0.20",   # kept
-            "0 0.70 0.70 0.20 0.20",   # kept
+            "0 -0.60 0.40 -0.40 0.40 -0.40 0.60 -0.60 0.60",  # dropped
+            "0 0.30 0.30 0.20 0.20",  # kept
+            "0 0.70 0.70 1.10 0.70 1.10 1.10 0.70 1.10",  # clipped
         ],
     )
 
@@ -122,3 +121,84 @@ def test_dropping_a_row_keeps_segments_aligned_with_labels(tmp_path):
         assert ring[:, 1].min() >= box[1] - 1e-3
         assert ring[:, 0].max() <= box[2] + 1e-3
         assert ring[:, 1].max() <= box[3] + 1e-3
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "0 nan nan 0.50 0.50",
+        "0 0.50 0.50 inf 0.50",
+        "0 nan 0.10 0.50 0.10 0.50 0.50",
+    ],
+)
+def test_non_finite_coordinates_are_dropped_by_both_paths(tmp_path, row):
+    """Corrupt numeric values must never become full-image targets."""
+    yaml_path = _make_dataset(tmp_path, [row])
+
+    with pytest.warns(UserWarning, match="coordinates must be finite"):
+        assert len(_train_boxes(tmp_path)) == 0
+    with pytest.warns(UserWarning, match="coordinates must be finite"):
+        assert len(_val_boxes(yaml_path)) == 0
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "0 0.10 0.10 0.90 0.10 0.90",  # odd coordinate count
+        "0 0.10 0.10 0.90 0.10 0.90 0.90 0.10",  # odd coordinate count
+    ],
+)
+def test_malformed_polygons_are_dropped_by_both_paths(tmp_path, row):
+    yaml_path = _make_dataset(tmp_path, [row])
+
+    with pytest.warns(UserWarning, match="coordinate pairs"):
+        assert len(_train_boxes(tmp_path)) == 0
+    with pytest.warns(UserWarning, match="coordinate pairs"):
+        assert len(_val_boxes(yaml_path)) == 0
+
+
+def test_invalid_class_is_dropped_when_training_knows_class_count(tmp_path):
+    yaml_path = _make_dataset(tmp_path, ["1 0.50 0.50 0.20 0.20"], nc=1)
+
+    with pytest.warns(UserWarning, match="out of range"):
+        assert len(_train_boxes(tmp_path, num_classes=1)) == 0
+    with pytest.warns(UserWarning, match="out of range"):
+        assert len(_val_boxes(yaml_path)) == 0
+
+
+def test_clipped_polygon_reaches_flagship_transforms_with_visible_box(tmp_path):
+    """YOLO9 and RF-DETR must receive the same clipped object extent."""
+    from libreyolo.data.augment.rfdetr import RFDETRDetTransform
+    from libreyolo.data.augment.yolo9 import YOLO9TrainTransform
+
+    _make_dataset(
+        tmp_path,
+        ["0 -0.12 -0.05 0.30 -0.02 0.34 0.40 -0.08 0.36"],
+    )
+    targets = _train_boxes(tmp_path)
+    image = np.zeros((IMG, IMG, 3), dtype=np.uint8)
+
+    yolo9 = YOLO9TrainTransform(
+        max_labels=2,
+        flip_prob=0.0,
+        hsv_prob=0.0,
+    )
+    _, yolo9_targets = yolo9(image.copy(), targets.copy(), (IMG, IMG))
+    np.testing.assert_allclose(
+        yolo9_targets[0],
+        [0.0, 0.0, 0.0, 0.34, 0.40],
+        atol=1e-5,
+    )
+
+    rfdetr = RFDETRDetTransform(
+        max_labels=2,
+        flip_prob=0.0,
+        imgsz=IMG,
+        imagenet_norm=False,
+    )
+    _, rfdetr_targets = rfdetr(image.copy(), targets.copy(), (IMG, IMG))
+    np.testing.assert_allclose(
+        rfdetr_targets[0],
+        [0.0, 0.17 * IMG, 0.20 * IMG, 0.34 * IMG, 0.40 * IMG],
+        atol=1e-4,
+    )


### PR DESCRIPTION
Fixes #814.

- Reuses the YOLO validation parser for txt training labels.
- Clips finite border-crossing boxes and drops boxes with no visible area.
- Rejects non-finite and malformed polygon rows before target creation.
- Preserves clipped segment-to-label alignment.
- Covers final YOLO9 and RF-DETR detection targets.

Tests: 157 affected and adjacent unit tests pass locally, including the CUDA-enabled RF-DETR device path. GitHub CI is pending.

## Code provenance

Original implementation written for LibreYOLO. It reuses the repository's existing YOLO label parser; no third-party code was copied or adapted. No notice files change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes YOLO text-label training use the validation parser so boxes and polygon extents are validated, clamped to image bounds, and dropped when no visible area remains.
- Rejects malformed and non-finite coordinates before box conversion and clipping.
- Keeps labels and segments aligned when rows are dropped.
- Adds train/validation parity tests for border-crossing, outside-image, malformed, and non-finite annotations.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported non-finite-coordinate issue is fixed before clipping in the shared parser used by both training and validation.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libreyolo/data/dataset.py | Replaces independent YOLO box and polygon parsing with the shared validation parser and preserves segment alignment when labels are rejected. |
| libreyolo/data/yolo_coco_api.py | Adds finite-coordinate and polygon-shape validation while allowing callers without a known class count. |
| tests/unit/test_gt_box_clamping.py | Covers clamping parity, degenerate-row removal, segment alignment, non-finite values, malformed polygons, class validation, and transform inputs. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  T[YOLO text training labels] --> P[Shared label parser]
  V[YOLO validation labels] --> P
  P --> F{Coordinates finite and row valid?}
  F -- No --> D[Drop row]
  F -- Yes --> C[Convert and clamp box to image]
  C --> A{Visible area remains?}
  A -- No --> D
  A -- Yes --> O[Emit aligned box and optional segment]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Validate YOLO labels consistently"](https://github.com/libreyolo/libreyolo/commit/21971a10d5d2e1a91b9c72bf61da51281eb2a468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55360104)</sub>

**Context used:**

- Knowledge Base — [Data pipelines](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-pipelines.md)

<!-- /greptile_comment -->