### PR TITLE
Support guardless multi-GPU training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ before 1.4.0 are documented in the
 - **Guardless Python multi-GPU launch (#817).**
   `model.train(device=[0, 1])` and `device="0,1"` now coordinate local DDP
   ranks without re-importing and repeating an unguarded user script. Guarded
-  scripts and explicit `torchrun` launches remain compatible.
+  entry points remain supported, but coordinator ranks do not replay arbitrary
+  guarded top-level side effects. Explicit `torchrun` launches are unchanged.
 - **QAT training-state guards (#768).** Training a quantized model now
   disables EMA and SyncBatchNorm before setup and logs the changes, preventing
   those features from interfering with fake-quant observer and scale state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- **Guardless Python multi-GPU launch (#817).**
+  `model.train(device=[0, 1])` and `device="0,1"` now coordinate local DDP
+  ranks without re-importing and repeating an unguarded user script. Guarded
+  scripts and explicit `torchrun` launches remain compatible.
 - **QAT training-state guards (#768).** Training a quantized model now
   disables EMA and SyncBatchNorm before setup and logs the changes, preventing
   those features from interfering with fake-quant observer and scale state.

--- a/docs/training_loggers.md
+++ b/docs/training_loggers.md
@@ -40,11 +40,14 @@ Callbacks fire on rank 0 only under DDP. For multi-GPU spawn
 (`device="0,1"`), callbacks must be picklable: define them as a
 module-level function or class, not a closure or lambda.
 Automatic spawn works from both guarded and ordinary unguarded top-level
-Python scripts. Existing scripts with an `if __name__ == "__main__"` guard
-remain compatible. A rare callback that standard pickle can reference but
-cannot be transported by value (for example, one that captures a write-only
-file handle) uses the guarded-script compatibility launcher and emits a
-warning; keep that call under the `__main__` guard.
+Python scripts. Guarded-script model classes and callbacks are transported to
+the ranks, but arbitrary top-level runtime side effects are not replayed there.
+Put code needed by every rank in importable model or trainer execution paths
+and key it from the rank environment variables instead of relying on a guarded
+script to run again in each rank. A rare callback that standard pickle can
+reference but cannot be transported by value (for example, one that captures a
+write-only file handle) uses the guarded-script compatibility launcher and
+emits a warning; keep that call under the `__main__` guard.
 
 ## Built-in loggers
 

--- a/docs/training_loggers.md
+++ b/docs/training_loggers.md
@@ -38,7 +38,13 @@ model.train(data="coco8.yaml", epochs=10, callbacks=on_epoch)
 
 Callbacks fire on rank 0 only under DDP. For multi-GPU spawn
 (`device="0,1"`), callbacks must be picklable: define them as a
-module-level class, not a closure or lambda.
+module-level function or class, not a closure or lambda.
+Automatic spawn works from both guarded and ordinary unguarded top-level
+Python scripts. Existing scripts with an `if __name__ == "__main__"` guard
+remain compatible. A rare callback that standard pickle can reference but
+cannot be transported by value (for example, one that captures a write-only
+file handle) uses the guarded-script compatibility launcher and emits a
+warning; keep that call under the `__main__` guard.
 
 ## Built-in loggers
 

--- a/libreyolo/training/_ddp_coordinator.py
+++ b/libreyolo/training/_ddp_coordinator.py
@@ -1,0 +1,570 @@
+"""Private subprocess coordinator for automatic local DDP training.
+
+The user-facing process writes one short-lived job, then starts this file with
+``sys.executable``. Keeping ``torch.multiprocessing.spawn`` here means
+spawned ranks import a LibreYOLO module instead of re-importing the user's
+``__main__`` module and repeating an unguarded top-level ``model.train()``.
+
+Jobs are trusted, local, ephemeral data created by the current LibreYOLO
+process. Like every pickle transport, job payloads must never be accepted
+from an untrusted source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import json
+import os
+import pickle
+import secrets
+import signal
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+JOB_PROTOCOL = "libreyolo.ddp.local-job"
+JOB_PROTOCOL_VERSION = 1
+MANIFEST_NAME = "manifest.json"
+PAYLOAD_NAME = "payload.pkl"
+STATUS_NAME = "status.json"
+CLEANUP_SENTINEL_NAME = ".libreyolo-ddp-cleanup.json"
+
+
+class JobProtocolError(RuntimeError):
+    """Raised when a private DDP job descriptor is missing or incompatible."""
+
+
+class JobTransportError(RuntimeError):
+    """Raised when a standard-picklable job cannot use coordinator transport."""
+
+
+class ParentProcessExited(RuntimeError):
+    """Raised when the API process exits while its coordinator is running."""
+
+
+def _atomic_json_write(path: Path, data: dict[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_text(json.dumps(data), encoding="utf-8")
+    os.replace(temporary, path)
+
+
+@contextlib.contextmanager
+def job_workspace():
+    """Yield one launcher-owned job path plus its unpersisted cleanup token."""
+    with tempfile.TemporaryDirectory(prefix="libreyolo-ddp-job-") as temp_root:
+        root = Path(temp_root).resolve()
+        directory = root / "job"
+        cleanup_token = secrets.token_hex(32)
+        _atomic_json_write(
+            root / CLEANUP_SENTINEL_NAME,
+            {
+                "protocol": JOB_PROTOCOL,
+                "version": JOB_PROTOCOL_VERSION,
+                "job_id": None,
+                "job_dir": str(directory),
+                "workspace": str(root),
+                "token_sha256": hashlib.sha256(
+                    cleanup_token.encode("utf-8")
+                ).hexdigest(),
+            },
+        )
+        yield directory, cleanup_token
+
+
+def _validate_protocol(data: Any, *, source: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise JobProtocolError(f"DDP {source} must be a mapping")
+    if data.get("protocol") != JOB_PROTOCOL:
+        raise JobProtocolError(
+            f"Unsupported DDP {source} protocol {data.get('protocol')!r}; "
+            f"expected {JOB_PROTOCOL!r}."
+        )
+    if data.get("version") != JOB_PROTOCOL_VERSION:
+        raise JobProtocolError(
+            f"Unsupported DDP {source} version {data.get('version')!r}; "
+            f"expected {JOB_PROTOCOL_VERSION}."
+        )
+    return data
+
+
+def _load_manifest(job_dir: str | Path) -> dict[str, Any]:
+    path = Path(job_dir) / MANIFEST_NAME
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise JobProtocolError(
+            f"Could not read DDP job manifest {path}: {exc}"
+        ) from exc
+    data = _validate_protocol(data, source="job manifest")
+    nprocs = data.get("nprocs")
+    if not isinstance(nprocs, int) or isinstance(nprocs, bool) or nprocs < 1:
+        raise JobProtocolError(
+            f"DDP job nprocs must be a positive integer, got {nprocs!r}"
+        )
+    if not isinstance(data.get("job_id"), str) or not data["job_id"]:
+        raise JobProtocolError("DDP job manifest is missing job_id")
+    import_paths = data.get("import_paths")
+    if not isinstance(import_paths, list) or not all(
+        isinstance(item, str) and item for item in import_paths
+    ):
+        raise JobProtocolError(
+            "DDP job import_paths must be a list of non-empty strings"
+        )
+    return data
+
+
+def _configure_import_paths(manifest: dict[str, Any]) -> None:
+    """Prepend the parent's normalized import paths without using PYTHONPATH."""
+    requested = manifest["import_paths"]
+    requested_keys = {os.path.normcase(os.path.abspath(item)) for item in requested}
+    remainder = [
+        item
+        for item in sys.path
+        if not isinstance(item, str)
+        or os.path.normcase(os.path.abspath(item or os.getcwd())) not in requested_keys
+    ]
+    sys.path[:] = [*requested, *remainder]
+
+
+def _load_payload(job_dir: str | Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    import cloudpickle
+
+    path = Path(job_dir) / PAYLOAD_NAME
+    try:
+        with path.open("rb") as handle:
+            data = cloudpickle.load(handle)
+    except Exception as exc:
+        raise JobProtocolError(f"Could not read DDP job payload {path}: {exc}") from exc
+    data = _validate_protocol(data, source="job payload")
+    if data.get("job_id") != manifest["job_id"]:
+        raise JobProtocolError("DDP job manifest and payload IDs do not match")
+    if data.get("nprocs") != manifest["nprocs"]:
+        raise JobProtocolError(
+            "DDP job manifest and payload process counts do not match"
+        )
+    if data.get("import_paths") != manifest["import_paths"]:
+        raise JobProtocolError("DDP job manifest and payload import paths do not match")
+    if not callable(data.get("worker_fn")):
+        raise JobProtocolError("DDP job worker_fn is not callable")
+    if not isinstance(data.get("spawn_args"), tuple):
+        raise JobProtocolError("DDP job spawn_args must be a tuple")
+    return data
+
+
+def write_job(
+    job_dir: str | Path,
+    *,
+    worker_fn,
+    spawn_args: tuple,
+    nprocs: int,
+    result_path: str,
+    master_addr: str,
+    master_port: int,
+    import_paths: list[str],
+) -> None:
+    """Write a validated, versioned job for the private coordinator."""
+    import cloudpickle
+
+    if not isinstance(nprocs, int) or isinstance(nprocs, bool) or nprocs < 1:
+        raise ValueError(f"nprocs must be a positive integer, got {nprocs!r}")
+    if not isinstance(spawn_args, tuple):
+        raise TypeError(f"spawn_args must be a tuple, got {type(spawn_args).__name__}")
+    if not import_paths or not all(
+        isinstance(item, str) and item for item in import_paths
+    ):
+        raise TypeError("import_paths must be a non-empty list of strings")
+
+    # Keep the existing public contract even though cloudpickle is used for
+    # transport: lambdas, closures, and other objects rejected by standard
+    # pickle must still fail before any child is launched.
+    try:
+        pickle.dumps((worker_fn, spawn_args), protocol=pickle.HIGHEST_PROTOCOL)
+    except Exception as exc:
+        raise RuntimeError(
+            "DDP spawn: worker function and arguments must be picklable with "
+            "Python's standard pickle protocol."
+        ) from exc
+
+    directory = Path(job_dir)
+    directory.mkdir(parents=True, exist_ok=False)
+    job_id = uuid.uuid4().hex
+    common = {
+        "protocol": JOB_PROTOCOL,
+        "version": JOB_PROTOCOL_VERSION,
+        "job_id": job_id,
+        "nprocs": nprocs,
+        "import_paths": import_paths,
+    }
+    payload = {
+        **common,
+        "worker_fn": worker_fn,
+        "spawn_args": spawn_args,
+        "result_path": str(result_path),
+        "master_addr": str(master_addr),
+        "master_port": int(master_port),
+    }
+    try:
+        serialized = cloudpickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)
+    except Exception as exc:
+        raise JobTransportError(
+            "DDP coordinator transport could not serialize a job that passed "
+            "standard pickle validation."
+        ) from exc
+    (directory / PAYLOAD_NAME).write_bytes(serialized)
+    _atomic_json_write(directory / MANIFEST_NAME, common)
+
+
+def _coordinator_worker(rank: int, job_dir: str) -> None:
+    """Load the job independently in each rank and invoke its worker."""
+    manifest = _load_manifest(job_dir)
+    payload = _load_payload(job_dir, manifest)
+    nprocs = payload["nprocs"]
+
+    os.environ["LIBREYOLO_DDP_COORDINATOR_WORKER"] = "1"
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(nprocs)
+    os.environ["MASTER_ADDR"] = payload["master_addr"]
+    os.environ["MASTER_PORT"] = str(payload["master_port"])
+
+    payload["worker_fn"](
+        rank,
+        nprocs,
+        payload["master_addr"],
+        payload["master_port"],
+        payload["result_path"],
+        *payload["spawn_args"],
+    )
+
+
+def _write_status(
+    job_dir: Path, manifest: dict[str, Any] | None, **fields: Any
+) -> bool:
+    status = {
+        "protocol": JOB_PROTOCOL,
+        "version": JOB_PROTOCOL_VERSION,
+        "job_id": manifest.get("job_id") if manifest else None,
+        **fields,
+    }
+    try:
+        _atomic_json_write(job_dir / STATUS_NAME, status)
+    except OSError:
+        # The traceback printed by main remains the fallback if status cannot
+        # be persisted (for example, the temp directory was externally removed).
+        return False
+    return True
+
+
+def _watch_parent(
+    parent_gone: threading.Event, parent_connection: socket.socket
+) -> None:
+    """Set *parent_gone* when the API process closes its liveness socket."""
+    try:
+        parent_connection.recv(1)
+    except OSError:
+        pass
+    parent_gone.set()
+
+
+def _stop_spawned_workers(context) -> None:
+    """Terminate every still-live worker owned by a SpawnContext."""
+    processes = list(context.processes)
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+    for process in processes:
+        process.join(timeout=5)
+    for process in processes:
+        if process.is_alive():
+            process.kill()
+    for process in processes:
+        process.join(timeout=5)
+
+
+def _safe_cleanup_root(directory: Path) -> Path | None:
+    """Return the exact launcher temp root, or None for caller-chosen paths."""
+    try:
+        resolved_directory = directory.resolve()
+        system_temp = Path(tempfile.gettempdir()).resolve()
+    except (OSError, RuntimeError):
+        return None
+    temp_root = resolved_directory.parent
+    if (
+        resolved_directory.name != "job"
+        or temp_root.parent != system_temp
+        or not temp_root.name.startswith("libreyolo-ddp-job-")
+    ):
+        return None
+    return temp_root
+
+
+def _cleanup_abandoned_job(
+    directory: Path,
+    manifest: dict[str, Any] | None,
+    cleanup_token: str | None,
+) -> None:
+    """Remove only a launcher-authenticated job below the system temp root."""
+    if manifest is None or not cleanup_token:
+        return
+    temp_root = _safe_cleanup_root(directory)
+    if temp_root is None:
+        return
+    sentinel_path = temp_root / CLEANUP_SENTINEL_NAME
+    try:
+        sentinel = json.loads(sentinel_path.read_text(encoding="utf-8"))
+        sentinel_job_dir = Path(sentinel["job_dir"]).resolve()
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+        return
+    if sentinel != {
+        "protocol": JOB_PROTOCOL,
+        "version": JOB_PROTOCOL_VERSION,
+        "job_id": manifest.get("job_id"),
+        "job_dir": str(sentinel_job_dir),
+        "workspace": str(temp_root),
+        "token_sha256": hashlib.sha256(cleanup_token.encode("utf-8")).hexdigest(),
+    }:
+        return
+    if sentinel_job_dir != directory.resolve():
+        return
+    shutil.rmtree(temp_root, ignore_errors=True)
+
+
+def _write_cleanup_sentinel(directory: Path, cleanup_token: str) -> None:
+    """Authorize abandoned cleanup for one exact launcher-created job."""
+    temp_root = _safe_cleanup_root(directory)
+    if temp_root is None:
+        raise ValueError(
+            "DDP coordinator cleanup requires a direct LibreYOLO job directory "
+            "under the resolved system temporary directory."
+        )
+    manifest = _load_manifest(directory)
+    sentinel_path = temp_root / CLEANUP_SENTINEL_NAME
+    expected_token_hash = hashlib.sha256(cleanup_token.encode("utf-8")).hexdigest()
+    try:
+        sentinel = json.loads(sentinel_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("DDP coordinator cleanup sentinel is unavailable.") from exc
+    if sentinel != {
+        "protocol": JOB_PROTOCOL,
+        "version": JOB_PROTOCOL_VERSION,
+        "job_id": None,
+        "job_dir": str(directory.resolve()),
+        "workspace": str(temp_root),
+        "token_sha256": expected_token_hash,
+    }:
+        raise ValueError("DDP coordinator cleanup sentinel does not match its job.")
+    _atomic_json_write(
+        sentinel_path,
+        {
+            "protocol": JOB_PROTOCOL,
+            "version": JOB_PROTOCOL_VERSION,
+            "job_id": manifest["job_id"],
+            "job_dir": str(directory.resolve()),
+            "workspace": str(temp_root),
+            "token_sha256": expected_token_hash,
+        },
+    )
+
+
+def coordinator_main(
+    job_dir: str | Path,
+    *,
+    parent_connection: socket.socket | None = None,
+    cleanup_token: str | None = None,
+) -> int:
+    """Run one descriptor and return a process exit code."""
+    directory = Path(job_dir)
+    manifest: dict[str, Any] | None = None
+    parent_gone = threading.Event()
+    try:
+        manifest = _load_manifest(directory)
+        _configure_import_paths(manifest)
+
+        import torch.multiprocessing as mp
+
+        context = mp.spawn(
+            _coordinator_worker,
+            args=(str(directory),),
+            nprocs=manifest["nprocs"],
+            join=False,
+        )
+        if parent_connection is not None:
+            watcher = threading.Thread(
+                target=_watch_parent,
+                args=(parent_gone, parent_connection),
+                daemon=True,
+            )
+            watcher.start()
+        while not context.join(timeout=0.2):
+            if parent_gone.is_set():
+                _stop_spawned_workers(context)
+                raise ParentProcessExited(
+                    "The LibreYOLO API process exited while DDP workers were running."
+                )
+    except BaseException as exc:
+        rendered = traceback.format_exc()
+        persisted = _write_status(
+            directory,
+            manifest,
+            outcome="error",
+            error_type=type(exc).__name__,
+            message=str(exc),
+            traceback=rendered,
+        )
+        if not persisted:
+            print(rendered, file=sys.stderr, end="")
+        if parent_gone.is_set():
+            _cleanup_abandoned_job(directory, manifest, cleanup_token)
+        return 1
+
+    _write_status(directory, manifest, outcome="ok")
+    return 0
+
+
+def _interrupt_process_tree(process: subprocess.Popen) -> None:
+    """Ask a coordinator process group to stop, then escalate if necessary."""
+    if process.poll() is not None:
+        return
+    try:
+        if os.name == "nt":
+            process.send_signal(signal.CTRL_BREAK_EVENT)
+        else:
+            os.killpg(process.pid, signal.SIGINT)
+        process.wait(timeout=5)
+        return
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def launch_coordinator(
+    job_dir: str | Path, *, env: dict[str, str], cleanup_token: str
+) -> None:
+    """Launch the packaged coordinator and surface its structured failure."""
+    directory = Path(job_dir)
+    parent_token = secrets.token_hex(32)
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    listener.settimeout(15)
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        str(directory),
+        "--parent-port",
+        str(listener.getsockname()[1]),
+        "--parent-token",
+        parent_token,
+        "--cleanup-token",
+        cleanup_token,
+    ]
+    popen_kw: dict[str, Any] = {
+        "env": env,
+        "stdin": subprocess.DEVNULL,
+    }
+    if os.name == "nt":
+        popen_kw["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kw["start_new_session"] = True
+
+    process = subprocess.Popen(command, **popen_kw)
+    parent_connection: socket.socket | None = None
+    try:
+        parent_connection, _ = listener.accept()
+        parent_connection.settimeout(15)
+        received = bytearray()
+        expected_size = len(parent_token)
+        while len(received) < expected_size:
+            chunk = parent_connection.recv(expected_size - len(received))
+            if not chunk:
+                break
+            received.extend(chunk)
+        if not secrets.compare_digest(received.decode("ascii"), parent_token):
+            raise RuntimeError("LibreYOLO DDP coordinator handshake failed.")
+        parent_connection.settimeout(None)
+        returncode = process.wait()
+    except BaseException:
+        if parent_connection is not None:
+            parent_connection.close()
+            parent_connection = None
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            _interrupt_process_tree(process)
+        raise
+    finally:
+        listener.close()
+        if parent_connection is not None:
+            parent_connection.close()
+
+    if returncode == 0:
+        return
+
+    status_path = directory / STATUS_NAME
+    detail = ""
+    try:
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        if isinstance(status, dict):
+            detail = status.get("traceback") or status.get("message") or ""
+    except (OSError, json.JSONDecodeError):
+        pass
+    suffix = f"\n{detail.rstrip()}" if detail else ""
+    raise RuntimeError(
+        f"LibreYOLO DDP coordinator exited with code {returncode}.{suffix}"
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="LibreYOLO private DDP coordinator")
+    parser.add_argument("job_dir")
+    parser.add_argument("--parent-port", type=int, required=True)
+    parser.add_argument("--parent-token", required=True)
+    parser.add_argument("--cleanup-token", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    with socket.create_connection(
+        ("127.0.0.1", args.parent_port), timeout=15
+    ) as parent:
+        parent.sendall(args.parent_token.encode("ascii"))
+        parent.settimeout(None)
+        _write_cleanup_sentinel(Path(args.job_dir), args.cleanup_token)
+        return coordinator_main(
+            args.job_dir,
+            parent_connection=parent,
+            cleanup_token=args.cleanup_token,
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "JOB_PROTOCOL",
+    "JOB_PROTOCOL_VERSION",
+    "JobProtocolError",
+    "JobTransportError",
+    "coordinator_main",
+    "job_workspace",
+    "launch_coordinator",
+    "write_job",
+]

--- a/libreyolo/training/_ddp_coordinator.py
+++ b/libreyolo/training/_ddp_coordinator.py
@@ -28,16 +28,19 @@ import tempfile
 import threading
 import traceback
 import uuid
+import warnings
 from pathlib import Path
 from typing import Any
 
 
 JOB_PROTOCOL = "libreyolo.ddp.local-job"
-JOB_PROTOCOL_VERSION = 1
+JOB_PROTOCOL_VERSION = 2
 MANIFEST_NAME = "manifest.json"
 PAYLOAD_NAME = "payload.pkl"
 STATUS_NAME = "status.json"
 CLEANUP_SENTINEL_NAME = ".libreyolo-ddp-cleanup.json"
+COORDINATOR_BOOTSTRAP_ENV = "LIBREYOLO_DDP_COORDINATOR_BOOTSTRAP"
+PAYLOAD_SIZE_WARNING_BYTES = 8 * 1024 * 1024
 
 
 class JobProtocolError(RuntimeError):
@@ -97,6 +100,38 @@ def _validate_protocol(data: Any, *, source: str) -> dict[str, Any]:
     return data
 
 
+def _validate_caller_identity(data: dict[str, Any], *, source: str) -> None:
+    caller_argv = data.get("caller_argv")
+    if not isinstance(caller_argv, list) or not all(
+        isinstance(item, str) for item in caller_argv
+    ):
+        raise JobProtocolError(f"DDP {source} caller_argv must be a list of strings")
+    if data.get("caller_main_file") is not None and not isinstance(
+        data["caller_main_file"], str
+    ):
+        raise JobProtocolError(
+            f"DDP {source} caller_main_file must be a string or null"
+        )
+
+
+def _capture_caller_identity() -> tuple[list[str], str | None]:
+    """Normalize caller identity values for JSON and cloudpickle transport."""
+    caller_argv = []
+    for item in sys.argv:
+        try:
+            caller_argv.append(os.fsdecode(os.fspath(item)))
+        except TypeError:
+            caller_argv.append(str(item))
+
+    caller_main_file = getattr(sys.modules.get("__main__"), "__file__", None)
+    if caller_main_file is not None:
+        try:
+            caller_main_file = os.fsdecode(os.fspath(caller_main_file))
+        except TypeError:
+            caller_main_file = None
+    return caller_argv, caller_main_file
+
+
 def _load_manifest(job_dir: str | Path) -> dict[str, Any]:
     path = Path(job_dir) / MANIFEST_NAME
     try:
@@ -120,6 +155,7 @@ def _load_manifest(job_dir: str | Path) -> dict[str, Any]:
         raise JobProtocolError(
             "DDP job import_paths must be a list of non-empty strings"
         )
+    _validate_caller_identity(data, source="job manifest")
     return data
 
 
@@ -158,6 +194,14 @@ def _load_payload(job_dir: str | Path, manifest: dict[str, Any]) -> dict[str, An
         raise JobProtocolError("DDP job worker_fn is not callable")
     if not isinstance(data.get("spawn_args"), tuple):
         raise JobProtocolError("DDP job spawn_args must be a tuple")
+    _validate_caller_identity(data, source="job payload")
+    if (
+        data["caller_argv"] != manifest["caller_argv"]
+        or data["caller_main_file"] != manifest["caller_main_file"]
+    ):
+        raise JobProtocolError(
+            "DDP job manifest and payload caller identities do not match"
+        )
     return data
 
 
@@ -198,12 +242,15 @@ def write_job(
     directory = Path(job_dir)
     directory.mkdir(parents=True, exist_ok=False)
     job_id = uuid.uuid4().hex
+    caller_argv, caller_main_file = _capture_caller_identity()
     common = {
         "protocol": JOB_PROTOCOL,
         "version": JOB_PROTOCOL_VERSION,
         "job_id": job_id,
         "nprocs": nprocs,
         "import_paths": import_paths,
+        "caller_argv": caller_argv,
+        "caller_main_file": caller_main_file,
     }
     payload = {
         **common,
@@ -220,13 +267,39 @@ def write_job(
             "DDP coordinator transport could not serialize a job that passed "
             "standard pickle validation."
         ) from exc
+    if len(serialized) > PAYLOAD_SIZE_WARNING_BYTES:
+        size_mib = len(serialized) / (1024 * 1024)
+        warnings.warn(
+            f"LibreYOLO automatic DDP payload is {size_mib:.1f} MiB. Large "
+            "callbacks, loggers, or captured globals can slow startup and are "
+            "copied into every rank; keep large state in importable modules or files.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     (directory / PAYLOAD_NAME).write_bytes(serialized)
     _atomic_json_write(directory / MANIFEST_NAME, common)
+
+
+def _restore_caller_identity(payload: dict[str, Any]) -> None:
+    """Expose the original user program identity to rank-local integrations."""
+    sys.argv[:] = payload["caller_argv"]
+    caller_main_file = payload["caller_main_file"]
+    for module_name in ("__main__", "__mp_main__"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        if caller_main_file is None:
+            module.__dict__.pop("__file__", None)
+        else:
+            module.__file__ = caller_main_file
 
 
 def _coordinator_worker(rank: int, job_dir: str) -> None:
     """Load the job independently in each rank and invoke its worker."""
     manifest = _load_manifest(job_dir)
+    # Restore the logger-visible program identity before cloudpickle imports or
+    # reconstructs any callback/logger objects from the payload.
+    _restore_caller_identity(manifest)
     payload = _load_payload(job_dir, manifest)
     nprocs = payload["nprocs"]
 
@@ -463,19 +536,15 @@ def launch_coordinator(
     listener.bind(("127.0.0.1", 0))
     listener.listen(1)
     listener.settimeout(15)
-    command = [
-        sys.executable,
-        str(Path(__file__).resolve()),
-        str(directory),
-        "--parent-port",
-        str(listener.getsockname()[1]),
-        "--parent-token",
-        parent_token,
-        "--cleanup-token",
-        cleanup_token,
-    ]
+    command, coordinator_env = _coordinator_launch(
+        directory,
+        env=env,
+        parent_port=listener.getsockname()[1],
+        parent_token=parent_token,
+        cleanup_token=cleanup_token,
+    )
     popen_kw: dict[str, Any] = {
-        "env": env,
+        "env": coordinator_env,
         "stdin": subprocess.DEVNULL,
     }
     if os.name == "nt":
@@ -533,24 +602,67 @@ def launch_coordinator(
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="LibreYOLO private DDP coordinator")
     parser.add_argument("job_dir")
-    parser.add_argument("--parent-port", type=int, required=True)
-    parser.add_argument("--parent-token", required=True)
-    parser.add_argument("--cleanup-token", required=True)
     return parser.parse_args(argv)
+
+
+def _coordinator_launch(
+    job_dir: str | Path,
+    *,
+    env: dict[str, str],
+    parent_port: int,
+    parent_token: str,
+    cleanup_token: str,
+) -> tuple[list[str], dict[str, str]]:
+    """Build a coordinator command and its one-use private bootstrap envelope."""
+    bootstrap = {
+        "protocol": JOB_PROTOCOL,
+        "version": JOB_PROTOCOL_VERSION,
+        "parent_port": parent_port,
+        "parent_token": parent_token,
+        "cleanup_token": cleanup_token,
+    }
+    coordinator_env = dict(env)
+    coordinator_env[COORDINATOR_BOOTSTRAP_ENV] = json.dumps(bootstrap)
+    command = [sys.executable, str(Path(__file__).resolve()), str(job_dir)]
+    return command, coordinator_env
+
+
+def _pop_coordinator_bootstrap() -> dict[str, Any]:
+    """Consume bootstrap secrets before multiprocessing inherits the environment."""
+    serialized = os.environ.pop(COORDINATOR_BOOTSTRAP_ENV, None)
+    if serialized is None:
+        raise JobProtocolError("DDP coordinator bootstrap is unavailable")
+    try:
+        bootstrap = json.loads(serialized)
+    except json.JSONDecodeError as exc:
+        raise JobProtocolError("DDP coordinator bootstrap is invalid") from exc
+    bootstrap = _validate_protocol(bootstrap, source="coordinator bootstrap")
+    parent_port = bootstrap.get("parent_port")
+    if (
+        not isinstance(parent_port, int)
+        or isinstance(parent_port, bool)
+        or not 1 <= parent_port <= 65535
+    ):
+        raise JobProtocolError("DDP coordinator parent_port is invalid")
+    for field in ("parent_token", "cleanup_token"):
+        if not isinstance(bootstrap.get(field), str) or not bootstrap[field]:
+            raise JobProtocolError(f"DDP coordinator {field} is invalid")
+    return bootstrap
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    bootstrap = _pop_coordinator_bootstrap()
     with socket.create_connection(
-        ("127.0.0.1", args.parent_port), timeout=15
+        ("127.0.0.1", bootstrap["parent_port"]), timeout=15
     ) as parent:
-        parent.sendall(args.parent_token.encode("ascii"))
+        parent.sendall(bootstrap["parent_token"].encode("ascii"))
         parent.settimeout(None)
-        _write_cleanup_sentinel(Path(args.job_dir), args.cleanup_token)
+        _write_cleanup_sentinel(Path(args.job_dir), bootstrap["cleanup_token"])
         return coordinator_main(
             args.job_dir,
             parent_connection=parent,
-            cleanup_token=args.cleanup_token,
+            cleanup_token=bootstrap["cleanup_token"],
         )
 
 

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -67,7 +67,7 @@ class TrainConfig:
     # Single device or multi-device spec. Accepts:
     #   - "auto" / "" → auto-pick (cuda → mps → cpu)
     #   - "cpu", "mps", "0", "cuda:0", 0 → single device
-    #   - [0, 1] or "0,1" → multi-GPU, requires torchrun launch
+    #   - [0, 1] or "0,1" → automatic local multi-GPU DDP (torchrun also works)
     device: Union[str, int, List[int]] = "auto"
     # SyncBatchNorm across ranks under DDP. Off here; BatchNorm-heavy CNN
     # families (e.g. yolo9) override to True so BN statistics are computed

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -5,7 +5,7 @@ is given and we're NOT in a torchrun environment.  spawn_for_model() handles:
 
   1. Saving model weights to a temp file.
   2. Resolving batch=-1 via autobatch (single-GPU probe, before spawning).
-  3. Spawning DDP workers via mp.spawn.
+  3. Launching the private DDP coordinator, which owns mp.spawn.
   4. Loading the best checkpoint back into the caller's model instance.
 
 The generic worker (_libreyolo_ddp_worker) re-imports the correct model class

--- a/libreyolo/training/ddp_spawn.py
+++ b/libreyolo/training/ddp_spawn.py
@@ -8,9 +8,10 @@ is given and we're NOT in a torchrun environment.  spawn_for_model() handles:
   3. Launching the private DDP coordinator, which owns mp.spawn.
   4. Loading the best checkpoint back into the caller's model instance.
 
-The generic worker (_libreyolo_ddp_worker) re-imports the correct model class
-using module/class info packed into init_kw, rebuilds the model from saved
-weights, and calls model.train(**train_kw) — which falls through to the
+The generic worker (_libreyolo_ddp_worker) resolves the correct model class
+from module/class info packed into init_kw, or from the by-value class carried
+for a guarded script's ``__main__`` model. It rebuilds the model from saved
+weights and calls model.train(**train_kw) — which falls through to the
 single-device path because has_torchrun_env() returns True inside the spawned
 worker (RANK env var is set).
 """
@@ -59,9 +60,11 @@ def _libreyolo_ddp_worker(
         torch.cuda.set_device(rank)
 
     init_kw = dict(init_kw)  # copy — don't mutate caller's dict
+    cls = init_kw.pop("_class_object", None)
     module_path = init_kw.pop("_module")
     class_name = init_kw.pop("_class")
-    cls = getattr(importlib.import_module(module_path), class_name)
+    if cls is None:
+        cls = getattr(importlib.import_module(module_path), class_name)
 
     model = cls(weights_path, **init_kw)
     try:
@@ -155,6 +158,12 @@ def _build_init_kw(model_instance: Any) -> dict:
         "_class": cls.__name__,
         "device": "auto",
     }
+    if cls.__module__ == "__main__":
+        # Guarded scripts may define their model wrapper at top level. The
+        # coordinator deliberately does not re-import that script, so carry
+        # just this dynamic class by value while normal library classes retain
+        # the smaller and more stable import-by-name path.
+        kw["_class_object"] = cls
     for attr in (
         "size",
         "nb_classes",

--- a/libreyolo/training/distributed.py
+++ b/libreyolo/training/distributed.py
@@ -4,17 +4,22 @@ Thin helpers around ``torch.distributed`` so the rest of the trainer can stay
 backend-agnostic. All helpers degrade to no-ops when distributed is not
 initialised — single-GPU code paths continue to work unchanged.
 
-User-facing surface accepts ``device=[0, 1]`` (or ``device="0,1"``) and
-launches with ``torchrun --nproc_per_node=N``. Inside each child process
-``init_distributed()`` is called by the trainer; outside DDP everything is a
-no-op.
+User-facing surface accepts ``device=[0, 1]`` (or ``device="0,1"``). Model
+APIs launch local ranks automatically, while an explicit
+``torchrun --nproc_per_node=N`` launch remains supported. Inside each child
+process ``init_distributed()`` is called by the trainer; outside DDP
+everything is a no-op.
 """
 
 from __future__ import annotations
 
 import os
 import socket
+import sys
+import threading
+import warnings
 from datetime import timedelta
+from pathlib import Path
 from typing import Callable, List, Optional, Tuple, Union
 
 import torch
@@ -22,6 +27,7 @@ import torch.distributed as dist
 import torch.nn as nn
 
 DeviceArg = Union[str, int, List[int], None]
+_LEGACY_SPAWN_ENV_LOCK = threading.Lock()
 
 
 # =============================================================================
@@ -55,7 +61,7 @@ def is_main_process() -> bool:
 
 
 def has_torchrun_env() -> bool:
-    """True iff this process was spawned by torchrun (LOCAL_RANK is set)."""
+    """True iff a DDP launcher provided this process with ``LOCAL_RANK``."""
     return "LOCAL_RANK" in os.environ
 
 
@@ -129,11 +135,11 @@ def _select_backend() -> str:
 
 
 def init_distributed(timeout_seconds: int = 10800) -> None:
-    """Initialise the default process group from env vars set by torchrun.
+    """Initialise the default process group from launcher-provided env vars.
 
     Safe to call multiple times — second and later calls are no-ops.
     Expects ``RANK``, ``LOCAL_RANK``, ``WORLD_SIZE`` to be set in the
-    environment (which torchrun does automatically).
+    environment (which torchrun and LibreYOLO's coordinator do automatically).
     """
     import inspect
 
@@ -337,6 +343,118 @@ def _find_free_port() -> tuple:
     return port, s
 
 
+def _normalized_import_paths(entries) -> list[str]:
+    """Return absolute string paths suitable for the private job manifest."""
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        try:
+            raw = os.fspath(entry)
+        except TypeError:
+            continue
+        if isinstance(raw, bytes):
+            raw = os.fsdecode(raw)
+        if not isinstance(raw, str):
+            continue
+        try:
+            absolute = os.path.abspath(raw or os.getcwd())
+        except (OSError, TypeError, ValueError):
+            continue
+        key = os.path.normcase(absolute)
+        if key not in seen:
+            normalized.append(absolute)
+            seen.add(key)
+    return normalized
+
+
+def _legacy_spawn_worker(
+    rank: int,
+    worker_fn: Callable,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+    spawn_args: Tuple,
+) -> None:
+    """Invoke a standard-pickle job that cannot use by-value transport."""
+    os.environ["LIBREYOLO_DDP_COORDINATOR_WORKER"] = "1"
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(nprocs)
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+    worker_fn(
+        rank,
+        nprocs,
+        master_addr,
+        master_port,
+        result_path,
+        *spawn_args,
+    )
+
+
+def _spawn_standard_pickle_fallback(
+    worker_fn: Callable,
+    spawn_args: Tuple,
+    nprocs: int,
+    result_path: str,
+    master_addr: str,
+    master_port: int,
+    child_env: dict[str, str],
+) -> None:
+    """Preserve the guarded-script behavior of the former direct spawn path."""
+    import multiprocessing
+
+    if multiprocessing.current_process().name != "MainProcess":
+        raise RuntimeError(
+            "DDP spawn fell back to standard-pickle transport inside a spawned "
+            "subprocess. Put the multi-GPU train() call under "
+            "`if __name__ == '__main__':` for this callback or logger."
+        )
+
+    import torch.multiprocessing as mp
+
+    warnings.warn(
+        "DDP coordinator transport could not represent an otherwise "
+        "standard-picklable callback or logger. Using the guarded-script "
+        "compatibility launcher; this call must remain under "
+        "`if __name__ == '__main__':`.",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+    # Standard multiprocessing imports the guarded user module before calling
+    # _legacy_spawn_worker. Apply the child mask around the whole spawn so even
+    # import-time CUDA setup sees the translated value. This compatibility-only
+    # path is serialized because os.environ is process-global; the normal
+    # coordinator path continues to use an explicit child-only environment.
+    with _LEGACY_SPAWN_ENV_LOCK:
+        previous_cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+        child_has_cvd = "CUDA_VISIBLE_DEVICES" in child_env
+        if child_has_cvd:
+            os.environ["CUDA_VISIBLE_DEVICES"] = child_env["CUDA_VISIBLE_DEVICES"]
+        else:
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        try:
+            mp.spawn(
+                _legacy_spawn_worker,
+                args=(
+                    worker_fn,
+                    nprocs,
+                    master_addr,
+                    master_port,
+                    result_path,
+                    spawn_args,
+                ),
+                nprocs=nprocs,
+                join=True,
+            )
+        finally:
+            if previous_cvd is None:
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            else:
+                os.environ["CUDA_VISIBLE_DEVICES"] = previous_cvd
+
+
 def spawn_ddp_train(
     worker_fn: Callable,
     spawn_args: Tuple,
@@ -346,7 +464,7 @@ def spawn_ddp_train(
     master_port: Optional[int] = None,
     devices: Optional[List[int]] = None,
 ) -> None:
-    """Spawn *nprocs* DDP workers via :func:`torch.multiprocessing.spawn`.
+    """Run *nprocs* DDP workers through LibreYOLO's private coordinator.
 
     Each worker is called as::
 
@@ -362,30 +480,34 @@ def spawn_ddp_train(
     result JSON from *result_path*, and returns it to the caller — so the user
     gets a clean blocking call without any subprocess plumbing.
 
-    When *devices* is provided, ``CUDA_VISIBLE_DEVICES`` is set to the
-    comma-joined device indices before spawning so that ``cuda:N`` inside each
-    worker maps to the N-th requested physical GPU.  The original value is
-    restored after spawning completes.
+    When *devices* is provided, the coordinator subprocess receives a
+    translated ``CUDA_VISIBLE_DEVICES`` so that ``cuda:N`` inside each worker
+    maps to the N-th requested physical GPU without mutating the parent. The
+    guarded-script compatibility fallback temporarily applies and then
+    restores that mask so multiprocessing imports see the same mapping.
     """
     import multiprocessing
-    import torch.multiprocessing as mp
 
-    if multiprocessing.current_process().name != "MainProcess":
+    if (
+        os.environ.get("LIBREYOLO_DDP_COORDINATOR_WORKER") == "1"
+        or multiprocessing.current_process().name != "MainProcess"
+    ):
         raise RuntimeError(
-            "spawn_ddp_train() was called from inside a spawned subprocess. "
-            "This usually means your script calls model.train(device=...) at "
-            "the top level without a 'if __name__ == \"__main__\":' guard. "
-            "Each spawned worker re-imports __main__, which re-launches "
-            "training and causes infinite recursion. Wrap your training call:\n\n"
-            "    if __name__ == '__main__':\n"
-            "        model.train(device='0,1')\n"
+            "spawn_ddp_train() was called from a spawned subprocess. Nested "
+            "coordinator launches are not supported; put compatibility-only "
+            "callbacks or loggers under `if __name__ == '__main__':`."
         )
 
     port_sock = None
     if master_port is None:
         master_port, port_sock = _find_free_port()
 
-    prev_cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+    # A rare standard-pickle fallback temporarily changes the process-global
+    # mask while its children start. Serialize environment snapshots with that
+    # window so a concurrent normal coordinator launch cannot inherit it.
+    with _LEGACY_SPAWN_ENV_LOCK:
+        child_env = os.environ.copy()
+    prev_cvd = child_env.get("CUDA_VISIBLE_DEVICES")
     if devices:
         if prev_cvd is not None:
             # devices are logical indices into the existing mask — translate to
@@ -397,28 +519,59 @@ def spawn_ddp_train(
                 new_cvd = ",".join(str(d) for d in devices)
         else:
             new_cvd = ",".join(str(d) for d in devices)
-        os.environ["CUDA_VISIBLE_DEVICES"] = new_cvd
+        child_env["CUDA_VISIBLE_DEVICES"] = new_cvd
+
     try:
-        # Close the reservation socket as late as possible — just before
-        # spawning — so the OS cannot hand the port to another process in the
-        # gap between our bind(0) call and torch.distributed's TCPStore bind.
-        if port_sock is not None:
-            port_sock.close()
-            port_sock = None
-        mp.spawn(
-            worker_fn,
-            args=(nprocs, master_addr, master_port, result_path) + spawn_args,
-            nprocs=nprocs,
-            join=True,
+        # Serialize the job before releasing the reserved rendezvous port.
+        from libreyolo.training._ddp_coordinator import (
+            JobTransportError,
+            job_workspace,
+            launch_coordinator,
+            write_job,
         )
+
+        package_root = str(Path(__file__).resolve().parents[2])
+        import_paths = _normalized_import_paths((package_root, *sys.path))
+
+        with job_workspace() as (job_dir, cleanup_token):
+            try:
+                write_job(
+                    job_dir,
+                    worker_fn=worker_fn,
+                    spawn_args=spawn_args,
+                    nprocs=nprocs,
+                    result_path=result_path,
+                    master_addr=master_addr,
+                    master_port=master_port,
+                    import_paths=import_paths,
+                )
+            except JobTransportError:
+                if port_sock is not None:
+                    port_sock.close()
+                    port_sock = None
+                _spawn_standard_pickle_fallback(
+                    worker_fn,
+                    spawn_args,
+                    nprocs,
+                    result_path,
+                    master_addr,
+                    master_port,
+                    child_env,
+                )
+                return
+            # Release the port immediately before the coordinator starts and
+            # binds its TCPStore, minimizing the unavoidable bind race.
+            if port_sock is not None:
+                port_sock.close()
+                port_sock = None
+            launch_coordinator(
+                job_dir,
+                env=child_env,
+                cleanup_token=cleanup_token,
+            )
     finally:
         if port_sock is not None:
             port_sock.close()
-        if devices:
-            if prev_cvd is None:
-                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-            else:
-                os.environ["CUDA_VISIBLE_DEVICES"] = prev_cvd
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = [
     "click>=8.0.0",
     "safetensors>=0.4.0",
     "scipy>=1.7.0",
+    # Ephemeral automatic-DDP job transport. Standard pickle validation still
+    # rejects lambdas/closures; cloudpickle carries transportable __main__
+    # callbacks without importing and re-running the user's training script.
+    "cloudpickle>=3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/smoke/install_surface.py
+++ b/tests/smoke/install_surface.py
@@ -55,6 +55,7 @@ def _load_json_stdout(result: subprocess.CompletedProcess[str]) -> dict[str, Any
 
 
 def _check_import_surface(expect_source: str, source_root: Path | None) -> None:
+    import cloudpickle
     import libreyolo
     from libreyolo import (
         EdgeMap,
@@ -72,6 +73,19 @@ def _check_import_surface(expect_source: str, source_root: Path | None) -> None:
         raise AssertionError("LibreYOLO import did not resolve to a callable")
     if Results.__name__ != "Results":
         raise AssertionError("Results import did not resolve correctly")
+    if not callable(cloudpickle.dumps):
+        raise AssertionError("cloudpickle DDP transport dependency is unavailable")
+
+    # This private file is launched by its resolved packaged path during
+    # automatic DDP, so it must be present in wheels and sdists, not only
+    # checkouts.
+    from libreyolo.training._ddp_coordinator import (
+        JOB_PROTOCOL,
+        JOB_PROTOCOL_VERSION,
+    )
+
+    if JOB_PROTOCOL != "libreyolo.ddp.local-job" or JOB_PROTOCOL_VERSION != 1:
+        raise AssertionError("Automatic-DDP coordinator protocol is unavailable")
     if FaceGallery is not Gallery:
         raise AssertionError("FaceGallery did not resolve to the Gallery alias")
     if "Gallery" not in libreyolo.__all__ or "FaceGallery" not in libreyolo.__all__:

--- a/tests/smoke/install_surface.py
+++ b/tests/smoke/install_surface.py
@@ -84,7 +84,7 @@ def _check_import_surface(expect_source: str, source_root: Path | None) -> None:
         JOB_PROTOCOL_VERSION,
     )
 
-    if JOB_PROTOCOL != "libreyolo.ddp.local-job" or JOB_PROTOCOL_VERSION != 1:
+    if JOB_PROTOCOL != "libreyolo.ddp.local-job" or JOB_PROTOCOL_VERSION != 2:
         raise AssertionError("Automatic-DDP coordinator protocol is unavailable")
     if FaceGallery is not Gallery:
         raise AssertionError("FaceGallery did not resolve to the Gallery alias")

--- a/tests/unit/test_ddp_coordinator.py
+++ b/tests/unit/test_ddp_coordinator.py
@@ -1,0 +1,808 @@
+"""Regression tests for the private automatic-DDP coordinator."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from libreyolo.training._ddp_coordinator import (
+    CLEANUP_SENTINEL_NAME,
+    JOB_PROTOCOL,
+    JOB_PROTOCOL_VERSION,
+    MANIFEST_NAME,
+    STATUS_NAME,
+    __file__ as coordinator_file,
+    _cleanup_abandoned_job,
+    _load_manifest,
+    _load_payload,
+    coordinator_main,
+    job_workspace,
+    write_job,
+)
+from libreyolo.training.ddp_spawn import ddp_aware
+from libreyolo.training.ddp_spawn import spawn_for_model
+from libreyolo.training.distributed import spawn_ddp_train
+from libreyolo.training.distributed import _spawn_standard_pickle_fallback
+
+
+pytestmark = pytest.mark.unit
+
+
+def _recording_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+    token: str,
+) -> None:
+    record = {
+        "rank": rank,
+        "world": nprocs,
+        "rank_env": os.environ["RANK"],
+        "local_rank_env": os.environ["LOCAL_RANK"],
+        "world_env": os.environ["WORLD_SIZE"],
+        "master_addr": os.environ["MASTER_ADDR"],
+        "master_port": os.environ["MASTER_PORT"],
+        "cvd": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "cwd": os.getcwd(),
+        "token": token,
+    }
+    rank_path = Path(result_path).with_name(f"rank-{rank}.json")
+    rank_path.write_text(json.dumps(record), encoding="utf-8")
+    if rank == 0:
+        Path(result_path).write_text(json.dumps(record), encoding="utf-8")
+
+
+def _failing_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+) -> None:
+    if rank == 1:
+        raise RuntimeError("intentional rank failure")
+
+
+def _slow_worker(
+    rank: int,
+    nprocs: int,
+    master_addr: str,
+    master_port: int,
+    result_path: str,
+) -> None:
+    import time
+
+    Path(result_path).write_text("started", encoding="utf-8")
+    time.sleep(30)
+
+
+def _job_dirs() -> set[Path]:
+    root = Path(tempfile.gettempdir())
+    return set(root.glob("libreyolo-ddp-job-*"))
+
+
+def test_job_protocol_round_trip(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    write_job(
+        job_dir,
+        worker_fn=_recording_worker,
+        spawn_args=("protocol-token",),
+        nprocs=2,
+        result_path=str(tmp_path / "result.json"),
+        master_addr="127.0.0.1",
+        master_port=12345,
+        import_paths=[str(tmp_path)],
+    )
+
+    manifest = _load_manifest(job_dir)
+    payload = _load_payload(job_dir, manifest)
+    assert manifest["protocol"] == JOB_PROTOCOL
+    assert manifest["version"] == JOB_PROTOCOL_VERSION
+    assert payload["job_id"] == manifest["job_id"]
+    assert payload["spawn_args"] == ("protocol-token",)
+    assert manifest["import_paths"] == [str(tmp_path)]
+
+
+def test_job_protocol_rejects_future_version(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    (job_dir / MANIFEST_NAME).write_text(
+        json.dumps(
+            {
+                "protocol": JOB_PROTOCOL,
+                "version": JOB_PROTOCOL_VERSION + 1,
+                "job_id": "future",
+                "nprocs": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert coordinator_main(job_dir) == 1
+    status = json.loads((job_dir / STATUS_NAME).read_text(encoding="utf-8"))
+    assert status["outcome"] == "error"
+    assert "Unsupported DDP job manifest version" in status["message"]
+
+
+def test_coordinator_propagates_env_result_mask_and_cleans_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    before = _job_dirs()
+    result_path = tmp_path / "result.json"
+
+    spawn_ddp_train(
+        _recording_worker,
+        spawn_args=("round-trip",),
+        nprocs=2,
+        result_path=str(result_path),
+        devices=[0, 1],
+    )
+
+    assert _job_dirs() == before
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "2,3"
+    for rank in range(2):
+        record = json.loads((tmp_path / f"rank-{rank}.json").read_text())
+        assert record["rank"] == rank
+        assert record["rank_env"] == str(rank)
+        assert record["local_rank_env"] == str(rank)
+        assert record["world"] == 2
+        assert record["world_env"] == "2"
+        assert record["cvd"] == "2,3"
+        assert record["token"] == "round-trip"
+    assert json.loads(result_path.read_text())["rank"] == 0
+
+
+def test_coordinator_surfaces_worker_traceback_and_cleans_up(tmp_path: Path) -> None:
+    before = _job_dirs()
+    with pytest.raises(RuntimeError, match="intentional rank failure"):
+        spawn_ddp_train(
+            _failing_worker,
+            spawn_args=(),
+            nprocs=2,
+            result_path=str(tmp_path / "unused.json"),
+        )
+    assert _job_dirs() == before
+
+
+def test_coordinator_keeps_standard_pickle_rejection(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="standard pickle"):
+        spawn_ddp_train(
+            lambda *args: None,
+            spawn_args=(),
+            nprocs=1,
+            result_path=str(tmp_path / "unused.json"),
+        )
+
+
+def test_coordinator_uses_selected_package_when_cwd_contains_shadow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shadow_root = tmp_path / "shadow"
+    shadow_package = shadow_root / "libreyolo"
+    shadow_package.mkdir(parents=True)
+    shadow_marker = tmp_path / "shadow-imported.txt"
+    (shadow_package / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(shadow_marker)!r}).write_text('bad')\n"
+        "raise RuntimeError('shadow LibreYOLO was imported')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(shadow_root)
+    result_path = tmp_path / "result.json"
+
+    spawn_ddp_train(
+        _recording_worker,
+        spawn_args=("shadow-check",),
+        nprocs=1,
+        result_path=str(result_path),
+    )
+
+    assert not shadow_marker.exists()
+    assert json.loads(result_path.read_text(encoding="utf-8"))["cwd"] == str(
+        shadow_root
+    )
+
+
+def test_pathlike_sys_path_entry_is_normalized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "path", [Path("."), *sys.path])
+    result_path = tmp_path / "result.json"
+
+    spawn_ddp_train(
+        _recording_worker,
+        spawn_args=("pathlike",),
+        nprocs=1,
+        result_path=str(result_path),
+    )
+
+    assert json.loads(result_path.read_text(encoding="utf-8"))["token"] == "pathlike"
+
+
+def test_parent_liveness_socket_stops_workers_and_cleans_job(tmp_path: Path) -> None:
+    import time
+
+    with job_workspace() as (job_dir, cleanup_token):
+        temp_root = job_dir.parent
+        started_path = tmp_path / "worker-started.txt"
+        import_paths = []
+        for entry in sys.path:
+            try:
+                import_paths.append(
+                    os.path.abspath(os.fsdecode(os.fspath(entry)) or os.getcwd())
+                )
+            except (OSError, TypeError, ValueError):
+                continue
+        write_job(
+            job_dir,
+            worker_fn=_slow_worker,
+            spawn_args=(),
+            nprocs=1,
+            result_path=str(started_path),
+            master_addr="127.0.0.1",
+            master_port=12345,
+            import_paths=list(dict.fromkeys(import_paths)),
+        )
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        listener.settimeout(15)
+        parent_token = "parent-liveness-test-token"
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(Path(coordinator_file).resolve()),
+                str(job_dir),
+                "--parent-port",
+                str(listener.getsockname()[1]),
+                "--parent-token",
+                parent_token,
+                "--cleanup-token",
+                cleanup_token,
+            ],
+            env=os.environ.copy(),
+            stdin=subprocess.DEVNULL,
+        )
+        parent_connection, _ = listener.accept()
+        assert parent_connection.recv(len(parent_token)).decode("ascii") == parent_token
+        listener.close()
+        deadline = time.monotonic() + 20
+        while not started_path.exists() and process.poll() is None:
+            if time.monotonic() >= deadline:
+                process.kill()
+                pytest.fail("coordinator worker did not start")
+            time.sleep(0.1)
+
+        parent_connection.close()
+        assert process.wait(timeout=15) == 1
+        assert not temp_root.exists()
+
+
+def test_abandoned_cleanup_preserves_caller_chosen_directory(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="libreyolo-ddp-job-") as root:
+        temp_root = Path(root).resolve()
+        job_dir = temp_root / "job"
+        job_dir.mkdir()
+        valuable = temp_root / "valuable-sibling.txt"
+        valuable.write_text("preserve me", encoding="utf-8")
+        manifest = {"job_id": "forged-job-id"}
+        (temp_root / CLEANUP_SENTINEL_NAME).write_text(
+            json.dumps(
+                {
+                    "protocol": JOB_PROTOCOL,
+                    "version": JOB_PROTOCOL_VERSION,
+                    "job_id": manifest["job_id"],
+                    "job_dir": str(job_dir.resolve()),
+                    "workspace": str(temp_root),
+                    "token_sha256": "forged-token-hash",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        _cleanup_abandoned_job(job_dir, manifest, "real-launcher-token")
+
+        assert valuable.read_text(encoding="utf-8") == "preserve me"
+        assert job_dir.is_dir()
+
+
+class _DispatchProbe:
+    @ddp_aware()
+    def train(self, *, device="auto", batch=4):
+        return {"device": device, "batch": batch}
+
+
+class _BatchSizeDispatchProbe:
+    @ddp_aware(batch_key="batch_size")
+    def train(self, *, device="auto", batch_size=4, resume=False):
+        raise AssertionError("multi-device call did not dispatch")
+
+
+@pytest.mark.parametrize("device", [None, "auto", "cpu", "mps", 0, "0", [0]])
+def test_single_device_forms_do_not_launch(
+    device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_launch(*args, **kwargs):
+        raise AssertionError("single-device call reached automatic DDP")
+
+    monkeypatch.setattr("libreyolo.training.ddp_spawn.spawn_for_model", fail_launch)
+    assert _DispatchProbe().train(device=device, batch=7) == {
+        "device": device,
+        "batch": 7,
+    }
+
+
+def test_existing_torchrun_env_does_not_launch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    def fail_launch(*args, **kwargs):
+        raise AssertionError("explicit torchrun call reached automatic DDP")
+
+    monkeypatch.setattr("libreyolo.training.ddp_spawn.spawn_for_model", fail_launch)
+    assert _DispatchProbe().train(device="0,1")["device"] == "0,1"
+
+
+@pytest.mark.parametrize("device", [[0, 1], "0,1"])
+def test_multi_device_forms_forward_batch_key_and_resume(
+    device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected = {"dispatched": True}
+    launch = MagicMock(return_value=expected)
+    monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+    monkeypatch.setattr("libreyolo.training.ddp_spawn.spawn_for_model", launch)
+
+    result = _BatchSizeDispatchProbe().train(
+        device=device,
+        batch_size=-1,
+        resume=True,
+    )
+
+    assert result is expected
+    call = launch.call_args
+    assert call.args[1]["device"] == device
+    assert call.args[1]["batch_size"] == -1
+    assert call.args[1]["resume"] is True
+    assert call.args[2] == 2
+    assert call.kwargs == {"devices": [0, 1], "batch_key": "batch_size"}
+
+
+def _wrapper(model_path=None):
+    instance = MagicMock()
+    instance.model = nn.Linear(4, 2)
+    instance.model_path = model_path
+    return instance
+
+
+def test_spawn_for_model_preserves_resume_checkpoint(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "resume.pt"
+    checkpoint.write_bytes(b"checkpoint placeholder")
+    instance = _wrapper(str(checkpoint))
+    captured = {}
+
+    def fake_spawn(worker_fn, spawn_args, nprocs, result_path, **kwargs):
+        captured["spawn_args"] = spawn_args
+        Path(result_path).write_text("{}", encoding="utf-8")
+
+    with (
+        patch("torch.save") as save,
+        patch("libreyolo.training.distributed.spawn_ddp_train", side_effect=fake_spawn),
+        patch("libreyolo.training.ddp_spawn._build_init_kw", return_value={}),
+    ):
+        spawn_for_model(
+            instance,
+            train_kw={"resume": True, "batch": 8},
+            nprocs=2,
+            devices=[0, 1],
+        )
+
+    save.assert_not_called()
+    assert captured["spawn_args"][0] == str(checkpoint)
+    assert captured["spawn_args"][2]["resume"] is True
+    assert captured["spawn_args"][2]["batch"] == 8
+
+
+def test_spawn_for_model_resolves_batch_size_autobatch_before_launch() -> None:
+    instance = _wrapper()
+    captured = {}
+
+    def fake_spawn(worker_fn, spawn_args, nprocs, result_path, **kwargs):
+        captured["train_kw"] = spawn_args[2]
+        Path(result_path).write_text("{}", encoding="utf-8")
+
+    with (
+        patch("torch.save"),
+        patch("torch.cuda.is_available", return_value=False),
+        patch("torch.cuda.empty_cache"),
+        patch(
+            "libreyolo.training.autobatch.resolve_auto_batch", return_value=12
+        ) as resolve,
+        patch("libreyolo.training.distributed.spawn_ddp_train", side_effect=fake_spawn),
+        patch("libreyolo.training.ddp_spawn._build_init_kw", return_value={}),
+    ):
+        spawn_for_model(
+            instance,
+            train_kw={"batch_size": -1, "imgsz": 320, "amp": False},
+            nprocs=2,
+            devices=[0, 1],
+            batch_key="batch_size",
+        )
+
+    assert captured["train_kw"]["batch_size"] == 12
+    assert resolve.call_args.kwargs["world_size"] == 2
+    assert resolve.call_args.kwargs["imgsz"] == 320
+
+
+def test_spawn_for_model_returns_result_and_reloads_parent_checkpoint(
+    tmp_path: Path,
+) -> None:
+    checkpoint = tmp_path / "last.pt"
+    checkpoint.write_bytes(b"checkpoint placeholder")
+    instance = _wrapper()
+
+    def fake_spawn(worker_fn, spawn_args, nprocs, result_path, **kwargs):
+        Path(result_path).write_text(
+            json.dumps({"last_checkpoint": str(checkpoint), "metric": 0.5}),
+            encoding="utf-8",
+        )
+
+    with (
+        patch("torch.save"),
+        patch("torch.cuda.is_available", return_value=False),
+        patch("libreyolo.training.distributed.spawn_ddp_train", side_effect=fake_spawn),
+        patch("libreyolo.training.ddp_spawn._build_init_kw", return_value={}),
+    ):
+        result = spawn_for_model(
+            instance,
+            train_kw={"batch": 8},
+            nprocs=2,
+            devices=[0, 1],
+        )
+
+    assert result["metric"] == 0.5
+    assert instance.model_path == str(checkpoint)
+    instance._load_weights.assert_called_once_with(str(checkpoint))
+    assert instance.device == torch.device("cpu")
+    assert instance.model.training is False
+
+
+def _run_model_script(tmp_path: Path, *, guarded: bool) -> dict:
+    helper = tmp_path / "ddp_script_support.py"
+    helper.write_text(
+        textwrap.dedent(
+            """
+            import json
+            import os
+            from pathlib import Path
+
+            from libreyolo.training.ddp_spawn import ddp_aware
+
+            def script_worker(rank, nprocs, master_addr, master_port, result_path, train_kw):
+                callback = train_kw["callbacks"]
+                if rank == 0:
+                    callback({"rank": rank, "world": nprocs})
+                    Path(result_path).write_text(json.dumps({
+                        "rank": rank,
+                        "world": nprocs,
+                        "batch": train_kw["batch"],
+                        "logger": train_kw["loggers"],
+                    }))
+
+            class ScriptModel:
+                @ddp_aware()
+                def train(self, *, device="auto", batch=4, callbacks=None, loggers=None):
+                    raise AssertionError("multi-device call did not dispatch")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    launch_path = tmp_path / (
+        "guarded-launches.txt" if guarded else "unguarded-launches.txt"
+    )
+    callback_path = tmp_path / (
+        "guarded-callback.json" if guarded else "unguarded-callback.json"
+    )
+    output_path = tmp_path / (
+        "guarded-result.json" if guarded else "unguarded-result.json"
+    )
+    script = tmp_path / ("guarded.py" if guarded else "unguarded.py")
+    script_body = textwrap.dedent(
+        f"""
+            import json
+            from pathlib import Path
+            from unittest.mock import patch
+
+            import torch
+            from ddp_script_support import ScriptModel, script_worker
+            from libreyolo.training.distributed import spawn_ddp_train
+
+            LAUNCH_PATH = Path({str(launch_path)!r})
+            CALLBACK_PATH = Path({str(callback_path)!r})
+            OUTPUT_PATH = Path({str(output_path)!r})
+            with LAUNCH_PATH.open("a", encoding="utf-8") as handle:
+                handle.write("launch\\n")
+
+            def module_callback(event):
+                CALLBACK_PATH.write_text(json.dumps(event), encoding="utf-8")
+
+            def launch(model, train_kw, nprocs, *, devices, batch_key):
+                result_path = OUTPUT_PATH.with_name("worker-result.json")
+                spawn_ddp_train(
+                    script_worker,
+                    spawn_args=(train_kw,),
+                    nprocs=nprocs,
+                    result_path=str(result_path),
+                    devices=devices,
+                )
+                return json.loads(result_path.read_text(encoding="utf-8"))
+
+            def run():
+                with patch("torch.cuda.is_available", return_value=True), patch(
+                    "libreyolo.training.ddp_spawn.spawn_for_model", side_effect=launch
+                ):
+                    result = ScriptModel().train(
+                        device="0,1", batch=8, callbacks=module_callback, loggers="mlflow"
+                    )
+                OUTPUT_PATH.write_text(json.dumps(result), encoding="utf-8")
+            """
+    )
+    script_body += (
+        "\nif __name__ == '__main__':\n    run()\n" if guarded else "\nrun()\n"
+    )
+    script.write_text(script_body, encoding="utf-8")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root), str(tmp_path), env.get("PYTHONPATH", "")]
+    )
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    assert launch_path.read_text(encoding="utf-8").splitlines() == ["launch"]
+    assert json.loads(callback_path.read_text(encoding="utf-8")) == {
+        "rank": 0,
+        "world": 2,
+    }
+    return json.loads(output_path.read_text(encoding="utf-8"))
+
+
+def test_unguarded_top_level_model_train_matches_guarded_script(tmp_path: Path) -> None:
+    unguarded = _run_model_script(tmp_path, guarded=False)
+    guarded = _run_model_script(tmp_path, guarded=True)
+    assert (
+        unguarded
+        == guarded
+        == {
+            "rank": 0,
+            "world": 2,
+            "batch": 8,
+            "logger": "mlflow",
+        }
+    )
+
+
+def test_guarded_standard_pickle_callback_uses_compatibility_launcher(
+    tmp_path: Path,
+) -> None:
+    helper = tmp_path / "ddp_callback_support.py"
+    helper.write_text(
+        textwrap.dedent(
+            """
+            import json
+            import os
+            from pathlib import Path
+
+            def callback_worker(
+                rank, nprocs, master_addr, master_port, result_path, callback
+            ):
+                if rank == 0:
+                    callback(f"rank={rank}")
+                    Path(result_path).write_text(json.dumps({
+                        "rank": rank,
+                        "world": nprocs,
+                        "cvd": os.environ.get("CUDA_VISIBLE_DEVICES"),
+                    }), encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+    callback_path = tmp_path / "callback.txt"
+    import_mask_dir = tmp_path / "import-masks"
+    result_path = tmp_path / "fallback-result.json"
+    script = tmp_path / "guarded_fallback.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import multiprocessing
+            import os
+            from pathlib import Path
+
+            from ddp_callback_support import callback_worker
+            from libreyolo.training.distributed import spawn_ddp_train
+
+            if multiprocessing.current_process().name != "MainProcess":
+                mask_dir = Path({str(import_mask_dir)!r})
+                mask_dir.mkdir(exist_ok=True)
+                (mask_dir / f"{{os.getpid()}}.txt").write_text(
+                    os.environ.get("CUDA_VISIBLE_DEVICES", "<missing>"),
+                    encoding="utf-8",
+                )
+
+            CALLBACK_HANDLE = Path({str(callback_path)!r}).open(
+                "a", encoding="utf-8"
+            )
+
+            def module_callback(message):
+                CALLBACK_HANDLE.write(message)
+                CALLBACK_HANDLE.flush()
+
+            def main():
+                os.environ["CUDA_VISIBLE_DEVICES"] = "4,7"
+                spawn_ddp_train(
+                    callback_worker,
+                    spawn_args=(module_callback,),
+                    nprocs=2,
+                    result_path={str(result_path)!r},
+                    devices=[1, 0],
+                )
+                CALLBACK_HANDLE.close()
+                assert os.environ["CUDA_VISIBLE_DEVICES"] == "4,7"
+
+            if __name__ == "__main__":
+                main()
+            """
+        ),
+        encoding="utf-8",
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root), str(tmp_path), env.get("PYTHONPATH", "")]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, (
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    assert "guarded-script compatibility launcher" in completed.stderr
+    assert callback_path.read_text(encoding="utf-8") == "rank=0"
+    assert sorted(
+        path.read_text(encoding="utf-8") for path in import_mask_dir.iterdir()
+    ) == ["7,4", "7,4"]
+    assert json.loads(result_path.read_text(encoding="utf-8")) == {
+        "rank": 0,
+        "world": 2,
+        "cvd": "7,4",
+    }
+
+
+def test_compatibility_launcher_restores_parent_mask_after_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,7")
+    child_env = os.environ.copy()
+    child_env["CUDA_VISIBLE_DEVICES"] = "7,4"
+    observed = []
+
+    def failing_spawn(*args, **kwargs):
+        observed.append(os.environ.get("CUDA_VISIBLE_DEVICES"))
+        raise RuntimeError("intentional compatibility launch failure")
+
+    monkeypatch.setattr("torch.multiprocessing.spawn", failing_spawn)
+
+    with (
+        pytest.warns(RuntimeWarning, match="compatibility launcher"),
+        pytest.raises(RuntimeError, match="intentional compatibility launch failure"),
+    ):
+        _spawn_standard_pickle_fallback(
+            _recording_worker,
+            ("unused",),
+            2,
+            str(tmp_path / "unused.json"),
+            "127.0.0.1",
+            12345,
+            child_env,
+        )
+
+    assert observed == ["7,4"]
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "4,7"
+
+
+def test_unguarded_compatibility_fallback_stops_without_recursing(
+    tmp_path: Path,
+) -> None:
+    helper = tmp_path / "ddp_fallback_support.py"
+    helper.write_text(
+        "def callback_worker(rank, world, host, port, result_path, callback):\n"
+        "    callback(str(rank))\n",
+        encoding="utf-8",
+    )
+    launches = tmp_path / "launches.txt"
+    callback_path = tmp_path / "callback.txt"
+    script = tmp_path / "unguarded_fallback.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            from pathlib import Path
+
+            from ddp_fallback_support import callback_worker
+            from libreyolo.training.distributed import spawn_ddp_train
+
+            with Path({str(launches)!r}).open("a", encoding="utf-8") as marker:
+                marker.write("launch\\n")
+            CALLBACK_HANDLE = Path({str(callback_path)!r}).open(
+                "w", encoding="utf-8"
+            )
+
+            def module_callback(message):
+                CALLBACK_HANDLE.write(message)
+                CALLBACK_HANDLE.flush()
+
+            spawn_ddp_train(
+                callback_worker,
+                spawn_args=(module_callback,),
+                nprocs=1,
+                result_path={str(tmp_path / "unused.json")!r},
+            )
+            """
+        ),
+        encoding="utf-8",
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root), str(tmp_path), env.get("PYTHONPATH", "")]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert launches.read_text(encoding="utf-8").splitlines() == [
+        "launch",
+        "launch",
+    ]
+    assert "from a spawned subprocess" in completed.stderr
+    assert "if __name__ == '__main__'" in completed.stderr

--- a/tests/unit/test_ddp_coordinator.py
+++ b/tests/unit/test_ddp_coordinator.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,19 +19,24 @@ import torch.nn as nn
 
 from libreyolo.training._ddp_coordinator import (
     CLEANUP_SENTINEL_NAME,
+    COORDINATOR_BOOTSTRAP_ENV,
     JOB_PROTOCOL,
     JOB_PROTOCOL_VERSION,
     MANIFEST_NAME,
+    PAYLOAD_NAME,
+    PAYLOAD_SIZE_WARNING_BYTES,
     STATUS_NAME,
     __file__ as coordinator_file,
     _cleanup_abandoned_job,
+    _coordinator_launch,
     _load_manifest,
     _load_payload,
+    _pop_coordinator_bootstrap,
     coordinator_main,
     job_workspace,
     write_job,
 )
-from libreyolo.training.ddp_spawn import ddp_aware
+from libreyolo.training.ddp_spawn import _build_init_kw, ddp_aware
 from libreyolo.training.ddp_spawn import spawn_for_model
 from libreyolo.training.distributed import spawn_ddp_train
 from libreyolo.training.distributed import _spawn_standard_pickle_fallback
@@ -58,6 +64,9 @@ def _recording_worker(
         "cvd": os.environ.get("CUDA_VISIBLE_DEVICES"),
         "cwd": os.getcwd(),
         "token": token,
+        "argv": sys.argv,
+        "main_file": getattr(sys.modules.get("__main__"), "__file__", None),
+        "bootstrap_env": os.environ.get(COORDINATOR_BOOTSTRAP_ENV),
     }
     rank_path = Path(result_path).with_name(f"rank-{rank}.json")
     rank_path.write_text(json.dumps(record), encoding="utf-8")
@@ -96,16 +105,18 @@ def _job_dirs() -> set[Path]:
 
 def test_job_protocol_round_trip(tmp_path: Path) -> None:
     job_dir = tmp_path / "job"
-    write_job(
-        job_dir,
-        worker_fn=_recording_worker,
-        spawn_args=("protocol-token",),
-        nprocs=2,
-        result_path=str(tmp_path / "result.json"),
-        master_addr="127.0.0.1",
-        master_port=12345,
-        import_paths=[str(tmp_path)],
-    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        write_job(
+            job_dir,
+            worker_fn=_recording_worker,
+            spawn_args=("protocol-token",),
+            nprocs=2,
+            result_path=str(tmp_path / "result.json"),
+            master_addr="127.0.0.1",
+            master_port=12345,
+            import_paths=[str(tmp_path)],
+        )
 
     manifest = _load_manifest(job_dir)
     payload = _load_payload(job_dir, manifest)
@@ -114,6 +125,102 @@ def test_job_protocol_round_trip(tmp_path: Path) -> None:
     assert payload["job_id"] == manifest["job_id"]
     assert payload["spawn_args"] == ("protocol-token",)
     assert manifest["import_paths"] == [str(tmp_path)]
+    assert payload["caller_argv"] == sys.argv
+    assert manifest["caller_argv"] == sys.argv
+    assert payload["caller_main_file"] == getattr(
+        sys.modules.get("__main__"), "__file__", None
+    )
+    assert manifest["caller_main_file"] == payload["caller_main_file"]
+    assert (job_dir / PAYLOAD_NAME).stat().st_size < PAYLOAD_SIZE_WARNING_BYTES
+    assert caught == []
+
+
+@pytest.mark.parametrize("main_file", [Path("program.py"), b"program.py"])
+def test_job_identity_normalizes_pathlike_and_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    main_file,
+) -> None:
+    main_module = sys.modules["__main__"]
+    monkeypatch.setattr(sys, "argv", [Path("program.py"), b"--bytes-flag"])
+    monkeypatch.setattr(main_module, "__file__", main_file, raising=False)
+    job_dir = tmp_path / "job"
+
+    write_job(
+        job_dir,
+        worker_fn=_recording_worker,
+        spawn_args=("identity-normalization",),
+        nprocs=1,
+        result_path=str(tmp_path / "result.json"),
+        master_addr="127.0.0.1",
+        master_port=12345,
+        import_paths=[str(tmp_path)],
+    )
+
+    manifest = _load_manifest(job_dir)
+    payload = _load_payload(job_dir, manifest)
+    expected_argv = ["program.py", "--bytes-flag"]
+    expected_main_file = "program.py"
+    assert manifest["caller_argv"] == expected_argv
+    assert payload["caller_argv"] == expected_argv
+    assert manifest["caller_main_file"] == expected_main_file
+    assert payload["caller_main_file"] == expected_main_file
+
+
+def test_successful_oversized_payload_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "libreyolo.training._ddp_coordinator.PAYLOAD_SIZE_WARNING_BYTES", 1
+    )
+    job_dir = tmp_path / "job"
+
+    with pytest.warns(RuntimeWarning, match="automatic DDP payload is"):
+        write_job(
+            job_dir,
+            worker_fn=_recording_worker,
+            spawn_args=("large-enough-for-test",),
+            nprocs=1,
+            result_path=str(tmp_path / "result.json"),
+            master_addr="127.0.0.1",
+            master_port=12345,
+            import_paths=[str(tmp_path)],
+        )
+
+    assert (job_dir / PAYLOAD_NAME).is_file()
+
+
+def test_coordinator_bootstrap_stays_off_command_line_and_is_consumed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    command, coordinator_env = _coordinator_launch(
+        tmp_path / "job",
+        env={"PRESERVED": "value"},
+        parent_port=23456,
+        parent_token="private-parent-token",
+        cleanup_token="private-cleanup-token",
+    )
+
+    assert command == [
+        sys.executable,
+        str(Path(coordinator_file).resolve()),
+        str(tmp_path / "job"),
+    ]
+    rendered_command = " ".join(command)
+    assert "23456" not in rendered_command
+    assert "private-parent-token" not in rendered_command
+    assert "private-cleanup-token" not in rendered_command
+    assert coordinator_env["PRESERVED"] == "value"
+
+    monkeypatch.setenv(
+        COORDINATOR_BOOTSTRAP_ENV,
+        coordinator_env[COORDINATOR_BOOTSTRAP_ENV],
+    )
+    bootstrap = _pop_coordinator_bootstrap()
+    assert bootstrap["parent_port"] == 23456
+    assert bootstrap["parent_token"] == "private-parent-token"
+    assert bootstrap["cleanup_token"] == "private-cleanup-token"
+    assert COORDINATOR_BOOTSTRAP_ENV not in os.environ
 
 
 def test_job_protocol_rejects_future_version(tmp_path: Path) -> None:
@@ -163,6 +270,8 @@ def test_coordinator_propagates_env_result_mask_and_cleans_up(
         assert record["world_env"] == "2"
         assert record["cvd"] == "2,3"
         assert record["token"] == "round-trip"
+        assert record["bootstrap_env"] is None
+        assert all("libreyolo-ddp-job-" not in arg for arg in record["argv"])
     assert json.loads(result_path.read_text())["rank"] == 0
 
 
@@ -261,19 +370,16 @@ def test_parent_liveness_socket_stops_workers_and_cleans_job(tmp_path: Path) -> 
         listener.listen(1)
         listener.settimeout(15)
         parent_token = "parent-liveness-test-token"
-        process = subprocess.Popen(
-            [
-                sys.executable,
-                str(Path(coordinator_file).resolve()),
-                str(job_dir),
-                "--parent-port",
-                str(listener.getsockname()[1]),
-                "--parent-token",
-                parent_token,
-                "--cleanup-token",
-                cleanup_token,
-            ],
+        command, coordinator_env = _coordinator_launch(
+            job_dir,
             env=os.environ.copy(),
+            parent_port=listener.getsockname()[1],
+            parent_token=parent_token,
+            cleanup_token=cleanup_token,
+        )
+        process = subprocess.Popen(
+            command,
+            env=coordinator_env,
             stdin=subprocess.DEVNULL,
         )
         parent_connection, _ = listener.accept()
@@ -329,6 +435,14 @@ class _BatchSizeDispatchProbe:
     @ddp_aware(batch_key="batch_size")
     def train(self, *, device="auto", batch_size=4, resume=False):
         raise AssertionError("multi-device call did not dispatch")
+
+
+def test_normal_model_class_remains_imported_by_name() -> None:
+    init_kw = _build_init_kw(_DispatchProbe())
+
+    assert init_kw["_module"] == __name__
+    assert init_kw["_class"] == "_DispatchProbe"
+    assert "_class_object" not in init_kw
 
 
 @pytest.mark.parametrize("device", [None, "auto", "cpu", "mps", 0, "0", [0]])
@@ -603,6 +717,105 @@ def test_unguarded_top_level_model_train_matches_guarded_script(tmp_path: Path) 
             "logger": "mlflow",
         }
     )
+
+
+def test_guarded_main_model_class_and_program_identity_reach_model_worker(
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "guarded-main-result.json"
+    side_effect_path = tmp_path / "guarded-main-side-effect.txt"
+    script = tmp_path / "guarded_main_model.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import json
+            import os
+            import sys
+            from pathlib import Path
+
+            import torch
+            import torch.nn as nn
+
+            from libreyolo.training._ddp_coordinator import COORDINATOR_BOOTSTRAP_ENV
+            from libreyolo.training.ddp_spawn import spawn_for_model
+
+            OUTPUT_PATH = Path({str(output_path)!r})
+            SIDE_EFFECT_PATH = Path({str(side_effect_path)!r})
+            with SIDE_EFFECT_PATH.open("a", encoding="utf-8") as marker:
+                marker.write("parent-only\\n")
+
+            class GuardedMainModel:
+                def __init__(self, model_path=None, device="auto"):
+                    self.model = nn.Linear(2, 1)
+                    self.model_path = model_path
+                    self.device = torch.device("cpu")
+                    if model_path:
+                        state = torch.load(
+                            model_path, map_location="cpu", weights_only=True
+                        )
+                        self.model.load_state_dict(state)
+
+                def train(self, *, device="auto"):
+                    import __main__
+
+                    return {{
+                        "rank": int(os.environ["LOCAL_RANK"]),
+                        "class_name": type(self).__name__,
+                        "class_module": type(self).__module__,
+                        "argv": list(sys.argv),
+                        "main_file": getattr(__main__, "__file__", None),
+                        "bootstrap_env": os.environ.get(
+                            COORDINATOR_BOOTSTRAP_ENV
+                        ),
+                    }}
+
+            def main():
+                result = spawn_for_model(
+                    GuardedMainModel(),
+                    train_kw={{}},
+                    nprocs=2,
+                )
+                OUTPUT_PATH.write_text(json.dumps(result), encoding="utf-8")
+
+            if __name__ == "__main__":
+                main()
+            """
+        ),
+        encoding="utf-8",
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = "-1"
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root), str(tmp_path), env.get("PYTHONPATH", "")]
+    )
+    original_args = [str(script), "--user-flag", "value with spaces"]
+
+    completed = subprocess.run(
+        [sys.executable, *original_args],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, (
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+    assert result == {
+        "rank": 0,
+        "class_name": "GuardedMainModel",
+        "class_module": "__main__",
+        "argv": original_args,
+        "main_file": str(script),
+        "bootstrap_env": None,
+    }
+    assert side_effect_path.read_text(encoding="utf-8").splitlines() == ["parent-only"]
+    assert all("libreyolo-ddp-job-" not in arg for arg in result["argv"])
 
 
 def test_guarded_standard_pickle_callback_uses_compatibility_launcher(


### PR DESCRIPTION
- Allow automatic local DDP from ordinary guarded and unguarded Python scripts (#817).
- Add a private versioned coordinator with parent-liveness and authenticated cleanup.
- Preserve explicit `torchrun`, device masks, and standard-pickle callback compatibility.
- Preserve guarded `__main__` model classes and caller program metadata without replaying arbitrary top-level side effects.
- Keep coordinator bootstrap tokens out of process arguments and worker environments.
- Warn when captured callback/logger globals create an oversized DDP payload.
- Add subprocess, packaging, logger, dispatch, Gloo, liveness, and cleanup coverage.

Verified: 32 coordinator tests; 47 DDP/logger tests with 2 hardware skips; 10 Gloo distributed tests; ruff and diff checks; Greptile found no DDP blocker.
Not verified: real 2+ GPU CUDA/NCCL training.
Opened by an agent.

## Code provenance

Original code written for this PR using LibreYOLO first-party code and standard Python/PyTorch APIs; no third-party code was ported or adapted. Cloudpickle is used only as a separately installed BSD-3-Clause runtime dependency; no cloudpickle source was copied.




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces direct local DDP spawning with a private coordinator so guarded and unguarded Python entry points can start multi-GPU training without replaying user-script side effects.
- Adds versioned cloudpickle job transport, authenticated cleanup, parent-liveness monitoring, and structured error propagation.
- Preserves explicit torchrun behavior, CUDA device-mask translation, guarded-script fallback, callbacks, loggers, and caller metadata.
- Adds packaging smoke coverage and coordinator, subprocess, cleanup, failure, and compatibility tests.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libreyolo/training/_ddp_coordinator.py | Adds the versioned coordinator protocol, subprocess handshake, worker spawning, parent-liveness handling, status propagation, and authenticated temporary-workspace cleanup. |
| libreyolo/training/distributed.py | Routes automatic local DDP through the coordinator while preserving device masks, explicit launcher environments, and the guarded-script compatibility path. |
| libreyolo/training/ddp_spawn.py | Supports transporting guarded-script model classes by value while retaining import-by-name behavior for normal library classes. |
| tests/unit/test_ddp_coordinator.py | Adds broad protocol, environment, subprocess, failure, liveness, cleanup, logger, callback, and guarded-versus-unguarded launch coverage. |
| pyproject.toml | Adds cloudpickle as the runtime dependency for automatic DDP payload transport. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User process
    participant C as DDP coordinator
    participant W0 as Rank 0
    participant WN as Other ranks
    U->>U: Serialize versioned job
    U->>C: Launch with private bootstrap environment
    C->>U: Authenticate liveness socket
    C->>C: Consume bootstrap credentials
    C->>W0: Spawn and load job payload
    C->>WN: Spawn and load job payload
    W0->>WN: Initialize distributed process group
    WN->>W0: Synchronize training
    W0-->>C: Persist training result
    C-->>U: Return structured status
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Update DDP protocol smoke check"](https://github.com/libreyolo/libreyolo/commit/194ac8c38bf5327228a78cc89c59cd0373b95146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55860626)</sub>

**Context used:**

- Knowledge Base — [Training and validation](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-and-validation.md)
- Knowledge Base — [Training runtime and experiment control](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-runtime-and-experiment-control.md)

<!-- /greptile_comment -->