### PR TITLE
Feature, allow tracking on image sequences

### DIFF
--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -11,6 +11,7 @@ import functools
 import inspect
 import logging
 import re
+import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
@@ -1589,6 +1590,10 @@ class BaseModel(ABC):
                 the buffer is timed against ``fps / vid_stride`` — the rate
                 at which frames are actually retained and reach the tracker.
                 Ignored for video files, which use their own detected fps.
+                Also ignored when *tracker_config* is given (same rule as
+                *track_conf*) — set ``frame_rate`` on it yourself in that
+                case, or a mismatch will emit a warning and the buffer will
+                use *tracker_config*'s frame_rate as-is.
             output_path: Path for saved video. Defaults to
                 ``runs/track/<video_stem>.mp4`` for a video file, or
                 ``runs/track/<name>.mp4`` for an image sequence.
@@ -1701,8 +1706,24 @@ class BaseModel(ABC):
             # times longer (in wall-clock terms) than the buffer intends.
             # OC-SORT/Deep OC-SORT have no frame_rate field (their buffer is
             # a plain frame count via max_age), so they're left alone.
-            retained_fps = fps / max(1, vid_stride)
-            tracker_kwargs.setdefault("frame_rate", max(1, int(round(retained_fps))))
+            retained_fps = max(1, int(round(fps / max(1, vid_stride))))
+            if tracker_config is None:
+                tracker_kwargs.setdefault("frame_rate", retained_fps)
+            elif getattr(tracker_config, "frame_rate", retained_fps) != retained_fps:
+                # An explicit tracker_config always wins it is never silently overwritten, even
+                # here. But since its frame_rate now silently controls the
+                # lost-track buffer's real-world duration for this image
+                # sequence, a mismatch is surfaced instead of staying quiet.
+                warnings.warn(
+                    f"tracker_config.frame_rate={tracker_config.frame_rate} does "
+                    f"not match this image sequence's retained-frame rate "
+                    f"(fps / vid_stride = {retained_fps}). tracker_config is "
+                    "used as-is -- fps and vid_stride are ignored once "
+                    "tracker_config is given -- so lost tracks will be kept "
+                    "recoverable for the wrong duration unless you set "
+                    f"frame_rate={retained_fps} on it yourself.",
+                    stacklevel=2,
+                )
 
         if tracker == "deepocsort":
             if tracker_config is None:

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1582,9 +1582,11 @@ class BaseModel(ABC):
             fps: Frame rate to assume when *source* is an image sequence
                 (directory, list, or iterator) rather than a video file,
                 since those have no real capture rate of their own. Affects
-                the tracker's lost-track buffer timing and the fps written
-                into a saved output video. Ignored for video files, which
-                use their own detected fps.
+                the fps written into a saved output video, and — for
+                ByteTrack/BoT-SORT only — the lost-track buffer timing
+                (OC-SORT/Deep OC-SORT count lost-track age in frames, not
+                time, so *fps* doesn't affect them). Ignored for video
+                files, which use their own detected fps.
             output_path: Path for saved video. Defaults to
                 ``runs/track/<video_stem>.mp4`` for a video file, or
                 ``runs/track/<name>.mp4`` for an image sequence.
@@ -1672,6 +1674,10 @@ class BaseModel(ABC):
         from ...utils.source import ImageSequenceSource, SourceKind, classify_source
         from ...utils.video import run_video_inference
 
+        # Classified up front (rather than after the tracker is built) so a
+        # non-video source can seed the tracker's frame_rate default below.
+        source_spec = classify_source(source)
+
         # A provided config picks the tracker; otherwise honour the selector.
         if isinstance(tracker_config, BoTSortConfig):
             # BoTSortConfig subclasses TrackConfig, so it must be checked first.
@@ -1683,6 +1689,14 @@ class BaseModel(ABC):
         elif isinstance(tracker_config, TrackConfig):
             tracker = "bytetrack"
         tracker = (tracker or "bytetrack").lower()
+
+        if tracker in ("bytetrack", "botsort") and source_spec.kind != SourceKind.VIDEO:
+            # ByteTrack/BoT-SORT scale their lost-track buffer by frame_rate;
+            # an image sequence has no real capture rate of its own, so seed
+            # it from *fps* instead of silently keeping the class default.
+            # OC-SORT/Deep OC-SORT have no frame_rate field (their buffer is
+            # a plain frame count via max_age), so they're left alone.
+            tracker_kwargs.setdefault("frame_rate", int(round(fps)))
 
         if tracker == "deepocsort":
             if tracker_config is None:
@@ -1721,7 +1735,6 @@ class BaseModel(ABC):
                 "choose 'bytetrack', 'botsort', 'ocsort' or 'deepocsort'."
             )
 
-        source_spec = classify_source(source)
         default_stem = "sequence"
         if source_spec.kind == SourceKind.VIDEO:
             frame_source: Union[Path, ImageSequenceSource] = Path(source_spec.source)

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1698,32 +1698,31 @@ class BaseModel(ABC):
         tracker = (tracker or "bytetrack").lower()
 
         if tracker in ("bytetrack", "botsort") and source_spec.kind != SourceKind.VIDEO:
-            # ByteTrack/BoT-SORT scale their lost-track buffer by frame_rate,
-            # which must match the actual rate at which update() is called --
-            # one call per *retained* frame, i.e. fps / vid_stride, since
-            # strided-out frames never reach the tracker at all. Seeding it
-            # with the raw fps would let lost identities survive vid_stride
-            # times longer (in wall-clock terms) than the buffer intends.
-            # OC-SORT/Deep OC-SORT have no frame_rate field (their buffer is
-            # a plain frame count via max_age), so they're left alone.
-            retained_fps = max(1, int(round(fps / max(1, vid_stride))))
+            # update() runs once per retained frame, so frame_rate must be fps / vid_stride
+            retained_fps = fps / max(1, vid_stride)
             if tracker_config is None:
+                # Pass the exact fraction: tracker.py already truncates via
+                # int(), so pre-rounding here would double-round and can
+                # shift max_time_lost by a frame at the expiry boundary.
                 tracker_kwargs.setdefault("frame_rate", retained_fps)
-            elif getattr(tracker_config, "frame_rate", retained_fps) != retained_fps:
-                # An explicit tracker_config always wins it is never silently overwritten, even
-                # here. But since its frame_rate now silently controls the
-                # lost-track buffer's real-world duration for this image
-                # sequence, a mismatch is surfaced instead of staying quiet.
-                warnings.warn(
-                    f"tracker_config.frame_rate={tracker_config.frame_rate} does "
-                    f"not match this image sequence's retained-frame rate "
-                    f"(fps / vid_stride = {retained_fps}). tracker_config is "
-                    "used as-is -- fps and vid_stride are ignored once "
-                    "tracker_config is given -- so lost tracks will be kept "
-                    "recoverable for the wrong duration unless you set "
-                    f"frame_rate={retained_fps} on it yourself.",
-                    stacklevel=2,
-                )
+            else:
+                # frame_rate is a typed int field, so compare against the
+                # nearest achievable value rather than the exact fraction.
+                nearest_retained_fps = max(1, round(retained_fps))
+                current = getattr(tracker_config, "frame_rate", nearest_retained_fps)
+                if current != nearest_retained_fps:
+                    # tracker_config always wins and is never overwritten --
+                    # just warn so a silent mismatch doesn't linger.
+                    warnings.warn(
+                        f"tracker_config.frame_rate={tracker_config.frame_rate} does "
+                        f"not match this image sequence's retained-frame rate "
+                        f"(fps / vid_stride ≈ {nearest_retained_fps}). "
+                        "tracker_config is used as-is -- fps and vid_stride are "
+                        "ignored once tracker_config is given -- so lost tracks "
+                        "will be kept recoverable for the wrong duration unless "
+                        f"you set frame_rate={nearest_retained_fps} on it yourself.",
+                        stacklevel=2,
+                    )
 
         if tracker == "deepocsort":
             if tracker_config is None:

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -19,8 +19,10 @@ from typing import (
     ClassVar,
     Dict,
     Generator,
+    Iterator,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,
@@ -1525,7 +1527,7 @@ class BaseModel(ABC):
 
     def track(
         self,
-        source: str | Path,
+        source: Union[str, Path, Sequence[ImageInput], Iterator[ImageInput]],
         *,
         track_conf: float = 0.25,
         iou: float = 0.45,
@@ -1535,13 +1537,14 @@ class BaseModel(ABC):
         save: bool = False,
         show: bool = False,
         vid_stride: int = 1,
+        fps: float = 30.0,
         output_path: Optional[str] = None,
         tracker: str = "bytetrack",
         tracker_config=None,
         augment: bool = False,
         **tracker_kwargs,
     ) -> Generator[Results, None, None]:
-        """Track objects across video frames.
+        """Track objects across video frames or an image sequence.
 
         Runs detection on each frame and associates detections across time.
         Four trackers are available via ``tracker``: ByteTrack (default) and
@@ -1553,7 +1556,13 @@ class BaseModel(ABC):
         with ``track_id`` set.
 
         Args:
-            source: Path to a video file.
+            source: A video file path, a directory of images (sorted by
+                name), a finite list/tuple of already-loaded images (paths,
+                PIL Images, NumPy arrays, or tensors), or an iterator/
+                generator yielding images one at a time for incremental,
+                unbounded tracking. In every case, items are treated as
+                consecutive frames of one logical video and tracked in
+                order.
             track_conf: Confidence threshold for the tracker's first
                 association stage — ``track_high_thresh`` for ByteTrack and
                 BoT-SORT, ``det_thresh`` for OC-SORT and Deep OC-SORT. For the
@@ -1570,8 +1579,15 @@ class BaseModel(ABC):
             save: If True, save annotated video to *output_path*.
             show: Display tracked frames in a window.
             vid_stride: Process every N-th frame.
+            fps: Frame rate to assume when *source* is an image sequence
+                (directory, list, or iterator) rather than a video file,
+                since those have no real capture rate of their own. Affects
+                the tracker's lost-track buffer timing and the fps written
+                into a saved output video. Ignored for video files, which
+                use their own detected fps.
             output_path: Path for saved video. Defaults to
-                ``runs/track/<video_stem>.mp4``.
+                ``runs/track/<video_stem>.mp4`` for a video file, or
+                ``runs/track/<name>.mp4`` for an image sequence.
             tracker: Which tracker to use: ``"bytetrack"``, ``"botsort"``,
                 ``"ocsort"`` or ``"deepocsort"``. Ignored when
                 *tracker_config* is given (the config type selects the tracker).
@@ -1652,6 +1668,8 @@ class BaseModel(ABC):
             TrackConfig,
         )
         from ...utils.drawing import draw_boxes, draw_masks
+        from ...utils.image_loader import ImageLoader
+        from ...utils.source import ImageSequenceSource, SourceKind, classify_source
         from ...utils.video import run_video_inference
 
         # A provided config picks the tracker; otherwise honour the selector.
@@ -1703,9 +1721,47 @@ class BaseModel(ABC):
                 "choose 'bytetrack', 'botsort', 'ocsort' or 'deepocsort'."
             )
 
-        source = Path(source)
-        if not source.exists():
-            raise FileNotFoundError(f"Video file not found: {source}")
+        source_spec = classify_source(source)
+        default_stem = "sequence"
+        if source_spec.kind == SourceKind.VIDEO:
+            frame_source: Union[Path, ImageSequenceSource] = Path(source_spec.source)
+            if not frame_source.exists():
+                raise FileNotFoundError(f"Video file not found: {frame_source}")
+            default_stem = frame_source.stem
+        elif source_spec.kind == SourceKind.DIRECTORY:
+            images = ImageLoader.collect_images(source_spec.source)
+            if not images:
+                return
+            default_stem = Path(source_spec.source).name
+            frame_source = ImageSequenceSource(
+                images, vid_stride=vid_stride, fps=fps, save_name=default_stem
+            )
+        elif source_spec.kind == SourceKind.IMAGE_BATCH:
+            frame_source = ImageSequenceSource(
+                list(source_spec.items),
+                vid_stride=vid_stride,
+                fps=fps,
+                save_name=default_stem,
+            )
+        elif source_spec.kind == SourceKind.IMAGE_SEQUENCE:
+            frame_source = ImageSequenceSource(
+                source_spec.source, vid_stride=vid_stride, fps=fps, save_name=default_stem
+            )
+        elif source_spec.kind == SourceKind.IMAGE:
+            # A single already-loaded image or path, treated as a one-frame
+            # sequence so predict()-style single-image inputs also work.
+            frame_source = ImageSequenceSource(
+                [source_spec.source],
+                vid_stride=vid_stride,
+                fps=fps,
+                save_name=default_stem,
+            )
+        else:
+            raise NotImplementedError(
+                f"track() does not yet support {source_spec.kind.value!r} sources. "
+                "Pass a video file, a directory or list of images, or an "
+                "image iterator."
+            )
 
         model_names = self.names
 
@@ -1751,13 +1807,13 @@ class BaseModel(ABC):
 
             track_output = str(
                 increment_path(
-                    Path("runs") / "track" / f"{source.stem}.mp4",
+                    Path("runs") / "track" / f"{default_stem}.mp4",
                     exist_ok=False,
                 )
             )
 
         yield from run_video_inference(
-            source,
+            frame_source,
             predict_and_track,
             vid_stride=vid_stride,
             save=save,

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -10,6 +10,7 @@ import contextlib
 import functools
 import inspect
 import logging
+import math
 import re
 import warnings
 from abc import ABC, abstractmethod
@@ -23,7 +24,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Sequence,
     Tuple,
     Type,
     Union,
@@ -1528,7 +1528,12 @@ class BaseModel(ABC):
 
     def track(
         self,
-        source: Union[str, Path, Sequence[ImageInput], Iterator[ImageInput]],
+        source: Union[
+            ImageInput,
+            List[ImageInput],
+            Tuple[ImageInput, ...],
+            Iterator[ImageInput],
+        ],
         *,
         track_conf: float = 0.25,
         iou: float = 0.45,
@@ -1539,6 +1544,7 @@ class BaseModel(ABC):
         show: bool = False,
         vid_stride: int = 1,
         fps: float = 30.0,
+        color_format: str = "auto",
         output_path: Optional[str] = None,
         tracker: str = "bytetrack",
         tracker_config=None,
@@ -1590,10 +1596,14 @@ class BaseModel(ABC):
                 the buffer is timed against ``fps / vid_stride`` — the rate
                 at which frames are actually retained and reach the tracker.
                 Ignored for video files, which use their own detected fps.
-                Also ignored when *tracker_config* is given (same rule as
-                *track_conf*) — set ``frame_rate`` on it yourself in that
-                case, or a mismatch will emit a warning and the buffer will
-                use *tracker_config*'s frame_rate as-is.
+                A typed *tracker_config* keeps its explicit ``frame_rate`` for
+                tracker timing, while *fps* and *vid_stride* still control
+                image-sequence sampling and saved-video playback. A mismatch
+                emits a warning rather than overwriting the explicit config.
+            color_format: Color format for NumPy image-sequence items:
+                ``"rgb"``, ``"bgr"``, or ``"auto"``. Other image input
+                types are normalized to RGB by ``ImageLoader``. Ignored for
+                video files.
             output_path: Path for saved video. Defaults to
                 ``runs/track/<video_stem>.mp4`` for a video file, or
                 ``runs/track/<name>.mp4`` for an image sequence.
@@ -1684,6 +1694,21 @@ class BaseModel(ABC):
         # Classified up front (rather than after the tracker is built) so a
         # non-video source can seed the tracker's frame_rate default below.
         source_spec = classify_source(source)
+        image_sequence_kinds = {
+            SourceKind.IMAGE,
+            SourceKind.IMAGE_BATCH,
+            SourceKind.IMAGE_SEQUENCE,
+            SourceKind.DIRECTORY,
+        }
+        if source_spec.kind in image_sequence_kinds:
+            try:
+                fps = float(fps)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"fps must be a finite value > 0, got {fps!r}"
+                ) from exc
+            if not math.isfinite(fps) or fps <= 0:
+                raise ValueError(f"fps must be a finite value > 0, got {fps!r}")
 
         # A provided config picks the tracker; otherwise honour the selector.
         if isinstance(tracker_config, BoTSortConfig):
@@ -1697,8 +1722,12 @@ class BaseModel(ABC):
             tracker = "bytetrack"
         tracker = (tracker or "bytetrack").lower()
 
-        if tracker in ("bytetrack", "botsort") and source_spec.kind != SourceKind.VIDEO:
-            # update() runs once per retained frame, so frame_rate must be fps / vid_stride
+        if (
+            tracker in ("bytetrack", "botsort")
+            and source_spec.kind in image_sequence_kinds
+        ):
+            # update() runs once per retained frame, so frame_rate must be
+            # fps / vid_stride.
             retained_fps = fps / max(1, vid_stride)
             if tracker_config is None:
                 # Pass the exact fraction: tracker.py already truncates via
@@ -1717,9 +1746,9 @@ class BaseModel(ABC):
                         f"tracker_config.frame_rate={tracker_config.frame_rate} does "
                         f"not match this image sequence's retained-frame rate "
                         f"(fps / vid_stride ≈ {nearest_retained_fps}). "
-                        "tracker_config is used as-is -- fps and vid_stride are "
-                        "ignored once tracker_config is given -- so lost tracks "
-                        "will be kept recoverable for the wrong duration unless "
+                        "tracker_config is used as-is for tracker timing, so lost "
+                        "tracks will be kept recoverable for the wrong duration "
+                        "unless "
                         f"you set frame_rate={nearest_retained_fps} on it yourself.",
                         stacklevel=2,
                     )
@@ -1773,7 +1802,11 @@ class BaseModel(ABC):
                 return
             default_stem = Path(source_spec.source).name
             frame_source = ImageSequenceSource(
-                images, vid_stride=vid_stride, fps=fps, save_name=default_stem
+                images,
+                vid_stride=vid_stride,
+                fps=fps,
+                save_name=default_stem,
+                color_format=color_format,
             )
         elif source_spec.kind == SourceKind.IMAGE_BATCH:
             frame_source = ImageSequenceSource(
@@ -1781,10 +1814,15 @@ class BaseModel(ABC):
                 vid_stride=vid_stride,
                 fps=fps,
                 save_name=default_stem,
+                color_format=color_format,
             )
         elif source_spec.kind == SourceKind.IMAGE_SEQUENCE:
             frame_source = ImageSequenceSource(
-                source_spec.source, vid_stride=vid_stride, fps=fps, save_name=default_stem
+                source_spec.source,
+                vid_stride=vid_stride,
+                fps=fps,
+                save_name=default_stem,
+                color_format=color_format,
             )
         elif source_spec.kind == SourceKind.IMAGE:
             # A single already-loaded image or path, treated as a one-frame
@@ -1794,6 +1832,7 @@ class BaseModel(ABC):
                 vid_stride=vid_stride,
                 fps=fps,
                 save_name=default_stem,
+                color_format=color_format,
             )
         else:
             raise NotImplementedError(

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -1585,8 +1585,10 @@ class BaseModel(ABC):
                 the fps written into a saved output video, and — for
                 ByteTrack/BoT-SORT only — the lost-track buffer timing
                 (OC-SORT/Deep OC-SORT count lost-track age in frames, not
-                time, so *fps* doesn't affect them). Ignored for video
-                files, which use their own detected fps.
+                time, so *fps* doesn't affect them). With *vid_stride* > 1,
+                the buffer is timed against ``fps / vid_stride`` — the rate
+                at which frames are actually retained and reach the tracker.
+                Ignored for video files, which use their own detected fps.
             output_path: Path for saved video. Defaults to
                 ``runs/track/<video_stem>.mp4`` for a video file, or
                 ``runs/track/<name>.mp4`` for an image sequence.
@@ -1691,12 +1693,16 @@ class BaseModel(ABC):
         tracker = (tracker or "bytetrack").lower()
 
         if tracker in ("bytetrack", "botsort") and source_spec.kind != SourceKind.VIDEO:
-            # ByteTrack/BoT-SORT scale their lost-track buffer by frame_rate;
-            # an image sequence has no real capture rate of its own, so seed
-            # it from *fps* instead of silently keeping the class default.
+            # ByteTrack/BoT-SORT scale their lost-track buffer by frame_rate,
+            # which must match the actual rate at which update() is called --
+            # one call per *retained* frame, i.e. fps / vid_stride, since
+            # strided-out frames never reach the tracker at all. Seeding it
+            # with the raw fps would let lost identities survive vid_stride
+            # times longer (in wall-clock terms) than the buffer intends.
             # OC-SORT/Deep OC-SORT have no frame_rate field (their buffer is
             # a plain frame count via max_age), so they're left alone.
-            tracker_kwargs.setdefault("frame_rate", int(round(fps)))
+            retained_fps = fps / max(1, vid_stride)
+            tracker_kwargs.setdefault("frame_rate", max(1, int(round(retained_fps))))
 
         if tracker == "deepocsort":
             if tracker_config is None:

--- a/libreyolo/utils/source.py
+++ b/libreyolo/utils/source.py
@@ -44,6 +44,7 @@ class SourceKind(str, Enum):
 
     IMAGE = "image"
     IMAGE_BATCH = "image_batch"
+    IMAGE_SEQUENCE = "image_sequence"
     DIRECTORY = "directory"
     VIDEO = "video"
     SCREEN = "screen"
@@ -196,6 +197,12 @@ def classify_source(source: Any) -> SourceSpec:
                 "A source list cannot mix live/video streams with image inputs"
             )
         return SourceSpec(SourceKind.IMAGE_BATCH, source, items)
+
+    if hasattr(source, "__next__"):
+        # A bare iterator/generator of already-loaded images (e.g. PIL frames
+        # produced incrementally). Unlike IMAGE_BATCH its length is unknown
+        # ahead of time, so it must stay lazy for the whole call.
+        return SourceSpec(SourceKind.IMAGE_SEQUENCE, source)
 
     if isinstance(source, (str, Path)):
         path = Path(source)
@@ -552,6 +559,83 @@ class MultiStreamSource:
     def release(self) -> None:
         for stream in self.streams:
             stream.release()
+
+
+class ImageSequenceSource:
+    """Iterate an in-memory or lazily-produced sequence of images as frames.
+
+    Wraps a finite list/tuple or a lazy iterator of already-loaded images
+    (paths, PIL Images, ndarrays, tensors) so it can drive the same
+    frame-by-frame loop (:func:`~libreyolo.utils.video.run_video_inference`)
+    used for video files and live streams. This is what lets
+    :meth:`~libreyolo.models.base.model.BaseModel.track` track across a
+    batch or stream of images instead of only video files.
+
+    Args:
+        images: A finite sequence or an iterator/generator of image inputs.
+            A finite sequence reports its length up front; an iterator's
+            length is unknown and iteration stays lazy for the whole call.
+        vid_stride: Process every N-th image (default ``1`` = every image).
+        fps: Frame rate to report for the sequence. There is no real
+            capture rate for a bag of images, so this only affects derived
+            timing (a tracker's lost-track buffer, or the fps written into
+            a saved output video).
+        save_name: Base name used to derive an output path when saving.
+
+    Note:
+        Can only be iterated once, like :class:`~libreyolo.utils.video.VideoSource`.
+    """
+
+    num_streams = 1
+
+    def __init__(
+        self,
+        images: Sequence[Any] | Iterator[Any],
+        *,
+        vid_stride: int = 1,
+        fps: float = 30.0,
+        save_name: str = "sequence",
+    ):
+        self._images = images
+        self._vid_stride = max(1, int(vid_stride))
+        self.fps = float(fps)
+        self.save_name = save_name
+        self.total_frames = len(images) if hasattr(images, "__len__") else 0
+        self.width = 0
+        self.height = 0
+        self._iterated = False
+
+    def __enter__(self) -> "ImageSequenceSource":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        pass
+
+    def __iter__(self) -> Iterator[StreamFrame]:
+        if self._iterated:
+            raise RuntimeError(
+                "ImageSequenceSource has already been consumed. "
+                "Create a new instance to iterate again."
+            )
+        self._iterated = True
+
+        import cv2
+
+        from .image_loader import ImageLoader
+
+        for frame_idx, item in enumerate(self._images):
+            if frame_idx % self._vid_stride:
+                continue
+            pil_img = ImageLoader.load(item)
+            frame_bgr = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+            label = str(item) if isinstance(item, (str, Path)) else None
+            yield StreamFrame(
+                frame_bgr=frame_bgr,
+                frame_idx=frame_idx,
+                source_index=0,
+                source_label=label,
+                fps=self.fps,
+            )
 
 
 def build_stream_source(

--- a/libreyolo/utils/source.py
+++ b/libreyolo/utils/source.py
@@ -7,10 +7,12 @@ from falling through to :class:`ImageLoader` as if they were file paths.
 
 from __future__ import annotations
 
+import io
 import re
 import sys
 import threading
 from collections import deque
+from collections.abc import Sized
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
@@ -72,7 +74,7 @@ class StreamFrame:
     frame_bgr: np.ndarray
     frame_idx: int
     source_index: int
-    source_label: str
+    source_label: str | None
     fps: float
 
 
@@ -197,6 +199,11 @@ def classify_source(source: Any) -> SourceSpec:
                 "A source list cannot mix live/video streams with image inputs"
             )
         return SourceSpec(SourceKind.IMAGE_BATCH, source, items)
+
+    # BytesIO is both a supported atomic ImageInput and an iterator over bytes.
+    # Keep it on the single-image path before recognizing lazy frame iterators.
+    if isinstance(source, io.BytesIO):
+        return SourceSpec(SourceKind.IMAGE, source)
 
     if hasattr(source, "__next__"):
         # A bare iterator/generator of already-loaded images (e.g. PIL frames
@@ -581,6 +588,8 @@ class ImageSequenceSource:
             timing (a tracker's lost-track buffer, or the fps written into
             a saved output video).
         save_name: Base name used to derive an output path when saving.
+        color_format: Color format hint passed to ``ImageLoader`` for NumPy
+            frames: ``"auto"``, ``"rgb"``, or ``"bgr"``.
 
     Note:
         Can only be iterated once, like :class:`~libreyolo.utils.video.VideoSource`.
@@ -595,12 +604,21 @@ class ImageSequenceSource:
         vid_stride: int = 1,
         fps: float = 30.0,
         save_name: str = "sequence",
+        color_format: str = "auto",
     ):
         self._images = images
         self._vid_stride = max(1, int(vid_stride))
         self.fps = float(fps)
+        if not np.isfinite(self.fps) or self.fps <= 0:
+            raise ValueError(f"fps must be a finite value > 0, got {fps}")
         self.save_name = save_name
-        self.total_frames = len(images) if hasattr(images, "__len__") else 0
+        raw_total = len(images) if isinstance(images, Sized) else 0
+        self.total_frames = (
+            (raw_total + self._vid_stride - 1) // self._vid_stride
+            if raw_total
+            else 0
+        )
+        self._color_format = color_format
         self.width = 0
         self.height = 0
         self._iterated = False
@@ -632,7 +650,7 @@ class ImageSequenceSource:
         for frame_idx, item in enumerate(self._images):
             if frame_idx % self._vid_stride:
                 continue
-            pil_img = ImageLoader.load(item)
+            pil_img = ImageLoader.load(item, color_format=self._color_format)
             frame_bgr = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
             label = str(item) if isinstance(item, (str, Path)) else None
             yield StreamFrame(

--- a/libreyolo/utils/source.py
+++ b/libreyolo/utils/source.py
@@ -623,6 +623,12 @@ class ImageSequenceSource:
 
         from .image_loader import ImageLoader
 
+        # Fewer frames are retained at higher strides, so the fps reported
+        # alongside them must drop proportionally -- otherwise a saved
+        # output video plays back vid_stride times too fast (mirrors how
+        # VideoSource's stride is compensated for in run_video_inference).
+        effective_fps = self.fps / self._vid_stride
+
         for frame_idx, item in enumerate(self._images):
             if frame_idx % self._vid_stride:
                 continue
@@ -634,7 +640,7 @@ class ImageSequenceSource:
                 frame_idx=frame_idx,
                 source_index=0,
                 source_label=label,
-                fps=self.fps,
+                fps=effective_fps,
             )
 
 

--- a/libreyolo/utils/video.py
+++ b/libreyolo/utils/video.py
@@ -227,6 +227,7 @@ class VideoWriter:
             )
 
         self._path = str(path)
+        self._frame_size = (int(width), int(height))
         Path(path).parent.mkdir(parents=True, exist_ok=True)
 
         self.codec = None
@@ -277,6 +278,16 @@ class VideoWriter:
 
     def write_frame(self, frame_bgr: np.ndarray):
         """Write a single BGR frame."""
+        if self._writer is None:
+            raise RuntimeError("VideoWriter has already been released")
+        height, width = frame_bgr.shape[:2]
+        if (width, height) != self._frame_size:
+            expected_width, expected_height = self._frame_size
+            raise ValueError(
+                "Video frame size changed from "
+                f"{expected_width}x{expected_height} to {width}x{height}. "
+                "All frames in a saved video must have the same dimensions."
+            )
         self._writer.write(frame_bgr)
 
     def release(self):
@@ -491,7 +502,11 @@ def run_video_inference(
                     frame_bgr = frame_item.frame_bgr
                     frame_idx = int(frame_item.frame_idx)
                     source_index = int(frame_item.source_index)
-                    source_label = str(frame_item.source_label)
+                    source_label = (
+                        str(frame_item.source_label)
+                        if frame_item.source_label is not None
+                        else None
+                    )
                     frame_fps = float(frame_item.fps or effective_fps or 30.0)
                 else:
                     frame_bgr, frame_idx = frame_item

--- a/tests/e2e/test_tracking.py
+++ b/tests/e2e/test_tracking.py
@@ -22,8 +22,10 @@ from pathlib import Path
 
 import pytest
 import torch
+from PIL import Image
 
 from libreyolo import LibreYOLO
+from libreyolo.utils.video import VideoSource
 
 from .conftest import (
     cuda_cleanup,
@@ -94,6 +96,17 @@ def _run_tracker(model, video, n_frames=30, **track_kwargs):
         frames.append(result)
         if i + 1 >= n_frames:
             break
+    return frames
+
+
+def _load_image_sequence(video, n_frames=3):
+    """Load consecutive video frames as an in-memory RGB image sequence."""
+    frames = []
+    with VideoSource(video) as source:
+        for frame_bgr, _ in source:
+            frames.append(Image.fromarray(frame_bgr[:, :, ::-1].copy()))
+            if len(frames) >= n_frames:
+                break
     return frames
 
 
@@ -272,6 +285,15 @@ class TestTrackingYOLO9:
             assert f.track_id is not None
             assert len(f) > 0
 
+    def test_track_image_sequence(self, model, video_path):
+        frames = _load_image_sequence(video_path)
+
+        results = list(model.track(frames))
+
+        assert len(results) == len(frames)
+        assert all(result.track_id is not None for result in results)
+        assert all(result.path is None for result in results)
+
     def test_id_consistency(self, model, video_path):
         """IDs should persist across consecutive frames."""
         frames = _run_tracker(model, video_path, n_frames=10)
@@ -365,6 +387,15 @@ class TestTrackingRFDETR:
         for f in frames:
             assert f.track_id is not None
             assert len(f) > 0
+
+    def test_track_image_sequence(self, model, video_path):
+        frames = _load_image_sequence(video_path)
+
+        results = list(model.track(frames))
+
+        assert len(results) == len(frames)
+        assert all(result.track_id is not None for result in results)
+        assert all(result.path is None for result in results)
 
     def test_id_consistency(self, model, video_path):
         """IDs should persist across consecutive frames."""

--- a/tests/unit/test_live_sources.py
+++ b/tests/unit/test_live_sources.py
@@ -9,9 +9,11 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import torch
+from PIL import Image
 
 from libreyolo.utils import source as source_module
 from libreyolo.utils.source import (
+    ImageSequenceSource,
     MultiStreamSource,
     SourceKind,
     StreamFrame,
@@ -262,3 +264,78 @@ def test_shared_video_loop_preserves_per_camera_path_and_frame_index():
         ("camera-a", 4),
         ("camera-b", 5),
     ]
+
+
+def test_list_of_images_dispatches_as_image_batch():
+    images = [Image.new("RGB", (4, 4)), Image.new("RGB", (4, 4))]
+    spec = classify_source(images)
+    assert spec.kind == SourceKind.IMAGE_BATCH
+    assert spec.items == tuple(images)
+
+
+def test_bare_generator_dispatches_as_image_sequence():
+    def frames():
+        yield Image.new("RGB", (4, 4))
+
+    gen = frames()
+    spec = classify_source(gen)
+    assert spec.kind == SourceKind.IMAGE_SEQUENCE
+    assert spec.source is gen
+
+
+def test_ndarray_is_not_mistaken_for_an_image_sequence():
+    # np.ndarray has __iter__ but not __next__; must stay a single IMAGE.
+    assert classify_source(np.zeros((4, 4, 3), dtype=np.uint8)).kind == SourceKind.IMAGE
+
+
+class TestImageSequenceSource:
+    def test_iterates_a_finite_list_reporting_its_length(self):
+        images = [Image.new("RGB", (4, 4)) for _ in range(3)]
+        src = ImageSequenceSource(images, fps=15.0, save_name="clip")
+
+        assert src.total_frames == 3
+        with src as opened:
+            packets = list(opened)
+
+        assert [p.frame_idx for p in packets] == [0, 1, 2]
+        assert all(p.fps == 15.0 for p in packets)
+        assert all(p.frame_bgr.shape == (4, 4, 3) for p in packets)
+        assert src.save_name == "clip"
+
+    def test_iterates_a_lazy_iterator_reporting_unknown_length(self):
+        def frames():
+            for _ in range(5):
+                yield Image.new("RGB", (4, 4))
+
+        src = ImageSequenceSource(frames())
+        assert src.total_frames == 0
+
+        packets = list(src)
+        assert [p.frame_idx for p in packets] == [0, 1, 2, 3, 4]
+
+    def test_applies_vid_stride(self):
+        images = [Image.new("RGB", (4, 4)) for _ in range(5)]
+        src = ImageSequenceSource(images, vid_stride=2)
+
+        packets = list(src)
+        assert [p.frame_idx for p in packets] == [0, 2, 4]
+
+    def test_path_items_are_reported_as_the_source_label(self, tmp_path):
+        path = tmp_path / "frame.png"
+        Image.new("RGB", (4, 4)).save(path)
+        src = ImageSequenceSource([path])
+
+        (packet,) = list(src)
+        assert packet.source_label == str(path)
+
+    def test_in_memory_items_have_no_source_label(self):
+        src = ImageSequenceSource([Image.new("RGB", (4, 4))])
+
+        (packet,) = list(src)
+        assert packet.source_label is None
+
+    def test_reiteration_raises(self):
+        src = ImageSequenceSource([Image.new("RGB", (4, 4))])
+        list(src)
+        with pytest.raises(RuntimeError, match="already been consumed"):
+            list(src)

--- a/tests/unit/test_live_sources.py
+++ b/tests/unit/test_live_sources.py
@@ -320,6 +320,16 @@ class TestImageSequenceSource:
         packets = list(src)
         assert [p.frame_idx for p in packets] == [0, 2, 4]
 
+    def test_vid_stride_scales_down_reported_fps(self):
+        # Retaining half the frames must halve the reported fps, or a saved
+        # output video (written one retained frame per tick) plays back
+        # vid_stride times too fast.
+        images = [Image.new("RGB", (4, 4)) for _ in range(4)]
+        src = ImageSequenceSource(images, vid_stride=2, fps=30.0)
+
+        packets = list(src)
+        assert all(p.fps == 15.0 for p in packets)
+
     def test_path_items_are_reported_as_the_source_label(self, tmp_path):
         path = tmp_path / "frame.png"
         Image.new("RGB", (4, 4)).save(path)

--- a/tests/unit/test_live_sources.py
+++ b/tests/unit/test_live_sources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ import torch
 from PIL import Image
 
 from libreyolo.utils import source as source_module
+from libreyolo.utils.results import Probs, Results
 from libreyolo.utils.source import (
     ImageSequenceSource,
     MultiStreamSource,
@@ -22,7 +24,6 @@ from libreyolo.utils.source import (
     redact_source,
     resolve_youtube_stream,
 )
-from libreyolo.utils.results import Probs, Results
 from libreyolo.utils.video import run_video_inference
 
 pytestmark = pytest.mark.unit
@@ -288,6 +289,10 @@ def test_ndarray_is_not_mistaken_for_an_image_sequence():
     assert classify_source(np.zeros((4, 4, 3), dtype=np.uint8)).kind == SourceKind.IMAGE
 
 
+def test_bytesio_is_not_mistaken_for_an_image_sequence():
+    assert classify_source(io.BytesIO(b"image bytes")).kind == SourceKind.IMAGE
+
+
 class TestImageSequenceSource:
     def test_iterates_a_finite_list_reporting_its_length(self):
         images = [Image.new("RGB", (4, 4)) for _ in range(3)]
@@ -319,6 +324,7 @@ class TestImageSequenceSource:
 
         packets = list(src)
         assert [p.frame_idx for p in packets] == [0, 2, 4]
+        assert src.total_frames == 3
 
     def test_vid_stride_scales_down_reported_fps(self):
         # Retaining half the frames must halve the reported fps, or a saved
@@ -329,6 +335,19 @@ class TestImageSequenceSource:
 
         packets = list(src)
         assert all(p.fps == 15.0 for p in packets)
+
+    def test_bgr_numpy_frames_preserve_their_color_format(self):
+        frame_bgr = np.zeros((4, 4, 3), dtype=np.uint8)
+        frame_bgr[:] = [0, 0, 255]
+        src = ImageSequenceSource([frame_bgr], color_format="bgr")
+
+        (packet,) = list(src)
+        assert packet.frame_bgr[0, 0].tolist() == [0, 0, 255]
+
+    @pytest.mark.parametrize("fps", [0, -1, np.nan, np.inf])
+    def test_rejects_invalid_fps(self, fps):
+        with pytest.raises(ValueError, match="fps must be a finite value > 0"):
+            ImageSequenceSource([Image.new("RGB", (4, 4))], fps=fps)
 
     def test_path_items_are_reported_as_the_source_label(self, tmp_path):
         path = tmp_path / "frame.png"

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -757,3 +757,40 @@ class TestTrackImageSequences:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             list(BaseModel.track(model, _make_frames(2), fps=12.0, tracker="ocsort"))
+
+    def test_mismatched_typed_tracker_config_frame_rate_warns(self):
+        # tracker_config is never silently overwritten (same contract as
+        # track_conf), but its frame_rate silently governs lost-track
+        # timing for this sequence, so a mismatch must not stay quiet.
+        model = _StubTrackModel()
+        config = TrackConfig()  # frame_rate=30, left at the class default
+
+        with pytest.warns(UserWarning, match="frame_rate"):
+            list(
+                BaseModel.track(
+                    model,
+                    _make_frames(6),
+                    fps=30.0,
+                    vid_stride=3,  # retained rate is 10, not config's 30
+                    tracker_config=config,
+                )
+            )
+
+        # tracker_config itself is never mutated.
+        assert config.frame_rate == 30
+
+    def test_typed_tracker_config_frame_rate_already_matching_is_quiet(self):
+        model = _StubTrackModel()
+        config = TrackConfig(frame_rate=10)  # caller already did the math
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            list(
+                BaseModel.track(
+                    model,
+                    _make_frames(6),
+                    fps=30.0,
+                    vid_stride=3,
+                    tracker_config=config,
+                )
+            )

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -692,6 +692,24 @@ class TestTrackImageSequences:
 
         assert captured["frame_rate"] == 12
 
+    def test_fps_seeds_frame_rate_at_the_retained_frame_cadence(self, monkeypatch):
+        # tracker.update() only ever sees retained frames, so frame_rate
+        # must be scaled by vid_stride -- not the raw fps -- or a lost
+        # track's real-world expiry stretches out by vid_stride times.
+        captured = {}
+        original = TrackConfig.from_kwargs.__func__
+
+        def spy(cls, **kwargs):
+            captured.update(kwargs)
+            return original(cls, **kwargs)
+
+        monkeypatch.setattr(TrackConfig, "from_kwargs", classmethod(spy))
+        model = _StubTrackModel()
+
+        list(BaseModel.track(model, _make_frames(6), fps=30.0, vid_stride=3))
+
+        assert captured["frame_rate"] == 10
+
     def test_explicit_frame_rate_kwarg_overrides_fps(self, monkeypatch):
         captured = {}
         original = TrackConfig.from_kwargs.__func__

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -1,5 +1,6 @@
 """Unit tests for the ByteTrack tracking module."""
 
+import warnings
 from pathlib import Path
 
 import pytest
@@ -675,3 +676,66 @@ class TestTrackImageSequences:
 
         assert len(results) == 3
         assert output_path.exists()
+
+    def test_fps_seeds_bytetrack_frame_rate_for_image_sequences(self, monkeypatch):
+        captured = {}
+        original = TrackConfig.from_kwargs.__func__
+
+        def spy(cls, **kwargs):
+            captured.update(kwargs)
+            return original(cls, **kwargs)
+
+        monkeypatch.setattr(TrackConfig, "from_kwargs", classmethod(spy))
+        model = _StubTrackModel()
+
+        list(BaseModel.track(model, _make_frames(2), fps=12.0))
+
+        assert captured["frame_rate"] == 12
+
+    def test_explicit_frame_rate_kwarg_overrides_fps(self, monkeypatch):
+        captured = {}
+        original = TrackConfig.from_kwargs.__func__
+
+        def spy(cls, **kwargs):
+            captured.update(kwargs)
+            return original(cls, **kwargs)
+
+        monkeypatch.setattr(TrackConfig, "from_kwargs", classmethod(spy))
+        model = _StubTrackModel()
+
+        list(BaseModel.track(model, _make_frames(2), fps=12.0, frame_rate=5))
+
+        assert captured["frame_rate"] == 5
+
+    def test_fps_does_not_seed_frame_rate_for_video_sources(self, tmp_path, monkeypatch):
+        cv2 = pytest.importorskip("cv2", reason="opencv-python required for video tests")
+        path = str(tmp_path / "clip.mp4")
+        writer = cv2.VideoWriter(
+            path, cv2.VideoWriter_fourcc(*"mp4v"), 30.0, (20, 16)
+        )
+        for _ in range(2):
+            writer.write(np.zeros((16, 20, 3), dtype=np.uint8))
+        writer.release()
+
+        captured = {}
+        original = TrackConfig.from_kwargs.__func__
+
+        def spy(cls, **kwargs):
+            captured.update(kwargs)
+            return original(cls, **kwargs)
+
+        monkeypatch.setattr(TrackConfig, "from_kwargs", classmethod(spy))
+        model = _StubTrackModel()
+
+        list(BaseModel.track(model, path, fps=12.0))
+
+        assert "frame_rate" not in captured
+
+    def test_fps_does_not_leak_into_ocsort_config(self):
+        # OCSortConfig has no frame_rate field; passing it through would
+        # otherwise trigger a spurious "unknown config key" warning.
+        model = _StubTrackModel()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            list(BaseModel.track(model, _make_frames(2), fps=12.0, tracker="ocsort"))

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -710,6 +710,24 @@ class TestTrackImageSequences:
 
         assert captured["frame_rate"] == 10
 
+    def test_fps_is_not_pre_rounded_before_reaching_track_config(self, monkeypatch):
+        # tracker.py truncates (int()) frame_rate itself; pre-rounding here
+        # too would double-round and can shift max_time_lost by a frame at
+        # the boundary (e.g. an exact 6.6 cadence: round()->7, int()->6).
+        captured = {}
+        original = TrackConfig.from_kwargs.__func__
+
+        def spy(cls, **kwargs):
+            captured.update(kwargs)
+            return original(cls, **kwargs)
+
+        monkeypatch.setattr(TrackConfig, "from_kwargs", classmethod(spy))
+        model = _StubTrackModel()
+
+        list(BaseModel.track(model, _make_frames(6), fps=33.0, vid_stride=5))
+
+        assert captured["frame_rate"] == pytest.approx(6.6)
+
     def test_explicit_frame_rate_kwarg_overrides_fps(self, monkeypatch):
         captured = {}
         original = TrackConfig.from_kwargs.__func__

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -1,13 +1,16 @@
 """Unit tests for the ByteTrack tracking module."""
 
+import io
 import warnings
 from pathlib import Path
 
-import pytest
 import numpy as np
+import pytest
 import torch
 from PIL import Image
 
+from libreyolo.models.base.inference import InferenceRunner
+from libreyolo.models.base.model import BaseModel
 from libreyolo.tracking.config import TrackConfig
 from libreyolo.tracking.kalman_filter import KalmanFilterXYAH
 from libreyolo.tracking.matching import (
@@ -18,8 +21,6 @@ from libreyolo.tracking.matching import (
 )
 from libreyolo.tracking.strack import STrack, TrackState
 from libreyolo.tracking.tracker import ByteTracker
-from libreyolo.models.base.model import BaseModel
-from libreyolo.models.base.inference import InferenceRunner
 from libreyolo.utils.image_loader import ImageLoader
 from libreyolo.utils.results import Boxes, Masks, Results
 
@@ -610,6 +611,7 @@ class TestTrackImageSequences:
 
         assert len(results) == 4
         assert [r.frame_idx for r in results] == [0, 1, 2, 3]
+        assert all(r.path is None for r in results)
         # The fixed-position detection matches itself frame over frame, so
         # ByteTrack keeps assigning it the same identity.
         assert [int(r.track_id[0]) for r in results] == [1, 1, 1, 1]
@@ -652,6 +654,35 @@ class TestTrackImageSequences:
 
         assert len(results) == 1
 
+    def test_tracks_a_single_bytesio_image(self):
+        buffer = io.BytesIO()
+        Image.new("RGB", (20, 16)).save(buffer, format="PNG")
+        buffer.seek(0)
+        model = _StubTrackModel()
+
+        results = list(BaseModel.track(model, buffer))
+
+        assert len(results) == 1
+
+    def test_bgr_numpy_frames_reach_the_model_as_rgb(self):
+        model = _StubTrackModel()
+        seen_pixels = []
+        original_preprocess = model._preprocess
+
+        def capture_preprocess(image, color_format="auto", input_size=None):
+            seen_pixels.append(np.asarray(image)[0, 0].tolist())
+            return original_preprocess(
+                image, color_format=color_format, input_size=input_size
+            )
+
+        model._preprocess = capture_preprocess
+        frame_bgr = np.zeros((16, 20, 3), dtype=np.uint8)
+        frame_bgr[:] = [0, 0, 255]
+
+        list(BaseModel.track(model, [frame_bgr], color_format="bgr"))
+
+        assert seen_pixels == [[255, 0, 0]]
+
     def test_empty_directory_yields_no_results(self, tmp_path):
         model = _StubTrackModel()
 
@@ -676,6 +707,29 @@ class TestTrackImageSequences:
 
         assert len(results) == 3
         assert output_path.exists()
+
+    def test_save_rejects_images_with_changed_dimensions(self, tmp_path):
+        pytest.importorskip("cv2", reason="opencv-python required for video tests")
+        model = _StubTrackModel()
+        output_path = tmp_path / "tracked.mp4"
+        frames = [
+            Image.new("RGB", (20, 16)),
+            Image.new("RGB", (30, 24)),
+        ]
+
+        with pytest.raises(ValueError, match="frame size changed"):
+            list(
+                BaseModel.track(
+                    model, frames, save=True, output_path=str(output_path)
+                )
+            )
+
+    @pytest.mark.parametrize("fps", [0, -1, np.nan, np.inf])
+    def test_rejects_invalid_image_sequence_fps(self, fps):
+        model = _StubTrackModel()
+
+        with pytest.raises(ValueError, match="fps must be a finite value > 0"):
+            list(BaseModel.track(model, _make_frames(1), fps=fps))
 
     def test_fps_seeds_bytetrack_frame_rate_for_image_sequences(self, monkeypatch):
         captured = {}

--- a/tests/unit/test_tracking.py
+++ b/tests/unit/test_tracking.py
@@ -1,5 +1,7 @@
 """Unit tests for the ByteTrack tracking module."""
 
+from pathlib import Path
+
 import pytest
 import numpy as np
 import torch
@@ -16,6 +18,8 @@ from libreyolo.tracking.matching import (
 from libreyolo.tracking.strack import STrack, TrackState
 from libreyolo.tracking.tracker import ByteTracker
 from libreyolo.models.base.model import BaseModel
+from libreyolo.models.base.inference import InferenceRunner
+from libreyolo.utils.image_loader import ImageLoader
 from libreyolo.utils.results import Boxes, Masks, Results
 
 pytestmark = pytest.mark.unit
@@ -533,3 +537,141 @@ class TestDrawBoxesWithTrackIds:
 
         draw_boxes(img, [[10, 10, 90, 90]], [0.9], [0], track_ids=[1])
         assert np.array_equal(np.array(img), original_arr)
+
+
+# --------------------------------------------------------------------------
+# track() over image sequences, not just video files
+# --------------------------------------------------------------------------
+
+
+class _StubTrackModel:
+    """Minimal stand-in for a BaseModel driving BaseModel.track().
+
+    Always reports one fixed-position detection, which is enough for
+    ByteTrack to assign and keep a single, stable track_id across frames.
+    """
+
+    task = "detect"
+    names = {0: "thing"}
+    device = torch.device("cpu")
+
+    def __init__(self, box=(1.0, 1.0, 5.0, 5.0), score=0.9):
+        self._box = list(box)
+        self._score = score
+
+    def _get_input_size(self):
+        return 32
+
+    def _get_model_name(self):
+        return "stub"
+
+    def _preprocess(self, image, color_format="auto", input_size=None):
+        pil = ImageLoader.load(image, color_format=color_format)
+        return torch.zeros(1, 3, 32, 32), pil, pil.size, 1.0
+
+    def _forward(self, tensor):
+        return tensor
+
+    def _postprocess(
+        self,
+        output,
+        conf,
+        iou,
+        original_size,
+        max_det=300,
+        ratio=1.0,
+        classes=None,
+        **kwargs,
+    ):
+        return {
+            "boxes": [self._box],
+            "scores": [self._score],
+            "classes": [0],
+            "num_detections": 1,
+        }
+
+    @property
+    def _runner(self):
+        if getattr(self, "_runner_instance", None) is None:
+            self._runner_instance = InferenceRunner(self)
+        return self._runner_instance
+
+
+def _make_frames(n, size=(20, 16), color=(50, 50, 50)):
+    return [Image.new("RGB", size, color) for _ in range(n)]
+
+
+class TestTrackImageSequences:
+    def test_tracks_a_list_of_pil_images(self):
+        model = _StubTrackModel()
+
+        results = list(BaseModel.track(model, _make_frames(4)))
+
+        assert len(results) == 4
+        assert [r.frame_idx for r in results] == [0, 1, 2, 3]
+        # The fixed-position detection matches itself frame over frame, so
+        # ByteTrack keeps assigning it the same identity.
+        assert [int(r.track_id[0]) for r in results] == [1, 1, 1, 1]
+
+    def test_tracks_a_directory_of_images_in_sorted_order(self, tmp_path):
+        for i in range(3):
+            Image.new("RGB", (20, 16), (i * 40, 0, 0)).save(tmp_path / f"{i:03d}.png")
+        model = _StubTrackModel()
+
+        results = list(BaseModel.track(model, tmp_path))
+
+        assert len(results) == 3
+        assert [Path(r.path).name for r in results] == [
+            "000.png",
+            "001.png",
+            "002.png",
+        ]
+
+    def test_tracks_a_lazy_generator_without_materializing_it(self):
+        model = _StubTrackModel()
+        pulled = []
+
+        def frames():
+            for i in range(1000):
+                pulled.append(i)
+                yield Image.new("RGB", (20, 16))
+
+        gen = BaseModel.track(model, frames())
+        first_three = [next(gen) for _ in range(3)]
+
+        assert len(first_three) == 3
+        # Only as many source frames were pulled as were actually consumed
+        # from the tracking generator -- the iterator must stay lazy.
+        assert len(pulled) == 3
+
+    def test_tracks_a_single_image_as_a_one_frame_sequence(self):
+        model = _StubTrackModel()
+
+        results = list(BaseModel.track(model, Image.new("RGB", (20, 16))))
+
+        assert len(results) == 1
+
+    def test_empty_directory_yields_no_results(self, tmp_path):
+        model = _StubTrackModel()
+
+        assert list(BaseModel.track(model, tmp_path)) == []
+
+    def test_live_stream_sources_are_not_yet_supported(self):
+        model = _StubTrackModel()
+
+        with pytest.raises(NotImplementedError, match="stream"):
+            next(BaseModel.track(model, 0))
+
+    def test_save_writes_output_video_for_an_image_list(self, tmp_path):
+        pytest.importorskip("cv2", reason="opencv-python required for video tests")
+        model = _StubTrackModel()
+        output_path = tmp_path / "tracked.mp4"
+
+        results = list(
+            BaseModel.track(
+                model, _make_frames(3), save=True, output_path=str(output_path)
+            )
+        )
+
+        assert len(results) == 3
+        assert output_path.exists()

--- a/tests/unit/test_video.py
+++ b/tests/unit/test_video.py
@@ -148,6 +148,24 @@ class TestVideoSource:
 
 
 class TestVideoWriter:
+    def test_rejects_frames_with_changed_dimensions(self, tmp_path, monkeypatch):
+        class FakeWriter:
+            def isOpened(self):
+                return True
+
+            def write(self, frame):
+                raise AssertionError("mismatched frame must not reach OpenCV")
+
+            def release(self):
+                pass
+
+        monkeypatch.setattr(cv2, "VideoWriter", lambda *args: FakeWriter())
+        writer = VideoWriter(tmp_path / "output.avi", fps=10.0, width=32, height=32)
+
+        with pytest.raises(ValueError, match="frame size changed"):
+            writer.write_frame(np.zeros((16, 32, 3), dtype=np.uint8))
+        writer.release()
+
     def test_mp4_prefers_h264_codec(self, tmp_path, monkeypatch):
         from libreyolo.utils import video as video_mod
 


### PR DESCRIPTION
This PR enables the use of tracking on image sequences in addition to video files.
Adds a new source kind: `IMAGE_SEQUENCE ` which wraps a finite list/directory or a lazy iterator of images into the same FrameSource protocol that VideoSource/StreamSource already satisfy.

track() now dispatches through classify_source() like predict() does, instead of hardcoding a video-file path.
A directory of images, a list/tuple of already-loaded images, a single image, or a lazy generator of images can now be tracked the same way a video file can.

## Code provenance

original code written for this PR

## Issues

closes #823 












<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends `track()` to accept individual images, image collections, directories, and lazy image iterators while preserving video tracking.
- Adds source classification and a lazy `ImageSequenceSource` adapter.
- Aligns saved-video and tracker timing with the retained-frame cadence.
- Preserves source labels and rejects dimension changes while writing videos.
- Adds unit and end-to-end coverage for image-sequence tracking, saving, stride, FPS, color handling, and lazy consumption.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libreyolo/models/base/model.py | Extends tracking dispatch to image-sequence sources and now configures default ByteTrack and BoT-SORT timing from the retained-frame cadence. |
| libreyolo/utils/source.py | Adds lazy iterator classification and an image-sequence frame source that applies stride once while preserving frame metadata. |
| libreyolo/utils/video.py | Supports nullable source labels and validates saved-video frame dimensions before writing. |
| tests/unit/test_tracking.py | Covers image-sequence tracking inputs, lazy consumption, saving, FPS validation, cadence configuration, and typed-configuration warnings. |
| tests/unit/test_live_sources.py | Covers image-sequence classification, iteration, stride, effective FPS, labels, color conversion, and one-shot consumption. |
| tests/unit/test_video.py | Verifies that frames with dimensions differing from the initialized video writer are rejected. |
| tests/e2e/test_tracking.py | Exercises image-sequence tracking with both flagship model families. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[track source] --> B[classify_source]
  B -->|Video| C[VideoSource]
  B -->|Image, batch, directory, or iterator| D[ImageSequenceSource]
  D --> E[Apply vid_stride and retained FPS]
  C --> F[Shared frame inference loop]
  E --> F
  F --> G[Detection]
  G --> H[Tracker update]
  H --> I[Results with track IDs]
  I --> J[Optional saved video]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Fix image sequence tracking edge cases"](https://github.com/libreyolo/libreyolo/commit/1c7fe651c2f5549c9be7e72e815c80474c11b743) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57405673)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Inference pipeline](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/inference-pipeline.md)
- Knowledge Base — [Input sources and preprocessing](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/input-preprocessing.md)
- Knowledge Base — [Multi-object tracking](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/object-tracking.md)
</details>


<!-- /greptile_comment -->