### PR TITLE
Fix num classes bounds check

### DIFF
--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -389,6 +389,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     label_files=label_files,
                     img_size=img_size,
                     preproc=preproc,
+                    num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
                 )
             elif ann_file.exists():
@@ -416,6 +417,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     label_files=label_files,
                     img_size=img_size,
                     preproc=preproc,
+                    num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
                 )
         elif self.config.data_dir:
@@ -437,6 +439,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     split="train",
                     img_size=img_size,
                     preproc=preproc,
+                    num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
                 )
         else:

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -445,6 +445,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     load_segments=load_segments,
+                    num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
                 )
             elif ann_file.exists():
@@ -474,6 +475,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     load_segments=load_segments,
+                    num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
                 )
         elif self.config.data_dir:
@@ -497,6 +499,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     img_size=img_size,
                     preproc=preproc,
                     load_segments=load_segments,
+                    num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
                 )
         else:

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -837,7 +837,7 @@ class BaseTrainer(ABC):
                     preproc=preproc,
                     load_segments=load_segments,
                     load_obb=load_obb,
-                    num_classes=self.num_classes if load_obb else None,
+                    num_classes=self.num_classes,
                     single_cls=self.config.single_cls,
                 )
             elif ann_file.exists():
@@ -880,7 +880,7 @@ class BaseTrainer(ABC):
                     preproc=preproc,
                     load_segments=load_segments,
                     load_obb=load_obb,
-                    num_classes=self.num_classes if load_obb else None,
+                    num_classes=self.num_classes,
                     single_cls=self.config.single_cls,
                 )
         elif self.config.data_dir:
@@ -911,7 +911,7 @@ class BaseTrainer(ABC):
                     preproc=preproc,
                     load_segments=load_segments,
                     load_obb=load_obb,
-                    num_classes=self.num_classes if load_obb else None,
+                    num_classes=self.num_classes,
                     single_cls=self.config.single_cls,
                 )
         else:

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -343,6 +343,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 split=split_name,
                 img_size=img_size,
                 preproc=self.val_preproc,
+                num_classes=int(self.nc),
                 single_cls=self._single_cls_enabled(),
                 **dataset_kwargs,
             )

--- a/tests/unit/test_num_classes_bound_check.py
+++ b/tests/unit/test_num_classes_bound_check.py
@@ -1,0 +1,120 @@
+"""Regression coverage: num_classes must be threaded through for non-OBB
+YOLO training and for the plain YOLO-directory-format validation path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import yaml
+from PIL import Image
+
+from libreyolo.validation.config import ValidationConfig
+from libreyolo.validation.detection_validator import DetectionValidator
+
+pytestmark = pytest.mark.unit
+
+
+def _write_train_dataset(tmp_path, bad_class_id=5, nc=1):
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    Image.new("RGB", (64, 48), color="white").save(img_dir / "sample.jpg")
+    (lbl_dir / "sample.txt").write_text(f"{bad_class_id} 0.5 0.5 0.2 0.2\n")
+
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "train": "images/train",
+                "nc": nc,
+                "names": [f"c{i}" for i in range(nc)],
+            }
+        )
+    )
+    return data_yaml
+
+
+@pytest.mark.parametrize(
+    ("trainer_import", "size"),
+    [
+        # Uses the shared BaseTrainer._setup_data (libreyolo/training/trainer.py).
+        ("libreyolo.models.rtdetr.trainer:RTDETRTrainer", "r18"),
+        # DFINE/DEIM mirror BaseTrainer._setup_data by hand (their own
+        # _setup_data override, "duplicated from the parent for clarity") to
+        # wire a family-specific collate_fn -- same bug, independent copy.
+        ("libreyolo.models.dfine.trainer:DFINETrainer", "n"),
+        ("libreyolo.models.deim.trainer:DEIMTrainer", "n"),
+    ],
+)
+def test_trainer_setup_data_warns_and_drops_out_of_range_class_non_obb(
+    tmp_path, trainer_import, size
+):
+    """A class id >= nc in a plain detect dataset must be skipped with a
+    warning at data-loading time, not silently kept for the loss to choke
+    on later."""
+    module_name, class_name = trainer_import.split(":")
+    module = __import__(module_name, fromlist=[class_name])
+    trainer_cls = getattr(module, class_name)
+
+    data_yaml = _write_train_dataset(tmp_path, bad_class_id=5, nc=1)
+    trainer = trainer_cls(
+        model=torch.nn.Identity(),
+        size=size,
+        num_classes=1,
+        data=str(data_yaml),
+        epochs=1,
+        batch=1,
+        imgsz=64,
+        device="cpu",
+        amp=False,
+        ema=False,
+        workers=0,
+        eval_interval=-1,
+    )
+
+    with pytest.warns(UserWarning, match="out of range"):
+        trainer._setup_data()
+
+    raw_dataset = trainer.train_loader.dataset.dataset
+    assert len(raw_dataset.annotations[0][0]) == 0
+
+
+def _write_val_dataset(tmp_path, bad_class_id=5):
+    img_dir = tmp_path / "images" / "val"
+    lbl_dir = tmp_path / "labels" / "val"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    Image.new("RGB", (64, 48), color="white").save(img_dir / "sample.jpg")
+    (lbl_dir / "sample.txt").write_text(f"{bad_class_id} 0.5 0.5 0.2 0.2\n")
+
+
+def test_validator_warns_on_plain_yolo_directory_format(tmp_path):
+    """``data_dir=`` skips ``load_data_config()``'s file-list pre-resolution
+    entirely and lands in the plain "YOLO directory format" branch, which
+    used to omit num_classes altogether (unlike the file-list-mode and
+    COCO-JSON branches, which always passed it)."""
+    _write_val_dataset(tmp_path, bad_class_id=5)
+
+    model = SimpleNamespace(
+        nb_classes=1,
+        _checkpoint_train_config=lambda: {},
+        _get_val_preprocessor=lambda img_size: None,
+    )
+    config = ValidationConfig(
+        data_dir=str(tmp_path),
+        split="val",
+        batch_size=1,
+        num_workers=0,
+        device="cpu",
+    )
+    validator = DetectionValidator(model, config)
+
+    with pytest.warns(UserWarning, match="out of range"):
+        dataloader = validator._setup_dataloader()
+
+    assert len(dataloader.dataset.annotations[0][0]) == 0


### PR DESCRIPTION
## Description

Trainer._setup_data() currently only hands num_classes into the YOLO label parser for OBB training. For the much more common detect/segment path, num_classes=None is passed instead. That disables the bounds check in parse_yolo_label_line(). An out-of-range annotation class id (e.g. from a shrunk nc in data.yaml, or a plain labeling mistake) is not caught at data-loading time.

## Suggested fix
Always pass num_classes into YOLODataset (and the equivalent DetectionValidator dataset construction) for every YOLO training/validation path, not just OBB:

drop the if load_obb else None conditional in Trainer._setup_data() (both call sites), and fix _dataset_kwargs() in detection_validator.py to include num_classes for the YOLO-directory-format branch too.

## Code provenance

original code written for this PR, and/or

resolves #826 

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR consistently supplies the configured class count when constructing YOLO datasets, enabling early rejection of out-of-range labels in ordinary detection and segmentation paths.

- Threads `num_classes` through shared, DEIM, and DFINE trainer dataset construction.
- Adds the class bound to direct-directory detection validation.
- Adds regression coverage for training and validation with invalid class IDs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The changed paths propagate dataset-aligned class bounds into YOLO parsing, and existing single-class remapping and supported OBB entry-point constraints prevent the plausible class-collapsing regressions.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libreyolo/training/trainer.py | Passes the resolved dataset class count into all shared YOLO training dataset branches without introducing a reachable regression. |
| libreyolo/models/deim/trainer.py | Applies the same class-bound validation to DEIM’s duplicated detection dataset setup. |
| libreyolo/models/dfine/trainer.py | Applies the same class-bound validation to DFINE’s duplicated detection and segmentation dataset setup. |
| libreyolo/validation/detection_validator.py | Supplies the dataset-derived validation class count to the direct YOLO-directory dataset branch. |
| tests/unit/test_num_classes_bound_check.py | Covers invalid class filtering across shared, DEIM, and DFINE training setup and direct-directory validation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Trainer or validator class count] --> B[YOLODataset]
    B --> C[Parse label row]
    C --> D{Class ID in range?}
    D -->|Yes| E[Keep annotation]
    D -->|No| F[Warn and skip annotation]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add regression tests for num\_classes bou..."](https://github.com/libreyolo/libreyolo/commit/0a7d36ac217196fa051c1a343ea47e36dcbef853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57468354)</sub>

<!-- /greptile_comment -->