### PR TITLE
Fix rfdetr dinov2 overwriting train dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- **RF-DETR, DINOv2 and VLM training no longer overwrite the previous run
+  (#833).** Through the Python API, `train()` now increments the run
+  directory like every other family (`exist_ok=False` by default) instead of
+  writing into the same folder. The default location moves from
+  `runs/train` to `runs/train/rfdetr_exp` and `runs/train/dinov2_exp`;
+  the DINOv2 CLI default name is now `dinov2_exp`. `resume=True` keeps the
+  original run directory. DINOv2 `resume=` previously did nothing and now
+  restores the checkpoint before continuing.
 - **Guardless Python multi-GPU launch (#817).**
   `model.train(device=[0, 1])` and `device="0,1"` now coordinate local DDP
   ranks without re-importing and repeating an unguarded user script. Guarded

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -416,7 +416,9 @@ def _build_rfdetr_train_kwargs(
         mkdir=True,
     )
 
-    kwargs: dict[str, Any] = {"output_dir": str(output_dir)}
+    # The run dir was already incremented and created above, so the wrapper
+    # must not increment it a second time (its own default is exist_ok=False).
+    kwargs: dict[str, Any] = {"output_dir": str(output_dir), "exist_ok": True}
 
     direct_mappings = {
         "epochs": "epochs",

--- a/libreyolo/models/dinov2/config.py
+++ b/libreyolo/models/dinov2/config.py
@@ -1,0 +1,20 @@
+"""Training configuration for LibreDINOv2.
+
+``DINOv2Trainer`` inherits all training logic from ``RFDETRTrainer`` (optimizer,
+scheduler, freeze groups, augmentation), so this subclasses ``RFDETRConfig``
+rather than the bare ``TrainConfig`` — it needs every field RFDETRTrainer reads
+(``ema``, ``backbone_lr_mult``, ``amp``, ``scheduler``, ...) to stay in sync
+with RF-DETR's config automatically. Only DINOv2-specific defaults are
+overridden here.
+"""
+
+from dataclasses import dataclass
+
+from ..rfdetr.config import RFDETRConfig
+
+
+@dataclass(kw_only=True)
+class DINOv2Config(RFDETRConfig):
+    """CLI-visible LibreDINOv2 fine-tuning defaults."""
+
+    name: str = "dinov2_exp"

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -42,10 +42,12 @@ from ...tasks import normalize_task
 from ...utils.image_loader import ImageInput, ImageLoader
 from ...utils.serialization import load_trusted_torch_file
 from ..base.model import BaseModel
-from ..rfdetr.config import RFDETRConfig
+from .config import DINOv2Config
 from libreyolo.training.ddp_spawn import ddp_aware
 
 logger = logging.getLogger(__name__)
+
+_TRAIN_DEFAULTS = DINOv2Config()
 
 
 class _DINOv2ModelWrapper(nn.Module):
@@ -268,7 +270,7 @@ class LibreDINOv2(BaseModel):
     WEIGHT_TASKS: ClassVar[Tuple[str, ...]] = ("semantic", "classify")
     DEFAULT_TASK: ClassVar[str] = "semantic"
 
-    TRAIN_CONFIG: ClassVar[type] = RFDETRConfig
+    TRAIN_CONFIG: ClassVar[type] = DINOv2Config
 
     # Stretch-resize and DINOv2 patch divisibility.
     semantic_resize_mode: ClassVar[str] = "stretch"
@@ -751,7 +753,7 @@ class LibreDINOv2(BaseModel):
         epochs: int = 100,
         batch_size: int | None = None,
         lr: float | None = None,
-        output_dir: str = "runs/train",
+        output_dir: str | None = None,
         resume=None,
         callbacks: TrainCallbacks = None,
         **kwargs,
@@ -760,6 +762,10 @@ class LibreDINOv2(BaseModel):
 
         Task is taken from ``self.task``; ``DINOv2Trainer`` (via ``RFDETRTrainer``)
         routes the classify vs semantic data/loss branches accordingly.
+
+        ``output_dir``, when given, splits into ``project`` (parent) and
+        ``name`` (leaf); ``project=`` / ``name=`` kwargs take precedence.
+        Defaults to ``<DINOv2Config.project>/<DINOv2Config.name>`` when omitted.
         """
         if self.task == "embed":
             raise NotImplementedError(
@@ -770,17 +776,23 @@ class LibreDINOv2(BaseModel):
 
         from .trainer import DINOv2Trainer
 
-        output_path = _Path(output_dir)
         train_kwargs = dict(kwargs)
         project = train_kwargs.pop("project", None)
         name = train_kwargs.pop("name", None)
-        exist_ok = train_kwargs.pop("exist_ok", True)
+        exist_ok = train_kwargs.pop("exist_ok", _TRAIN_DEFAULTS.exist_ok)
         batch = train_kwargs.pop("batch", None)
         lr0 = train_kwargs.pop("lr0", None)
-        if project is None:
-            project = output_path.parent
-        if name is None:
-            name = output_path.name
+        if output_dir is not None:
+            output_path = _Path(output_dir)
+            if project is None:
+                project = output_path.parent
+            if name is None:
+                name = output_path.name
+        else:
+            if project is None:
+                project = _TRAIN_DEFAULTS.project
+            if name is None:
+                name = _TRAIN_DEFAULTS.name
 
         if batch is not None and batch_size is not None and batch != batch_size:
             raise ValueError(

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -754,7 +754,7 @@ class LibreDINOv2(BaseModel):
         batch_size: int | None = None,
         lr: float | None = None,
         output_dir: str | None = None,
-        resume=None,
+        resume: str | Path | bool | None = None,
         callbacks: TrainCallbacks = None,
         **kwargs,
     ) -> Dict:
@@ -766,6 +766,9 @@ class LibreDINOv2(BaseModel):
         ``output_dir``, when given, splits into ``project`` (parent) and
         ``name`` (leaf); ``project=`` / ``name=`` kwargs take precedence.
         Defaults to ``<DINOv2Config.project>/<DINOv2Config.name>`` when omitted.
+
+        ``resume``: checkpoint path, or True to resume from this run's own
+        ``weights/last.pt``.
         """
         if self.task == "embed":
             raise NotImplementedError(
@@ -793,6 +796,11 @@ class LibreDINOv2(BaseModel):
                 project = _TRAIN_DEFAULTS.project
             if name is None:
                 name = _TRAIN_DEFAULTS.name
+        run_dir = _Path(project) / str(name)
+        if resume is True:
+            # resume=True reads weights/last.pt from this exact run_dir below;
+            # never let _get_save_dir() increment away from it mid-resume.
+            exist_ok = True
 
         if batch is not None and batch_size is not None and batch != batch_size:
             raise ValueError(
@@ -814,6 +822,10 @@ class LibreDINOv2(BaseModel):
         if resolved_device is None:
             resolved_device = str(self.device)
 
+        resume_path = None
+        if resume:
+            resume_path = run_dir / "weights" / "last.pt" if resume is True else resume
+
         trainer = DINOv2Trainer(
             model=self.model,
             wrapper_model=self,
@@ -832,6 +844,9 @@ class LibreDINOv2(BaseModel):
             callbacks=callbacks,
             **train_kwargs,
         )
+        if resume:
+            trainer.setup()
+            trainer.resume(str(resume_path))
 
         result = trainer.train()
         self._restore_after_training(result)

--- a/libreyolo/models/dinov2/trainer.py
+++ b/libreyolo/models/dinov2/trainer.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Type
+
+from ...training.config import TrainConfig
 from ..base.semantic_validation_loss import SemanticValidationLossMixin
 from ..rfdetr.trainer import RFDETRTrainer
+from .config import DINOv2Config
 
 
 class DINOv2Trainer(SemanticValidationLossMixin, RFDETRTrainer):
@@ -12,11 +16,15 @@ class DINOv2Trainer(SemanticValidationLossMixin, RFDETRTrainer):
     Inherits all training logic from RFDETRTrainer (which handles the
     semantic task path through its ``on_setup``, ``on_forward``, and
     ``get_loss_components`` semantic branches). Only the model-family
-    metadata is overridden so saved checkpoints carry
+    metadata and config class are overridden so saved checkpoints carry
     ``model_family="dinov2"`` instead of ``"rfdetr"``.
     """
 
     artifact_model_families = ("dinov2",)
+
+    @classmethod
+    def _config_class(cls) -> Type[TrainConfig]:
+        return DINOv2Config
 
     def get_model_family(self) -> str:
         return "dinov2"

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -35,6 +35,8 @@ from ...validation.preprocessors import RFDETRValPreprocessor
 # ancestor) has the same 91-wide head. Aliased here for backward compat.
 _COCO91_TO_COCO80 = COCO91_TO_COCO80
 
+_TRAIN_DEFAULTS = RFDETRConfig()
+
 
 _RFDETR_UPSTREAM_WEIGHT_URLS = {
     "rf-detr-nano.pth": "https://storage.googleapis.com/rfdetr/nano_coco/checkpoint_best_regular.pth",
@@ -1199,7 +1201,7 @@ class LibreRFDETR(BaseModel):
         epochs: int = 100,
         batch_size: int | None = None,
         lr: float | None = None,
-        output_dir: str = "runs/train",
+        output_dir: str | None = None,
         resume: str | Path | bool | None = None,
         callbacks: TrainCallbacks = None,
         loggers=None,
@@ -1212,23 +1214,32 @@ class LibreRFDETR(BaseModel):
             epochs: Number of epochs to train.
             batch_size: Batch size (alias of ``batch=`` passed via kwargs).
             lr: Initial learning rate (alias of ``lr0=`` passed via kwargs).
-            output_dir: Directory for training runs and checkpoints.
+            output_dir: Directory for training runs and checkpoints, split into
+                ``project`` (parent) and ``name`` (leaf). Defaults to
+                ``<RFDETRConfig.project>/<RFDETRConfig.name>`` when omitted;
+                ``project=`` / ``name=`` kwargs take precedence over this split.
             resume: Checkpoint path, or True to resume the loaded checkpoint.
             callbacks: Optional training callback or iterable of callbacks.
             loggers: Optional built-in experiment loggers: a registered name,
                 a configured logger instance, or an iterable mixing both.
         """
-        output_path = Path(output_dir)
         train_kwargs = dict(kwargs)
         project = train_kwargs.pop("project", None)
         name = train_kwargs.pop("name", None)
-        exist_ok = train_kwargs.pop("exist_ok", True)
+        exist_ok = train_kwargs.pop("exist_ok", _TRAIN_DEFAULTS.exist_ok)
         batch = train_kwargs.pop("batch", None)
         lr0 = train_kwargs.pop("lr0", None)
-        if project is None:
-            project = output_path.parent
-        if name is None:
-            name = output_path.name
+        if output_dir is not None:
+            output_path = Path(output_dir)
+            if project is None:
+                project = output_path.parent
+            if name is None:
+                name = output_path.name
+        else:
+            if project is None:
+                project = _TRAIN_DEFAULTS.project
+            if name is None:
+                name = _TRAIN_DEFAULTS.name
         run_dir = Path(project) / str(name)
 
         if batch is not None and batch_size is not None and batch != batch_size:

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -1241,6 +1241,10 @@ class LibreRFDETR(BaseModel):
             if name is None:
                 name = _TRAIN_DEFAULTS.name
         run_dir = Path(project) / str(name)
+        if resume is True:
+            # resume=True reads weights/last.pt from this exact run_dir below;
+            # never let _get_save_dir() increment away from it mid-resume.
+            exist_ok = True
 
         if batch is not None and batch_size is not None and batch != batch_size:
             raise ValueError(

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -1184,7 +1184,7 @@ def train_rfdetr(
     epochs: int = 100,
     batch_size: int = 4,
     lr: float = 1e-4,
-    output_dir: str = "runs/train",
+    output_dir: str | None = None,
     resume: str | None = None,
     pretrain_weights: str | None = None,
     segmentation: bool = False,
@@ -1217,7 +1217,7 @@ def train_rfdetr(
         epochs=epochs,
         batch_size=batch_size,
         lr=lr,
-        output_dir=str(Path(output_dir)),
+        output_dir=str(Path(output_dir)) if output_dir is not None else None,
         resume=resume,
         **kwargs,
     )

--- a/libreyolo/models/vlm/training/trainer.py
+++ b/libreyolo/models/vlm/training/trainer.py
@@ -111,6 +111,11 @@ class VLMDetectionTrainer:
         self.callbacks = TrainCallbackList(callbacks)
         for logger_cb in resolve_loggers(loggers):
             self.callbacks.append(logger_cb)
+        if self.config.resume is True:
+            # resume=True reads weights/last from this exact save_dir (see
+            # _resolve_resume_dir); never let _resolve_save_dir() increment
+            # away from it mid-resume.
+            self.config.exist_ok = True
         self.save_dir = self._resolve_save_dir()
 
     # ------------------------------------------------------------------

--- a/libreyolo/models/vlm/training/trainer.py
+++ b/libreyolo/models/vlm/training/trainer.py
@@ -64,7 +64,7 @@ class VLMTrainConfig:
     output_dir: str = "runs/vlm/train"
     project: Optional[str] = None
     name: Optional[str] = None
-    exist_ok: bool = True
+    exist_ok: bool = False
     workers: int = 0
     seed: int = 0
     device: Optional[str] = None

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -322,6 +322,47 @@ class TestBuildTrainKwargs:
 
         assert kwargs["single_cls"] is True
 
+    def test_rfdetr_cli_run_dir_is_not_incremented_twice(self, monkeypatch, tmp_path):
+        """The CLI pre-increments and creates the run dir, so the wrapper must
+        write into that exact dir instead of incrementing it again."""
+        rfdetr_model = pytest.importorskip("libreyolo.models.rfdetr.model")
+        from libreyolo.models.rfdetr.config import RFDETRConfig
+        from libreyolo.training.trainer import BaseTrainer
+
+        class _SaveDirTrainer:
+            """Resolves save_dir exactly like BaseTrainer.setup() on rank 0."""
+
+            def __init__(self, model, wrapper_model=None, **kwargs):
+                self.config = RFDETRConfig(
+                    data=kwargs["data"],
+                    project=kwargs["project"],
+                    name=kwargs["name"],
+                    exist_ok=kwargs["exist_ok"],
+                )
+
+            def train(self):
+                return {"save_dir": str(BaseTrainer._get_save_dir(self))}
+
+        monkeypatch.setattr(rfdetr_model, "RFDETRTrainer", _SaveDirTrainer)
+
+        wrapper = rfdetr_model.LibreRFDETR.__new__(rfdetr_model.LibreRFDETR)
+        wrapper.model = object()
+        wrapper.size = "n"
+        wrapper.nb_classes = 2
+        wrapper.input_size = 560
+        wrapper.task = "detect"
+
+        params = {"project": str(tmp_path), "name": "rfdetr_exp", "exist_ok": False}
+        for expected in ("rfdetr_exp", "rfdetr_exp2"):
+            kwargs = cli_config._build_rfdetr_train_kwargs(params)
+            assert kwargs["output_dir"] == str(tmp_path / expected)
+            result = wrapper.train(data="data.yaml", **kwargs)
+            assert result["save_dir"] == str(tmp_path / expected)
+        assert sorted(p.name for p in tmp_path.iterdir()) == [
+            "rfdetr_exp",
+            "rfdetr_exp2",
+        ]
+
 
 class TestGetCfgDefaults:
     """Test that cfg defaults are fully derived from dataclasses."""

--- a/tests/unit/test_dinov2_semantic.py
+++ b/tests/unit/test_dinov2_semantic.py
@@ -507,6 +507,60 @@ def test_dinov2_checkpoint_family_is_dinov2(fake_backbone, tmp_path):
     assert ckpt.get("model_family") == "dinov2"
 
 
+def test_dinov2_semantic_resume_continues_same_run_dir(fake_backbone, tmp_path):
+    """resume=True must actually invoke the trainer's resume lifecycle and
+    keep writing into the same run_dir, not increment away from it."""
+    from libreyolo.models.dinov2.model import LibreDINOv2
+
+    yaml_path = _make_semantic_yaml(tmp_path)
+    runs_root = tmp_path / "runs"
+    run_dir = runs_root / "resume_test"
+
+    m1 = LibreDINOv2(
+        model_path=None, size="n", task="semantic", nb_classes=2, device="cpu"
+    )
+    res1 = m1.train(
+        data=str(yaml_path),
+        epochs=1,
+        batch=2,
+        imgsz=70,
+        workers=0,
+        eval_interval=0,
+        project=str(runs_root),
+        name="resume_test",
+        amp=False,
+        ema=False,
+        warmup_epochs=0,
+    )
+    assert run_dir.exists()
+    assert res1.get("last_checkpoint") is not None
+
+    m2 = LibreDINOv2(
+        model_path=None, size="n", task="semantic", nb_classes=2, device="cpu"
+    )
+    res2 = m2.train(
+        data=str(yaml_path),
+        epochs=2,
+        batch=2,
+        imgsz=70,
+        workers=0,
+        eval_interval=0,
+        project=str(runs_root),
+        name="resume_test",
+        resume=True,
+        amp=False,
+        ema=False,
+        warmup_epochs=0,
+    )
+
+    # exist_ok must have been forced True for the resumed run: no sibling
+    # "resume_test2" directory should exist alongside the original.
+    assert not (runs_root / "resume_test2").exists()
+    # The resume lifecycle actually ran: start_epoch was restored to 1, so
+    # only epoch index 1 trained, not epochs 0 and 1 from scratch.
+    assert len(res2["epoch_losses"]) == 1
+
+
 @pytest.mark.external_data
 @pytest.mark.network
 @pytest.mark.slow

--- a/tests/unit/test_rfdetr_lr_contract.py
+++ b/tests/unit/test_rfdetr_lr_contract.py
@@ -123,6 +123,11 @@ def test_rfdetr_train_resolves_resume_paths(monkeypatch, tmp_path, resume_arg):
 
     assert captured["setup"] is True
     assert captured["resume"] == str(expected)
+    # resume=True continues in the same run_dir that weights/last.pt was read
+    # from, so exist_ok must be forced True regardless of the new exist_ok=False
+    # default -- otherwise _get_save_dir() would increment away from it and
+    # split resumed state from newly written artifacts.
+    assert captured["kwargs"]["exist_ok"] is (resume is True)
 
 
 def test_rfdetr_train_rejects_conflicting_lr_aliases(tmp_path):

--- a/tests/unit/test_rfdetr_lr_contract.py
+++ b/tests/unit/test_rfdetr_lr_contract.py
@@ -68,7 +68,7 @@ def test_rfdetr_train_prefers_canonical_batch_and_lr0(monkeypatch, tmp_path):
     assert captured["kwargs"]["lr0"] == pytest.approx(0.001)
     assert captured["kwargs"]["project"] == str(tmp_path)
     assert captured["kwargs"]["name"] == "canonical"
-    assert captured["kwargs"]["exist_ok"] is True
+    assert captured["kwargs"]["exist_ok"] is False
 
 
 def test_rfdetr_train_accepts_legacy_aliases(monkeypatch, tmp_path):

--- a/tests/unit/test_vlm_training.py
+++ b/tests/unit/test_vlm_training.py
@@ -394,3 +394,47 @@ class TestTrainGating:
     def test_unknown_recipe_raises(self):
         with pytest.raises(NotImplementedError):
             get_recipe("not-a-family")
+
+
+class TestResumePreservesRunDir:
+    """resume=True must read weights/last from the exact directory it names,
+    not one _resolve_save_dir() incremented away from underneath it."""
+
+    @staticmethod
+    def _fake_wrapper():
+        return type("FakeWrapper", (), {"FAMILY": "qwen3vl"})()
+
+    def test_resume_true_forces_exist_ok_and_keeps_dir(self, tmp_path):
+        from libreyolo.models.vlm.training.trainer import VLMDetectionTrainer
+
+        run_dir = tmp_path / "runs" / "vlm_exp"
+        weights_dir = run_dir / "weights" / "last"
+        weights_dir.mkdir(parents=True)
+        (weights_dir / CONTRACT_FILENAME).write_text("{}")
+
+        trainer = VLMDetectionTrainer(
+            self._fake_wrapper(),
+            data="data.yaml",
+            project=str(tmp_path / "runs"),
+            name="vlm_exp",
+            resume=True,
+        )
+
+        assert trainer.save_dir == run_dir
+        assert trainer.config.exist_ok is True
+        assert trainer._resolve_resume_dir() == weights_dir
+
+    def test_non_resumed_run_still_increments_by_default(self, tmp_path):
+        from libreyolo.models.vlm.training.trainer import VLMDetectionTrainer
+
+        (tmp_path / "runs" / "vlm_exp").mkdir(parents=True)
+
+        trainer = VLMDetectionTrainer(
+            self._fake_wrapper(),
+            data="data.yaml",
+            project=str(tmp_path / "runs"),
+            name="vlm_exp",
+        )
+
+        assert trainer.save_dir == tmp_path / "runs" / "vlm_exp2"
+        assert trainer.config.exist_ok is False


### PR DESCRIPTION
Fix RF-DETR, DINOv2, and the VLM LoRA SFT trainer silently overwriting the previous training run's output directory instead of creating an incremented one.

RFDETR.train() and DINOv2.train() hardcoded a local exist_ok=True default instead of deferring to their config class's actual default (False, matching every other family), which disabled BaseTrainer._get_save_dir()'s increment-on-exists logic for direct Python API calls. VLMTrainConfig.exist_ok had the same wrong default in its own independent save-dir logic.

Split DINOv2Config out from RFDETRConfig as its own class (was previously reusing RFDETRConfig directly with no DINOv2 identity) so TRAIN_CONFIG/CLI introspection and the exist_ok/output_dir defaults are DINOv2's own, while still inheriting the RF-DETR-derived fields DINOv2Trainer actually depends on.

CLI training is unaffected — it already pre-increments the run directory itself before calling train().

fixes #833 

## Code provenance

original code written for this PR, and/or









<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns RF-DETR, DINOv2, and VLM output-directory defaults with increment-on-exists behavior while preserving the selected directory during boolean resume.
- Adds a dedicated DINOv2 training configuration and exposes it through trainer and CLI introspection.
- Ensures CLI-preincremented RF-DETR directories are not incremented again.
- Restores DINOv2 training state during resume and keeps boolean VLM resume in its configured run directory.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains in the previously reported resume-directory paths.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libreyolo/models/rfdetr/model.py | Resolves defaults from RFDETRConfig and preserves the configured directory for boolean resume. |
| libreyolo/models/dinov2/model.py | Uses DINOv2-specific defaults and invokes the shared setup-and-resume lifecycle before continuing training. |
| libreyolo/models/dinov2/config.py | Introduces a DINOv2-specific RF-DETR-derived configuration with its own run name. |
| libreyolo/cli/config.py | Marks the already-created CLI run directory as reusable to prevent a second increment. |
| libreyolo/models/vlm/training/trainer.py | Defaults new runs to incrementing while preserving the selected directory for boolean resume. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Training request] --> B{Resume enabled?}
  B -->|No| C[Resolve configured run directory]
  C --> D[Increment if directory exists]
  B -->|Yes| E[Keep selected existing run directory]
  E --> F[Load last checkpoint]
  D --> G[Train and write artifacts]
  F --> G
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Default train\_rfdetr() output\_dir to Non..."](https://github.com/libreyolo/libreyolo/commit/a4d0ecc9e17f29a459ace07ff0c6df037b07dbdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59481519)</sub>

**Context used:**

- Knowledge Base — [Training system](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/training-system.md)
- Knowledge Base — [Trainer orchestration and distributed execution](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/trainer-orchestration.md)

<!-- /greptile_comment -->