### PR TITLE
Keep OBB rows when single_cls collapses the class id

### DIFF
--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -429,7 +429,13 @@ class YOLODataset(ImageCacheMixin, Dataset):
                         try:
                             cls_id, corners = parse_yolo_obb_label_line(
                                 parts,
-                                num_classes=self.num_classes,
+                                # single_cls discards the source class id, so the
+                                # class-count bound does not apply to it. The YOLO
+                                # box path already works this way: parse_yolo_label_line
+                                # remaps to 0 and only then checks the range. Passing
+                                # the bound here instead dropped every row whose
+                                # source id was >= num_classes.
+                                num_classes=None if self.single_cls else self.num_classes,
                                 clip=True,
                             )
                             pixel_corners = corners.copy()

--- a/tests/unit/test_single_cls.py
+++ b/tests/unit/test_single_cls.py
@@ -248,6 +248,78 @@ def test_yolo_dataset_single_cls_remaps_every_positive_class(tmp_path):
     np.testing.assert_array_equal(labels[:, 4], np.zeros(2))
 
 
+def _write_yolo_obb_sample(tmp_path: Path) -> tuple[list[Path], list[Path]]:
+    image_path = tmp_path / "sample_obb.jpg"
+    label_path = tmp_path / "sample_obb.txt"
+    Image.new("RGB", (64, 48), color="white").save(image_path)
+    label_path.write_text(
+        "0 0.10 0.10 0.30 0.10 0.30 0.30 0.10 0.30\n"
+        "2 0.60 0.60 0.80 0.60 0.80 0.80 0.60 0.80\n",
+        encoding="utf-8",
+    )
+    return [image_path], [label_path]
+
+
+def test_obb_single_cls_remaps_every_positive_class_within_the_bound(tmp_path):
+    """single_cls collapses to one class, so num_classes=1 must not drop class 2.
+
+    The YOLO box path remaps before the range check and keeps the row. The OBB
+    path validated the source id against num_classes first, so with the class
+    count single_cls implies it dropped every row whose source id was not 0.
+    """
+    image_files, label_files = _write_yolo_obb_sample(tmp_path)
+
+    dataset = YOLODataset(
+        img_files=image_files,
+        label_files=label_files,
+        img_size=(64, 64),
+        load_obb=True,
+        num_classes=1,
+        single_cls=True,
+    )
+
+    labels = dataset.annotations[0][0]
+    assert labels.shape == (2, 6)
+    np.testing.assert_array_equal(labels[:, 4], np.zeros(2))
+
+
+def test_obb_class_bound_still_applies_without_single_cls(tmp_path):
+    image_files, label_files = _write_yolo_obb_sample(tmp_path)
+
+    dataset = YOLODataset(
+        img_files=image_files,
+        label_files=label_files,
+        img_size=(64, 64),
+        load_obb=True,
+        num_classes=1,
+    )
+
+    labels = dataset.annotations[0][0]
+    assert labels.shape == (1, 6)
+    np.testing.assert_array_equal(labels[:, 4], np.zeros(1))
+
+
+def test_obb_single_cls_still_rejects_a_negative_class(tmp_path):
+    image_path = tmp_path / "negative.jpg"
+    label_path = tmp_path / "negative.txt"
+    Image.new("RGB", (64, 48), color="white").save(image_path)
+    label_path.write_text(
+        "-1 0.10 0.10 0.30 0.10 0.30 0.30 0.10 0.30\n",
+        encoding="utf-8",
+    )
+
+    dataset = YOLODataset(
+        img_files=[image_path],
+        label_files=[label_path],
+        img_size=(64, 64),
+        load_obb=True,
+        num_classes=1,
+        single_cls=True,
+    )
+
+    assert dataset.annotations[0][0].shape[0] == 0
+
+
 def test_coco_dataset_single_cls_keeps_original_mapping_then_collapses(tmp_path):
     pytest.importorskip("pycocotools")
     _write_coco_sample(tmp_path)


### PR DESCRIPTION
Opened by an autonomous agent operating the `massimiliano1991` account, per AGENTS.md.

`YOLODataset` with `load_obb=True` checks the source class id against `num_classes`
*before* `single_cls` remaps it to 0. With the class count `single_cls` implies
(`num_classes=1`) every row whose source id is not 0 is dropped as "out of range".
The YOLO box path does not have this: `parse_yolo_label_line` remaps first and then
checks, so the row is kept.

- `dataset.py`: pass `num_classes=None` to the OBB parser when `single_cls` is on.
  Negative ids are still rejected by the parser regardless of the bound, matching the
  box path, which only remaps ids `>= 0`.
- Three tests in `tests/unit/test_single_cls.py`, mirroring the existing
  `test_yolo_dataset_single_cls_remaps_every_positive_class`: the OBB remap, the bound
  still applying without `single_cls`, and a negative id still rejected.

Reviewer check: whether `single_cls` on OBB data should be supported at the dataset
level at all, or rejected earlier. The CLI and `BaseModel` gate `single_cls` to G0/G1
`detect`, so this is reachable through the public `YOLODataset` class rather than
through `train`. I fixed the divergence rather than closing the path because the
constructor argument is public and its docstring says "Remap every non-negative class
id to class 0".

Verified: the three new tests fail before the change and pass after;
`test_single_cls.py`, `test_obb_labels.py`, `test_obb_validation.py`,
`test_dataset_loading.py` pass (66); the wider unit suite passes except families that
need `transformers>=5` and DINOv2, which my environment does not have — those were not
run.

Not verified: no training run, no OBB model was trained or evaluated with this change.

## Code provenance

Original code written for this PR. No code was ported, adapted, or derived from any
third-party project. The change is a one-argument edit in
`libreyolo/data/dataset.py` plus new tests written against the existing
`test_single_cls.py` conventions in this repository.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Aligns OBB label ingestion with the existing axis-aligned box behavior when `single_cls` is enabled.
- Skips the source class upper-bound check before collapsing valid non-negative OBB class IDs to class 0.
- Preserves normal class-bound validation when `single_cls` is disabled.
- Adds focused coverage for positive remapping, ordinary upper-bound enforcement, and negative-ID rejection.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

The changed path retains malformed and negative class-ID validation, remaps every accepted source ID before annotation storage, and preserves the configured upper bound when single-class collapsing is disabled.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libreyolo/data/dataset.py | Correctly bypasses only the obsolete source-class upper bound under `single_cls`, while retaining parser validation and remapping every accepted ID before storage. |
| tests/unit/test_single_cls.py | Adds focused OBB regression tests covering the intended remap and both relevant validation boundaries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Keep OBB rows when single\_cls collapses ..."](https://github.com/libreyolo/libreyolo/commit/34c63e2b6a4f0c32942091a6c3d1f9c4f45ac4b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60975325)</sub>

**Context used:**

- Knowledge Base — [Data loading and augmentation](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/data-and-augmentation.md)
- Knowledge Base — [Task-specific datasets and annotations](https://app.greptile.com/libreyolo/-/custom-context/knowledge-base/libreyolo/libreyolo/-/docs/task-datasets.md)

<!-- /greptile_comment -->