### PR TITLE
Add opt-in classification class weighting

### DIFF
--- a/docs/classification_training.md
+++ b/docs/classification_training.md
@@ -1,0 +1,58 @@
+# Classification class weighting
+
+Image-classification training uses unweighted cross-entropy by default.
+Set `class_weights=True` to weight rare classes more heavily:
+
+```python
+from libreyolo import LibreYOLO
+
+model = LibreYOLO("LibreResNet18-cls.pt")
+model.train(data="/path/to/imagefolder", class_weights=True)
+```
+
+Both CLI grammars expose the same boolean option:
+
+```bash
+libreyolo train model=LibreResNet18-cls.pt data=/path/to/imagefolder class_weights=true
+libreyolo train --model LibreResNet18-cls.pt --data /path/to/imagefolder --class-weights
+```
+
+`class_weights` is an additive LibreYOLO option. It accepts only `True` or
+`False`, not custom vectors. Supported image-classification trainers are
+ResNet, ConvNeXt, MobileNetV4, EfficientNetV2, and DINOv2. DINOv2 uses
+the shared RF-DETR trainer's classification path; RF-DETR itself no longer
+exposes classification as a public task. Other tasks and trainers reject enabled weighting.
+YOLO9 detection losses are unchanged.
+
+For `C` classes, `N` training images, and `n_c` images in class `c`, the
+weight is `N / (C * n_c)`. Counts come from the complete training split's
+label mapping before distributed sharding or batch mixing. Every class must
+contain training images. For a 9:1 split the weights are `5/9` and `5`.
+
+The loss multiplies each class's negative log-probability by its weight and
+target probability, sums across classes, then averages across images. Hard
+labels and MixUp/CutMix soft labels use this same normalization. It differs
+from dividing each batch by the sum of its observed class weights; homogeneous
+batches still retain the intended weight. Equal-sized DDP ranks average these
+local means without extra world-size scaling. The weights follow the loss
+logits' device; half-precision logits use float32 loss arithmetic to avoid
+overflowing large rare-class weights.
+
+This changes the training objective, not the sampling frequency. The existing
+`class_balanced` option is a separate detection sampler and is not supported by
+these classification loaders. Class weighting is not a guarantee of improved
+accuracy. Validation accuracy remains unweighted. For CNN trainers, optional
+`val_loss=True` uses the same training-set weights and loss normalization.
+Standalone validation without a training loss adapter remains unweighted.
+
+The setting is saved in the training checkpoint's existing `config` field.
+When resuming, pass the same `class_weights` setting and use the same dataset;
+weights are recomputed from its training split. A different setting raises an
+error rather than silently changing the objective. Older checkpoints imply
+`class_weights=False`. Start a new fine-tuning run to change the setting.
+No inference checkpoint tensors or metadata schema change.
+
+The four CNN trainers use the weighted loss in both eager and CUDA-graph
+assembly paths. DINOv2/RF-DETR classification retains its existing eager
+fallback when CUDA-graph training is requested. Hardware and convergence
+validation evidence is recorded with the change, separately from this API.

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -303,6 +303,11 @@ def train_cmd(
         help="LVIS-style repeat-factor sampling for long-tailed datasets "
         "(default: off)",
     ),
+    class_weights: bool = typer.Option(
+        False,
+        "--class-weights/--no-class-weights",
+        help="Automatic inverse-frequency classification loss weights (default: off)",
+    ),
     single_cls: bool = typer.Option(
         False,
         "--single-cls/--no-single-cls",
@@ -617,6 +622,7 @@ def train_cmd(
         "cache": cache_val,
         "min_samples": min_samples,
         "class_balanced": class_balanced,
+        "class_weights": class_weights,
         "single_cls": single_cls,
         "average_best": average_best,
         "export_check": export_check,
@@ -730,6 +736,7 @@ def train_cmd(
             "amp_dtype": params["amp_dtype"],
             "max_det": params["max_det"],
             "class_balanced": params["class_balanced"],
+            "class_weights": params["class_weights"],
             "single_cls": params["single_cls"],
             "average_best": params["average_best"],
             "export_check": params["export_check"],
@@ -766,6 +773,7 @@ def train_cmd(
                 "save_period": params["save_period"],
                 "lora": params["lora"],
                 "class_balanced": params["class_balanced"],
+                "class_weights": params["class_weights"],
                 "single_cls": params["single_cls"],
                 "average_best": params["average_best"],
                 "export_check": params["export_check"],

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -450,6 +450,7 @@ def _build_rfdetr_train_kwargs(
         "log_interval": "log_interval",
         "cache": "cache",
         "class_balanced": "class_balanced",
+        "class_weights": "class_weights",
         "single_cls": "single_cls",
         "average_best": "average_best",
         "export_check": "export_check",

--- a/libreyolo/models/base/classify_cuda_graph.py
+++ b/libreyolo/models/base/classify_cuda_graph.py
@@ -14,7 +14,8 @@ the graph.
 from __future__ import annotations
 
 import torch
-import torch.nn.functional as F
+
+from ...training.classification import classification_loss
 
 __all__ = ["ClassifyCudaGraphMixin"]
 
@@ -25,6 +26,8 @@ class ClassifyCudaGraphMixin:
     Mixed in ahead of ``BaseTrainer`` so it overrides the base hook, which
     returns ``None`` (eager) for families that have not opted in.
     """
+
+    supports_class_weights = True
 
     def cuda_graph_train_spec(self):
         from libreyolo.training.cuda_graph import (
@@ -43,7 +46,9 @@ class ClassifyCudaGraphMixin:
 
         def assemble(flat, imgs, targets, polygons=None):
             logits = network.rebuild(flat)
-            loss = F.cross_entropy(logits, targets)
+            loss = classification_loss(
+                logits, targets, getattr(self, "class_weights", None)
+            )
             return {"total_loss": loss, "loss_ce": loss.detach()}
 
         return CudaGraphTrainSpec(network=network, assemble=assemble)

--- a/libreyolo/models/base/classify_validation_loss.py
+++ b/libreyolo/models/base/classify_validation_loss.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 import torch
-import torch.nn.functional as F
+
+from ...training.classification import classification_loss
 
 __all__ = ["ClassifyValidationLoss", "ClassifyValidationLossMixin"]
 
@@ -37,7 +38,9 @@ class ClassifyValidationLossMixin:
     def build_validation_loss_adapter(self, model: torch.nn.Module):
         del model  # The validator feeds the adapter its own forward's logits.
         return ClassifyValidationLoss(
-            device=self.device, family=self.get_model_family()
+            device=self.device,
+            family=self.get_model_family(),
+            weights=getattr(self, "class_weights", None),
         )
 
 
@@ -48,9 +51,10 @@ class ClassifyValidationLoss:
     # so there is no target-capacity floor to raise.
     max_labels = None
 
-    def __init__(self, *, device: torch.device, family: str) -> None:
+    def __init__(self, *, device: torch.device, family: str, weights=None) -> None:
         self.device = device
         self.family = family
+        self.weights = weights
 
     def __call__(
         self,
@@ -64,7 +68,7 @@ class ClassifyValidationLoss:
         labels = self._labels(
             targets, batch=logits.shape[0], num_classes=logits.shape[1]
         )
-        loss = F.cross_entropy(logits, labels)
+        loss = classification_loss(logits, labels, self.weights)
         return {"loss": loss, "loss/ce": loss}
 
     def _logits(self, predictions: Any) -> torch.Tensor:

--- a/libreyolo/models/convnext/model.py
+++ b/libreyolo/models/convnext/model.py
@@ -219,6 +219,10 @@ class LibreConvNeXt(BaseModel):
         known name (e.g. ``"imagenette160"``), or a ``.zip`` URL. The head is
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
+
+        ``class_weights=True`` (classification only) applies automatic inverse-frequency
+        loss weighting from the training split. Default False preserves unweighted
+        cross-entropy. This does not change sampling. See docs/classification_training.md.
         """
         from .trainer import ConvNeXtTrainer
 

--- a/libreyolo/models/convnext/trainer.py
+++ b/libreyolo/models/convnext/trainer.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from typing import Dict, Type
 
 import torch
-import torch.nn.functional as F
 
+from ...training.classification import classification_loss
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
@@ -72,7 +72,9 @@ class ConvNeXtTrainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin, BaseT
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         logits = self.model(imgs)
-        loss = F.cross_entropy(logits, targets)
+        loss = classification_loss(
+            logits, targets, getattr(self, "class_weights", None)
+        )
         return {"total_loss": loss, "loss_ce": loss.detach()}
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -769,6 +769,10 @@ class LibreDINOv2(BaseModel):
 
         ``resume``: checkpoint path, or True to resume from this run's own
         ``weights/last.pt``.
+
+        ``class_weights=True`` (classification only) applies automatic inverse-frequency
+        loss weighting from the training split. Default False preserves unweighted
+        cross-entropy. This does not change sampling. See docs/classification_training.md.
         """
         if self.task == "embed":
             raise NotImplementedError(

--- a/libreyolo/models/efficientnetv2/model.py
+++ b/libreyolo/models/efficientnetv2/model.py
@@ -211,6 +211,10 @@ class LibreEfficientNetV2(BaseModel):
         known name (e.g. ``"imagenette160"``), or a ``.zip`` URL. The head is
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
+
+        ``class_weights=True`` (classification only) applies automatic inverse-frequency
+        loss weighting from the training split. Default False preserves unweighted
+        cross-entropy. This does not change sampling. See docs/classification_training.md.
         """
         from .trainer import EfficientNetV2Trainer
 

--- a/libreyolo/models/efficientnetv2/trainer.py
+++ b/libreyolo/models/efficientnetv2/trainer.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from typing import Dict, Type
 
 import torch
-import torch.nn.functional as F
 
+from ...training.classification import classification_loss
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
@@ -54,7 +54,9 @@ class EfficientNetV2Trainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin,
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         logits = self.model(imgs)
-        loss = F.cross_entropy(logits, targets)
+        loss = classification_loss(
+            logits, targets, getattr(self, "class_weights", None)
+        )
         return {"total_loss": loss, "loss_ce": loss.detach()}
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:

--- a/libreyolo/models/mobilenetv4/model.py
+++ b/libreyolo/models/mobilenetv4/model.py
@@ -211,6 +211,10 @@ class LibreMobileNetV4(BaseModel):
         known name (e.g. ``"imagenette160"``), or a ``.zip`` URL. The head is
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
+
+        ``class_weights=True`` (classification only) applies automatic inverse-frequency
+        loss weighting from the training split. Default False preserves unweighted
+        cross-entropy. This does not change sampling. See docs/classification_training.md.
         """
         from .trainer import MobileNetV4Trainer
 

--- a/libreyolo/models/mobilenetv4/trainer.py
+++ b/libreyolo/models/mobilenetv4/trainer.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from typing import Dict, Type
 
 import torch
-import torch.nn.functional as F
 
+from ...training.classification import classification_loss
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
@@ -54,7 +54,9 @@ class MobileNetV4Trainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin, Ba
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         logits = self.model(imgs)
-        loss = F.cross_entropy(logits, targets)
+        loss = classification_loss(
+            logits, targets, getattr(self, "class_weights", None)
+        )
         return {"total_loss": loss, "loss_ce": loss.detach()}
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:

--- a/libreyolo/models/resnet/model.py
+++ b/libreyolo/models/resnet/model.py
@@ -222,6 +222,10 @@ class LibreResNet(BaseModel):
         known name (e.g. ``"imagenette160"``), or a ``.zip`` URL. The head is
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
+
+        ``class_weights=True`` (classification only) applies automatic inverse-frequency
+        loss weighting from the training split. Default False preserves unweighted
+        cross-entropy. This does not change sampling. See docs/classification_training.md.
         """
         from .trainer import ResNetTrainer
 

--- a/libreyolo/models/resnet/trainer.py
+++ b/libreyolo/models/resnet/trainer.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import Dict, Type
 
 import torch
-import torch.nn.functional as F
 
+from ...training.classification import classification_loss
 from ...training.config import TrainConfig
 from ...training.scheduler import WarmupCosineScheduler
 from ...training.trainer import BaseTrainer
@@ -52,7 +52,9 @@ class ResNetTrainer(ClassifyCudaGraphMixin, ClassifyValidationLossMixin, BaseTra
 
     def on_forward(self, imgs: torch.Tensor, targets: torch.Tensor, polygons=None) -> Dict:
         logits = self.model(imgs)
-        loss = F.cross_entropy(logits, targets)
+        loss = classification_loss(
+            logits, targets, getattr(self, "class_weights", None)
+        )
         return {"total_loss": loss, "loss_ce": loss.detach()}
 
     def get_loss_components(self, outputs: Dict) -> Dict[str, float]:

--- a/libreyolo/models/rfdetr/trainer.py
+++ b/libreyolo/models/rfdetr/trainer.py
@@ -22,6 +22,7 @@ from ...data import (
     load_data_config,
     pose_collate_fn,
 )
+from ...training.classification import classification_loss
 from ...training.config import TrainConfig
 from ...training.distributed import is_main_process, unwrap_model
 from ...training.freezing import FreezeGroup
@@ -74,6 +75,7 @@ class RFDETRStepScheduler(BaseScheduler):
 
 
 class RFDETRTrainer(BaseTrainer):
+    supports_class_weights = True
     artifact_model_families = ("rfdetr",)
     # RF-DETR has a DINOv2 ViT backbone whose attention/MLP projections are
     # nn.Linear layers, so LoRA fine-tuning is supported here.
@@ -908,6 +910,10 @@ class RFDETRTrainer(BaseTrainer):
         polygons: Optional[List] = None,
     ) -> Dict:
         task = getattr(getattr(self, "wrapper_model", None), "task", "detect")
+        if task == "classify" and getattr(self, "class_weights", None) is not None:
+            logits = self.model(imgs)
+            loss = classification_loss(logits, targets, self.class_weights)
+            return {"total_loss": loss, "cls": loss}
         if task in ("classify", "semantic"):
             # ``targets`` are class indices [B] (classify) or dense class maps
             # [B, H, W] (semantic); the model head returns the loss dict

--- a/libreyolo/training/classification.py
+++ b/libreyolo/training/classification.py
@@ -1,0 +1,20 @@
+"""Shared image-classification training loss (first-party implementation)."""
+
+import torch
+import torch.nn.functional as F
+
+
+def classification_loss(logits, targets, weights=None):
+    """Sample-mean CE with optional train-set inverse-frequency weights.
+
+    A fixed batch denominator keeps hard labels and MixUp/CutMix probabilities
+    equivalent and lets DDP average local means without world-size scaling.
+    """
+    if weights is None:
+        return F.cross_entropy(logits, targets)
+    # Rare-class weights can exceed float16's finite range under AMP.
+    if logits.dtype in (torch.float16, torch.bfloat16):
+        logits = logits.float()
+    return F.cross_entropy(
+        logits, targets, weight=weights.to(logits), reduction="none"
+    ).mean()

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -228,6 +228,8 @@ class TrainConfig:
     # the historical uniform / DistributedSampler is unchanged. Honored by
     # families that build the train loader through create_dataloader.
     class_balanced: bool = False
+    # Classification-only inverse-frequency loss weighting; does not resample.
+    class_weights: bool = False
     # Rolling uniform average of the N best checkpoints ranked by the
     # watched validation metric, written to weights/average.pt at the end
     # of training. 0 (default) is off: best.pt / last.pt are unchanged.
@@ -284,6 +286,8 @@ class TrainConfig:
             raise ValueError(f"precise_bn must be >= 0, got {self.precise_bn}")
         self.single_cls = bool(self.single_cls)
         self.class_balanced = bool(self.class_balanced)
+        if not isinstance(self.class_weights, bool):
+            raise ValueError("class_weights must be True or False")
         self.export_check = bool(self.export_check)
 
     @classmethod

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -157,6 +157,7 @@ class BaseTrainer(ABC):
     # Whether this family supports ``lora=True`` fine-tuning. Overridden to True
     # by trainers with LoRA-amenable (transformer/nn.Linear) backbones.
     supports_lora: bool = False
+    supports_class_weights: bool = False
 
     def __init__(
         self,
@@ -187,6 +188,14 @@ class BaseTrainer(ABC):
                 )
         self.model = model
         self.wrapper_model = wrapper_model
+        self.class_weights = None
+        if self.config.class_weights and (
+            getattr(wrapper_model, "task", None) != "classify"
+            or not self.supports_class_weights
+        ):
+            raise ValueError(
+                "class_weights=True is supported only by image-classification trainers"
+            )
         self.callbacks = TrainCallbackList(callbacks)
         for logger_callback in resolve_loggers(loggers):
             self.callbacks.append(logger_callback)
@@ -1064,6 +1073,15 @@ class BaseTrainer(ABC):
                 "erasing": getattr(self.config, "erasing", 0.0),
             },
         )
+
+        if self.config.class_weights:
+            counts = torch.bincount(
+                torch.tensor(train_dataset._impl.targets), minlength=num_classes
+            ).float()
+            if (counts == 0).any():
+                raise ValueError("class_weights requires training images in every class")
+            # Full-dataset counts, before sharding: identical on every DDP rank.
+            self.class_weights = (counts.sum() / (num_classes * counts)).to(self.device)
 
         # Batch-level MixUp / CutMix (soft labels) when requested; otherwise this
         # returns the plain classify collate so default training is unchanged.
@@ -3824,6 +3842,13 @@ class BaseTrainer(ABC):
                 SCHEMA_VERSION,
                 "; ".join(metadata_errors),
                 SCHEMA_VERSION,
+            )
+
+        saved_class_weights = checkpoint.get("config", {}).get("class_weights", False)
+        if saved_class_weights != getattr(self.config, "class_weights", False):
+            raise ValueError(
+                "Resume requires the saved class_weights setting "
+                f"(class_weights={saved_class_weights}); use a new run to change it."
             )
 
         try:

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -885,3 +885,31 @@ def test_train_rfdetr_detect_checkpoint_switches_to_obb_architecture(
     data = json.loads(result.stdout)
     assert data["model_family"] == "rfdetr"
     assert data["epochs_completed"] == 1
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        ["class_weights=true"],
+        ["--class-weights"],
+        ["class_weights=false"],
+        ["--no-class-weights"],
+    ],
+)
+@pytest.mark.parametrize("model", ["LibreResNet18-cls.pt", "LibreDINOv2s-cls.pt"])
+def test_class_weights_cli_grammars(option, model):
+    result = runner.invoke(
+        _make_app(),
+        [f"model={model}", "data=unused", *option, "--dry-run", "--json", "--quiet"],
+    )
+    assert result.exit_code == 0, result.output
+    cfg = json.loads(result.stdout)["resolved_config"]
+    assert cfg["class_weights"] is (
+        option[0] in ("class_weights=true", "--class-weights")
+    )
+
+
+def test_class_weights_help_json():
+    result = runner.invoke(_make_app(), ["--help-json"])
+    assert result.exit_code == 0, result.output
+    assert "class_weights" in result.stdout or "class-weights" in result.stdout

--- a/tests/unit/test_class_weights.py
+++ b/tests/unit/test_class_weights.py
@@ -1,0 +1,236 @@
+"""Class weighting through public config, data, trainer and CLI surfaces."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.training.classification import classification_loss
+from libreyolo.training.config import TrainConfig
+
+pytestmark = pytest.mark.unit
+
+
+def test_config_is_opt_in_and_rejects_ambiguous_values():
+    assert TrainConfig().class_weights is False
+    assert (
+        TrainConfig.from_kwargs(class_weights=True).to_dict()["class_weights"] is True
+    )
+    for value in ("false", "auto", [1, 2], 1, None):
+        with pytest.raises(ValueError, match="class_weights"):
+            TrainConfig.from_kwargs(class_weights=value)
+
+
+def test_weighted_loss_hard_soft_and_distributed_gradient_equivalence():
+    logits = torch.tensor(
+        [[2.0, -1.0], [-1.0, 2.0], [1.0, 0.0], [0.0, 1.0]], requires_grad=True
+    )
+    labels = torch.tensor([0, 1, 0, 1])
+    weights = torch.tensor([5 / 9, 5.0])
+    probabilities = torch.nn.functional.one_hot(labels, 2).float()
+    hard = classification_loss(logits, labels, weights)
+    soft = classification_loss(logits, probabilities, weights)
+    expected = -(logits.log_softmax(-1) * probabilities * weights).sum(-1).mean()
+    torch.testing.assert_close(hard, expected)
+    torch.testing.assert_close(soft, hard)
+    mixed = 0.7 * probabilities + 0.3 * probabilities.flip(0)
+    torch.testing.assert_close(
+        classification_loss(logits, mixed, weights),
+        0.7 * hard + 0.3 * classification_loss(logits, labels.flip(0), weights),
+    )
+    full_gradient = torch.autograd.grad(hard, logits, retain_graph=True)[0]
+    local_means = (
+        sum(
+            classification_loss(x, y, weights)
+            for x, y in zip(logits.chunk(2), labels.chunk(2))
+        )
+        / 2
+    )
+    torch.testing.assert_close(
+        torch.autograd.grad(local_means, logits)[0], full_gradient
+    )
+    assert torch.equal(
+        classification_loss(logits, labels),
+        torch.nn.functional.cross_entropy(logits, labels),
+    )
+    # A single-class batch must not cancel its weight through the denominator.
+    torch.testing.assert_close(
+        classification_loss(logits[:1], labels[:1], weights),
+        classification_loss(logits[:1], labels[:1]) * weights[0],
+    )
+
+
+@pytest.mark.parametrize(
+    "family",
+    ["resnet", "convnext", "mobilenetv4", "efficientnetv2", "rfdetr", "dinov2"],
+)
+def test_all_image_trainers_consume_weights(family):
+    import importlib
+
+    classes = {
+        "resnet": "ResNetTrainer",
+        "convnext": "ConvNeXtTrainer",
+        "mobilenetv4": "MobileNetV4Trainer",
+        "efficientnetv2": "EfficientNetV2Trainer",
+        "rfdetr": "RFDETRTrainer",
+        "dinov2": "DINOv2Trainer",
+    }
+    trainer_cls = getattr(
+        importlib.import_module(f"libreyolo.models.{family}.trainer"), classes[family]
+    )
+    host = object.__new__(trainer_cls)
+    host.model = torch.nn.Linear(3, 2)
+    host.wrapper_model = SimpleNamespace(task="classify")
+    host.class_weights = torch.tensor([5 / 9, 5.0])
+    images = torch.randn(4, 3)
+    targets = torch.tensor([0, 0, 0, 1])
+    for labels in (targets, torch.nn.functional.one_hot(targets, 2).float()):
+        result = host.on_forward(images, labels)
+        torch.testing.assert_close(
+            result["total_loss"],
+            classification_loss(host.model(images), labels, host.class_weights),
+        )
+    assert host.supports_class_weights
+    if family not in ("rfdetr", "dinov2"):
+        spec = host.cuda_graph_train_spec()
+        flat = spec.network(images)
+        torch.testing.assert_close(
+            spec.assemble(flat, images, targets)["total_loss"],
+            host.on_forward(images, targets)["total_loss"],
+        )
+    else:
+        assert host.cuda_graph_train_spec() is None
+
+
+@pytest.mark.parametrize(
+    "rank,mixup,cutmix", [(None, 0.0, 0.0), (0, 1.0, 0.0), (1, 0.0, 1.0)]
+)
+def test_full_training_counts_and_public_keyword(
+    tmp_path, monkeypatch, rank, mixup, cutmix
+):
+    from libreyolo import LibreResNet
+    from libreyolo.models.resnet.trainer import ResNetTrainer
+
+    for c, count in enumerate((9, 1)):
+        folder = tmp_path / "data" / "train" / str(c)
+        folder.mkdir(parents=True)
+        for i in range(count):
+            Image.new("RGB", (32, 32), color=(255 * c, 20, 20)).save(
+                folder / f"{i}.png"
+            )
+    observed = {}
+
+    def train(host):
+        if rank is not None:
+            host.is_distributed = True
+            host.world_size = 2
+            host.rank = rank
+        host._setup_classify_data()
+        observed["weights"] = host.class_weights
+        observed["targets"] = host.train_loader.dataset._impl.targets
+        observed["batch_labels"] = next(iter(host.train_loader))[1]
+        return {}
+
+    monkeypatch.setattr(ResNetTrainer, "train", train)
+    model = LibreResNet(size="18", device="cpu")
+    model.train(
+        data=str(tmp_path / "data"),
+        class_weights=True,
+        device="cpu",
+        batch=4,
+        mixup=mixup,
+        cutmix=cutmix,
+        imgsz=32,
+        workers=0,
+        project=str(tmp_path),
+        name="run",
+    )
+    torch.testing.assert_close(observed["weights"], torch.tensor([5 / 9, 5.0]))
+    assert observed["targets"].count(0) == 9
+    assert observed["targets"].count(1) == 1
+    assert observed["batch_labels"].ndim == (2 if mixup or cutmix else 1)
+
+
+def test_non_classification_rejected_before_setup():
+    from libreyolo.models.resnet.trainer import ResNetTrainer
+
+    with pytest.raises(ValueError, match="image-classification"):
+        ResNetTrainer(
+            model=torch.nn.Linear(2, 2),
+            wrapper_model=SimpleNamespace(task="detect"),
+            class_weights=True,
+        )
+
+
+def test_validation_loss_uses_training_weights():
+    from libreyolo.models.base.classify_validation_loss import ClassifyValidationLoss
+
+    logits = torch.tensor([[1.0, -1.0], [1.0, -1.0]])
+    labels = torch.tensor([0, 1])
+    weights = torch.tensor([5 / 9, 5.0])
+    adapter = ClassifyValidationLoss(
+        device=torch.device("cpu"), family="resnet", weights=weights
+    )
+    torch.testing.assert_close(
+        adapter(logits, labels)["loss"], classification_loss(logits, labels, weights)
+    )
+
+
+def test_resume_rejects_changed_weighting_before_loading_weights(tmp_path):
+    from libreyolo.models.resnet.trainer import ResNetTrainer
+    from libreyolo.training.trainer import BaseTrainer
+
+    path = tmp_path / "checkpoint.pt"
+    torch.save({"config": {"class_weights": True}, "model": {}}, path)
+    host = object.__new__(ResNetTrainer)
+    host.device = torch.device("cpu")
+    host.config = TrainConfig(class_weights=False)
+    with pytest.raises(ValueError, match="saved class_weights setting"):
+        BaseTrainer.resume(host, str(path))
+
+
+def test_dinov2_classifier_wrapper_returns_logits_for_weighted_training():
+    from libreyolo.models.dinov2.model import _DINOv2ClassifierWrapper
+    from libreyolo.models.dinov2.trainer import DINOv2Trainer
+    from libreyolo.models.rfdetr.nn import RFDETRClassifier
+
+    class Backbone(torch.nn.Module):
+        def forward(self, nested):
+            return [SimpleNamespace(tensors=nested.tensors)]
+
+    classifier = object.__new__(RFDETRClassifier)
+    torch.nn.Module.__init__(classifier)
+    classifier.backbone = Backbone()
+    classifier.pool = torch.nn.AdaptiveAvgPool2d(1)
+    classifier.drop = torch.nn.Identity()
+    classifier.linear = torch.nn.Linear(3, 2)
+    wrapper = object.__new__(_DINOv2ClassifierWrapper)
+    torch.nn.Module.__init__(wrapper)
+    wrapper.classifier = classifier
+    host = object.__new__(DINOv2Trainer)
+    host.wrapper_model = SimpleNamespace(task="classify")
+    host.model = wrapper.train()
+    host.class_weights = torch.tensor([5 / 9, 5.0])
+    images = torch.randn(4, 3, 8, 8)
+    targets = torch.tensor([0, 0, 0, 1])
+    result = host.on_forward(images, targets)
+    result["total_loss"].backward()
+    assert classifier.linear.weight.grad is not None
+    torch.testing.assert_close(
+        result["total_loss"],
+        classification_loss(wrapper(images), targets, host.class_weights),
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64]
+)
+def test_weighted_loss_precision_and_gradients(dtype):
+    logits = torch.tensor([[0.0, 1.0]], dtype=dtype, requires_grad=True)
+    # Weight conversion to float16 would overflow before cross-entropy autocasts.
+    weights = torch.tensor([1.0, 100000.0])
+    loss = classification_loss(logits, torch.tensor([1]), weights)
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert torch.isfinite(logits.grad).all()


### PR DESCRIPTION
- Refs #839. Add opt-in `class_weights=True` to Python/CLI image-classification training; default behavior is unchanged.
- Share inverse-frequency loss weighting across ResNet, ConvNeXt, MobileNetV4, EfficientNetV2, and DINOv2's RF-DETR trainer path, including soft labels, CNN graph assembly and validation loss, and resume-setting checks.
- Document the API, normalization, supported tasks, and distinction from balanced sampling.
- Verified: 6,595 local gate tests passed; the three export failures also reproduce on unchanged dev. ResNet-18 synthetic CPU overfit and resume reached 100% train top-1; MPS loss/backward smoke passed.
- Not verified: actual CUDA capture/AMP, weighting-specific multi-process DDP training, pretrained accuracy, or transformer convergence. Greptile CLI unavailable.
- Opened by an agent. All applicable CI checks passed; Greptile confidence 5/5 with no findings.

## Code provenance
Original implementation from LibreYOLO's first-party code and mathematical inverse-frequency weighting; no third-party implementation was ported or adapted. A naming-only check read sanitized public parameter-table prose, with code blocks excluded. The maintainer authorized this independent implementation after an earlier coordinating-session source exposure; no implementation was carried from that session.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61791594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/libreyolo/-/pull-requests/libreyolo/libreyolo/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

<details><summary><h3>Summary</h3></summary>

- Exposes `class_weights` through Python configuration and both CLI grammars.
- Computes weights from the complete training split before distributed sharding.
- Shares weighted hard-label and soft-label cross-entropy across eager, CNN CUDA-graph, and CNN validation-loss paths.
- Adds resume compatibility checks, user documentation, and focused unit coverage.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Python or CLI training request] --> B[TrainConfig]
    B --> C{class_weights enabled?}
    C -- No --> D[Existing unweighted cross-entropy]
    C -- Yes --> E{Classification trainer supports weighting?}
    E -- No --> F[Reject configuration]
    E -- Yes --> G[Count labels in complete training split]
    G --> H[Compute N / C × n_c weights]
    H --> I[Move weights to trainer device]
    I --> J{Training path}
    J --> K[Eager classification loss]
    J --> L[CNN CUDA-graph assembly]
    J --> M[Optional CNN validation loss]
    K --> N[Sample-mean weighted cross-entropy]
    L --> N
    M --> N
    N --> O[Checkpoint saves class_weights setting]
    O --> P[Resume verifies matching setting]
```
</details>

<!-- /greptile_comment -->