### PR TITLE
Support cls_pw classification weighting power

### DIFF
--- a/docs/classification_training.md
+++ b/docs/classification_training.md
@@ -1,42 +1,76 @@
 # Classification class weighting
 
 Image-classification training uses unweighted cross-entropy by default.
-Set `class_weights=True` to weight rare classes more heavily:
+Set `cls_pw` between `0` and `1` to control inverse-frequency weighting:
 
 ```python
 from libreyolo import LibreYOLO
 
 model = LibreYOLO("LibreResNet18-cls.pt")
-model.train(data="/path/to/imagefolder", class_weights=True)
+model.train(data="/path/to/imagefolder", cls_pw=0.5)
 ```
 
-Both CLI grammars expose the same boolean option:
+Both CLI grammars expose the same numeric option:
 
 ```bash
-libreyolo train model=LibreResNet18-cls.pt data=/path/to/imagefolder class_weights=true
-libreyolo train --model LibreResNet18-cls.pt --data /path/to/imagefolder --class-weights
+libreyolo train model=LibreResNet18-cls.pt data=/path/to/imagefolder cls_pw=0.5
+libreyolo train --model LibreResNet18-cls.pt --data /path/to/imagefolder --cls-pw 0.5
 ```
 
-`class_weights` is an additive LibreYOLO option. It accepts only `True` or
-`False`, not custom vectors. Supported image-classification trainers are
-ResNet, ConvNeXt, MobileNetV4, EfficientNetV2, and DINOv2. DINOv2 uses
-the shared RF-DETR trainer's classification path; RF-DETR itself no longer
-exposes classification as a public task. Other tasks and trainers reject enabled weighting.
-YOLO9 detection losses are unchanged.
+`cls_pw` accepts a finite number in `[0, 1]`, not a boolean or a custom vector.
+Its default `0.0` disables weighting, `1.0` gives full inverse-frequency
+weighting, and intermediate values give partial weighting. For class `c`
+with `n_c` training images, first compute `u_c = n_c ** (-cls_pw)`, then
+`w_c = u_c / mean(u)`. This makes the arithmetic mean of the class weights
+`1.0`. Counts come from the complete training split's label mapping before
+distributed sharding or batch mixing. Every class must contain training images.
 
-For `C` classes, `N` training images, and `n_c` images in class `c`, the
-weight is `N / (C * n_c)`. Counts come from the complete training split's
-label mapping before distributed sharding or batch mixing. Every class must
-contain training images. For a 9:1 split the weights are `5/9` and `5`.
+The parameter name, range, default, power, and mean-one class normalization
+follow the public contract documented in the
+[Ultralytics training arguments](https://docs.ultralytics.com/modes/train/)
+and [configuration guide](https://docs.ultralytics.com/usage/cfg/), checked
+2026-09-08. LibreYOLO applies that interface to its supported image classifiers.
+This is not a claim of identical standalone-classification behavior, loss
+reduction, or whole-library numerical parity; those have not been verified.
 
-The loss multiplies each class's negative log-probability by its weight and
-target probability, sums across classes, then averages across images. Hard
-labels and MixUp/CutMix soft labels use this same normalization. It differs
-from dividing each batch by the sum of its observed class weights; homogeneous
-batches still retain the intended weight. Equal-sized DDP ranks average these
-local means without extra world-size scaling. The weights follow the loss
-logits' device; half-precision logits use float32 loss arithmetic to avoid
-overflowing large rare-class weights.
+Supported image-classification trainers are ResNet, ConvNeXt, MobileNetV4,
+EfficientNetV2, and DINOv2. DINOv2 uses the shared RF-DETR trainer's
+classification path; RF-DETR itself no longer exposes classification as a
+public task. Other tasks and trainers reject enabled weighting. YOLO9
+detection losses are unchanged.
+
+## Existing boolean option
+
+`class_weights=True` remains supported with exactly the behavior introduced
+in PR #841: `w_c = N / (C * n_c)`, where `N` is the number of training images
+and `C` the number of classes. This normalization makes the average weight
+across training images one. It differs from `cls_pw`'s mean across classes.
+
+For a two-class 9:1 training split:
+
+| Setting | Majority weight | Minority weight |
+| --- | ---: | ---: |
+| `cls_pw=0` (default, unweighted) | 1 | 1 |
+| `cls_pw=0.5` | 0.5 | 1.5 |
+| `cls_pw=1` | 0.2 | 1.8 |
+| `class_weights=True` | 5/9 | 5 |
+
+Enabling `class_weights=True` together with `cls_pw>0` raises an error;
+neither silently overrides the other. `class_weights=True, cls_pw=0` retains
+legacy behavior. `class_weights=False, cls_pw>0` uses the power option.
+The boolean default remains `False`, and its CLI forms remain
+`class_weights=true` or `--class-weights`.
+
+## Loss, validation, and resume
+
+LibreYOLO's loss multiplies each class's negative log-probability by its
+weight and target probability, sums across classes, then averages across
+images. Hard labels and MixUp/CutMix soft labels use this same normalization.
+It differs from dividing each batch by the sum of its observed class weights;
+homogeneous batches still retain the intended weight. Equal-sized DDP ranks
+average these local means without extra world-size scaling. The weights
+follow the loss logits' device; half-precision logits use float32 loss
+arithmetic to avoid overflowing large rare-class weights.
 
 This changes the training objective, not the sampling frequency. The existing
 `class_balanced` option is a separate detection sampler and is not supported by
@@ -45,14 +79,16 @@ accuracy. Validation accuracy remains unweighted. For CNN trainers, optional
 `val_loss=True` uses the same training-set weights and loss normalization.
 Standalone validation without a training loss adapter remains unweighted.
 
-The setting is saved in the training checkpoint's existing `config` field.
-When resuming, pass the same `class_weights` setting and use the same dataset;
-weights are recomputed from its training split. A different setting raises an
-error rather than silently changing the objective. Older checkpoints imply
-`class_weights=False`. Start a new fine-tuning run to change the setting.
-No inference checkpoint tensors or metadata schema change.
+Both settings are saved in the training checkpoint's existing `config` field.
+When resuming, pass the same `cls_pw` and `class_weights` values and use the
+same dataset; weights are recomputed from its training split. A different
+setting raises an error rather than silently changing the objective. Missing
+fields in older checkpoints imply `cls_pw=0.0` and `class_weights=False`.
+Checkpoints from PR #841 that saved `class_weights=True` therefore still resume
+with that boolean enabled and `cls_pw=0`. Start a new fine-tuning run to change
+the setting. No inference checkpoint tensors or metadata schema change.
 
 The four CNN trainers use the weighted loss in both eager and CUDA-graph
-assembly paths. DINOv2/RF-DETR classification retains its existing eager
-fallback when CUDA-graph training is requested. Hardware and convergence
+assembly paths. DINOv2's RF-DETR classification trainer retains its existing
+eager fallback when CUDA-graph training is requested. Hardware and convergence
 validation evidence is recorded with the change, separately from this API.

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -303,10 +303,17 @@ def train_cmd(
         help="LVIS-style repeat-factor sampling for long-tailed datasets "
         "(default: off)",
     ),
+    cls_pw: float = typer.Option(
+        0.0,
+        min=0.0,
+        max=1.0,
+        help="Classification inverse-frequency weighting power: 0 off, 1 full "
+        "(mean-one class weights; cannot combine with class_weights=True)",
+    ),
     class_weights: bool = typer.Option(
         False,
         "--class-weights/--no-class-weights",
-        help="Automatic inverse-frequency classification loss weights (default: off)",
+        help="Legacy sample-normalized classification loss weights (default: off)",
     ),
     single_cls: bool = typer.Option(
         False,
@@ -457,7 +464,9 @@ def train_cmd(
     # Parse tuple/list strings
     try:
         from libreyolo.utils.amp import normalize_amp_dtype
+        from libreyolo.training.config import validate_class_weighting
 
+        cls_pw = validate_class_weighting(cls_pw, class_weights)
         amp_dtype = normalize_amp_dtype(amp_dtype)
         if max_det < 1:
             raise ValueError(f"max_det must be >= 1, got {max_det}")
@@ -623,6 +632,7 @@ def train_cmd(
         "min_samples": min_samples,
         "class_balanced": class_balanced,
         "class_weights": class_weights,
+        "cls_pw": cls_pw,
         "single_cls": single_cls,
         "average_best": average_best,
         "export_check": export_check,
@@ -737,6 +747,7 @@ def train_cmd(
             "max_det": params["max_det"],
             "class_balanced": params["class_balanced"],
             "class_weights": params["class_weights"],
+            "cls_pw": params["cls_pw"],
             "single_cls": params["single_cls"],
             "average_best": params["average_best"],
             "export_check": params["export_check"],
@@ -774,6 +785,7 @@ def train_cmd(
                 "lora": params["lora"],
                 "class_balanced": params["class_balanced"],
                 "class_weights": params["class_weights"],
+                "cls_pw": params["cls_pw"],
                 "single_cls": params["single_cls"],
                 "average_best": params["average_best"],
                 "export_check": params["export_check"],

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -451,6 +451,7 @@ def _build_rfdetr_train_kwargs(
         "cache": "cache",
         "class_balanced": "class_balanced",
         "class_weights": "class_weights",
+        "cls_pw": "cls_pw",
         "single_cls": "single_cls",
         "average_best": "average_best",
         "export_check": "export_check",

--- a/libreyolo/models/convnext/model.py
+++ b/libreyolo/models/convnext/model.py
@@ -220,9 +220,11 @@ class LibreConvNeXt(BaseModel):
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
 
-        ``class_weights=True`` (classification only) applies automatic inverse-frequency
-        loss weighting from the training split. Default False preserves unweighted
-        cross-entropy. This does not change sampling. See docs/classification_training.md.
+        ``cls_pw`` (classification only, float in [0, 1], default 0) controls
+        inverse-frequency weighting strength with mean-one class weights.
+        ``class_weights=True`` retains legacy sample-normalized weighting and
+        cannot be combined with ``cls_pw>0``. Neither option changes sampling.
+        See docs/classification_training.md for compatibility and resume rules.
         """
         from .trainer import ConvNeXtTrainer
 

--- a/libreyolo/models/dinov2/model.py
+++ b/libreyolo/models/dinov2/model.py
@@ -770,9 +770,11 @@ class LibreDINOv2(BaseModel):
         ``resume``: checkpoint path, or True to resume from this run's own
         ``weights/last.pt``.
 
-        ``class_weights=True`` (classification only) applies automatic inverse-frequency
-        loss weighting from the training split. Default False preserves unweighted
-        cross-entropy. This does not change sampling. See docs/classification_training.md.
+        ``cls_pw`` (classification only, float in [0, 1], default 0) controls
+        inverse-frequency weighting strength with mean-one class weights.
+        ``class_weights=True`` retains legacy sample-normalized weighting and
+        cannot be combined with ``cls_pw>0``. Neither option changes sampling.
+        See docs/classification_training.md for compatibility and resume rules.
         """
         if self.task == "embed":
             raise NotImplementedError(

--- a/libreyolo/models/efficientnetv2/model.py
+++ b/libreyolo/models/efficientnetv2/model.py
@@ -212,9 +212,11 @@ class LibreEfficientNetV2(BaseModel):
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
 
-        ``class_weights=True`` (classification only) applies automatic inverse-frequency
-        loss weighting from the training split. Default False preserves unweighted
-        cross-entropy. This does not change sampling. See docs/classification_training.md.
+        ``cls_pw`` (classification only, float in [0, 1], default 0) controls
+        inverse-frequency weighting strength with mean-one class weights.
+        ``class_weights=True`` retains legacy sample-normalized weighting and
+        cannot be combined with ``cls_pw>0``. Neither option changes sampling.
+        See docs/classification_training.md for compatibility and resume rules.
         """
         from .trainer import EfficientNetV2Trainer
 

--- a/libreyolo/models/mobilenetv4/model.py
+++ b/libreyolo/models/mobilenetv4/model.py
@@ -212,9 +212,11 @@ class LibreMobileNetV4(BaseModel):
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
 
-        ``class_weights=True`` (classification only) applies automatic inverse-frequency
-        loss weighting from the training split. Default False preserves unweighted
-        cross-entropy. This does not change sampling. See docs/classification_training.md.
+        ``cls_pw`` (classification only, float in [0, 1], default 0) controls
+        inverse-frequency weighting strength with mean-one class weights.
+        ``class_weights=True`` retains legacy sample-normalized weighting and
+        cannot be combined with ``cls_pw>0``. Neither option changes sampling.
+        See docs/classification_training.md for compatibility and resume rules.
         """
         from .trainer import MobileNetV4Trainer
 

--- a/libreyolo/models/resnet/model.py
+++ b/libreyolo/models/resnet/model.py
@@ -223,9 +223,11 @@ class LibreResNet(BaseModel):
         rebuilt to the dataset's class count automatically. Cross-entropy +
         AdamW + cosine; the ImageNet-pretrained backbone transfers cleanly.
 
-        ``class_weights=True`` (classification only) applies automatic inverse-frequency
-        loss weighting from the training split. Default False preserves unweighted
-        cross-entropy. This does not change sampling. See docs/classification_training.md.
+        ``cls_pw`` (classification only, float in [0, 1], default 0) controls
+        inverse-frequency weighting strength with mean-one class weights.
+        ``class_weights=True`` retains legacy sample-normalized weighting and
+        cannot be combined with ``cls_pw>0``. Neither option changes sampling.
+        See docs/classification_training.md for compatibility and resume rules.
         """
         from .trainer import ResNetTrainer
 

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -1,8 +1,10 @@
 """Training configuration dataclasses for LibreYOLO."""
 
 import logging
+import math
 import warnings
 from dataclasses import asdict, dataclass, fields
+from numbers import Real
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 import yaml
@@ -11,6 +13,25 @@ from libreyolo.utils.amp import normalize_amp_dtype
 from libreyolo.utils.image_size import normalize_imgsz
 
 logger = logging.getLogger(__name__)
+
+
+def validate_class_weighting(cls_pw=0.0, class_weights=False) -> float:
+    """Validate the power option and its exclusive legacy boolean alternative."""
+    if not isinstance(class_weights, bool):
+        raise ValueError("class_weights must be True or False")
+    if (
+        isinstance(cls_pw, bool)
+        or not isinstance(cls_pw, Real)
+        or not 0.0 <= cls_pw <= 1.0
+        or not math.isfinite(cls_pw)
+    ):
+        raise ValueError("cls_pw must be a finite number in [0, 1]")
+    if class_weights and cls_pw > 0:
+        raise ValueError(
+            "Choose cls_pw>0 or class_weights=True, not both; "
+            "they use different weight normalization."
+        )
+    return float(cls_pw)
 
 
 def load_train_cfg(path) -> dict:
@@ -228,7 +249,9 @@ class TrainConfig:
     # the historical uniform / DistributedSampler is unchanged. Honored by
     # families that build the train loader through create_dataloader.
     class_balanced: bool = False
-    # Classification-only inverse-frequency loss weighting; does not resample.
+    # Classification-only inverse-frequency power; arithmetic mean-one weights.
+    cls_pw: float = 0.0
+    # Legacy sample-normalized weighting. Mutually exclusive with cls_pw > 0.
     class_weights: bool = False
     # Rolling uniform average of the N best checkpoints ranked by the
     # watched validation metric, written to weights/average.pt at the end
@@ -286,8 +309,7 @@ class TrainConfig:
             raise ValueError(f"precise_bn must be >= 0, got {self.precise_bn}")
         self.single_cls = bool(self.single_cls)
         self.class_balanced = bool(self.class_balanced)
-        if not isinstance(self.class_weights, bool):
-            raise ValueError("class_weights must be True or False")
+        self.cls_pw = validate_class_weighting(self.cls_pw, self.class_weights)
         self.export_check = bool(self.export_check)
 
     @classmethod

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -189,12 +189,13 @@ class BaseTrainer(ABC):
         self.model = model
         self.wrapper_model = wrapper_model
         self.class_weights = None
-        if self.config.class_weights and (
+        if (self.config.class_weights or self.config.cls_pw > 0) and (
             getattr(wrapper_model, "task", None) != "classify"
             or not self.supports_class_weights
         ):
             raise ValueError(
-                "class_weights=True is supported only by image-classification trainers"
+                "class_weights=True or cls_pw>0 requires a supported "
+                "image-classification trainer"
             )
         self.callbacks = TrainCallbackList(callbacks)
         for logger_callback in resolve_loggers(loggers):
@@ -1074,14 +1075,19 @@ class BaseTrainer(ABC):
             },
         )
 
-        if self.config.class_weights:
+        if self.config.class_weights or self.config.cls_pw > 0:
             counts = torch.bincount(
                 torch.tensor(train_dataset._impl.targets), minlength=num_classes
             ).float()
             if (counts == 0).any():
-                raise ValueError("class_weights requires training images in every class")
+                raise ValueError("Class weighting requires training images in every class")
             # Full-dataset counts, before sharding: identical on every DDP rank.
-            self.class_weights = (counts.sum() / (num_classes * counts)).to(self.device)
+            if self.config.class_weights:
+                weights = counts.sum() / (num_classes * counts)
+            else:
+                weights = counts.pow(-self.config.cls_pw)
+                weights = weights / weights.mean()
+            self.class_weights = weights.to(self.device)
 
         # Batch-level MixUp / CutMix (soft labels) when requested; otherwise this
         # returns the plain classify collate so default training is unchanged.
@@ -3844,12 +3850,13 @@ class BaseTrainer(ABC):
                 SCHEMA_VERSION,
             )
 
-        saved_class_weights = checkpoint.get("config", {}).get("class_weights", False)
-        if saved_class_weights != getattr(self.config, "class_weights", False):
-            raise ValueError(
-                "Resume requires the saved class_weights setting "
-                f"(class_weights={saved_class_weights}); use a new run to change it."
-            )
+        for option, default in (("class_weights", False), ("cls_pw", 0.0)):
+            saved_value = checkpoint.get("config", {}).get(option, default)
+            if saved_value != getattr(self.config, option, default):
+                raise ValueError(
+                    f"Resume requires the saved {option} setting "
+                    f"({option}={saved_value}); use a new run to change it."
+                )
 
         try:
             model_state = checkpoint.get("train_model", checkpoint["model"])

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -913,3 +913,93 @@ def test_class_weights_help_json():
     result = runner.invoke(_make_app(), ["--help-json"])
     assert result.exit_code == 0, result.output
     assert "class_weights" in result.stdout or "class-weights" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "option,value",
+    [([], 0.0), (["cls_pw=0.5"], 0.5), (["--cls-pw", "0.5"], 0.5), (["cls_pw=1"], 1.0)],
+)
+@pytest.mark.parametrize("model", ["LibreResNet18-cls.pt", "LibreDINOv2s-cls.pt"])
+def test_cls_pw_cli_grammars_and_default(option, value, model):
+    result = runner.invoke(
+        _make_app(),
+        [f"model={model}", "data=unused", *option, "--dry-run", "--json", "--quiet"],
+    )
+    assert result.exit_code == 0, result.output
+    cfg = json.loads(result.stdout)["resolved_config"]
+    assert cfg["cls_pw"] == value
+    assert cfg["class_weights"] is False
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1.1", "nan", "inf", "-inf", "true"])
+def test_cls_pw_cli_rejects_invalid_values(value):
+    result = runner.invoke(
+        _make_app(),
+        [
+            "model=LibreResNet18-cls.pt",
+            "data=unused",
+            f"cls_pw={value}",
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "cls_pw" in result.output or "cls-pw" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cls_pw_cli_rejects_enabled_legacy_conflict():
+    result = runner.invoke(
+        _make_app(),
+        [
+            "model=LibreResNet18-cls.pt",
+            "data=unused",
+            "cls_pw=0.5",
+            "class_weights=true",
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not both" in result.output
+
+
+@pytest.mark.parametrize(
+    "family,model",
+    [("resnet", "LibreResNet18-cls.pt"), ("dinov2", "LibreDINOv2s-cls.pt")],
+)
+@pytest.mark.parametrize("option", [["cls_pw=0.5"], ["--cls-pw", "0.5"]])
+def test_cls_pw_cli_forwards_numeric_strength(
+    monkeypatch, tmp_path, family, model, option
+):
+    captured = {}
+
+    class Classifier:
+        FAMILY = family
+        device = "cpu"
+        task = "classify"
+
+        def train(self, data, **kwargs):
+            captured.update(kwargs)
+            return {"output_dir": str(tmp_path)}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda *args, **kwargs: Classifier(),
+    )
+    result = runner.invoke(
+        _make_app(), [f"model={model}", "data=unused", *option, "--json", "--quiet"]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["cls_pw"] == 0.5
+    assert captured["class_weights"] is False
+
+
+def test_cls_pw_help_json_exposes_numeric_default():
+    result = runner.invoke(_make_app(), ["--help-json"])
+    assert result.exit_code == 0, result.output
+    schema = json.loads(result.stdout)
+    assert "cls_pw" in result.stdout
+
+    parameter = next(p for p in schema["parameters"] if p["name"] == "cls_pw")
+    assert parameter["default"] == 0.0

--- a/tests/unit/test_class_weights.py
+++ b/tests/unit/test_class_weights.py
@@ -22,12 +22,13 @@ def test_config_is_opt_in_and_rejects_ambiguous_values():
             TrainConfig.from_kwargs(class_weights=value)
 
 
-def test_weighted_loss_hard_soft_and_distributed_gradient_equivalence():
+@pytest.mark.parametrize("weight_values", [[5 / 9, 5.0], [0.5, 1.5]])
+def test_weighted_loss_hard_soft_and_distributed_gradient_equivalence(weight_values):
     logits = torch.tensor(
         [[2.0, -1.0], [-1.0, 2.0], [1.0, 0.0], [0.0, 1.0]], requires_grad=True
     )
     labels = torch.tensor([0, 1, 0, 1])
-    weights = torch.tensor([5 / 9, 5.0])
+    weights = torch.tensor(weight_values)
     probabilities = torch.nn.functional.one_hot(labels, 2).float()
     hard = classification_loss(logits, labels, weights)
     soft = classification_loss(logits, probabilities, weights)
@@ -65,7 +66,8 @@ def test_weighted_loss_hard_soft_and_distributed_gradient_equivalence():
     "family",
     ["resnet", "convnext", "mobilenetv4", "efficientnetv2", "rfdetr", "dinov2"],
 )
-def test_all_image_trainers_consume_weights(family):
+@pytest.mark.parametrize("weight_values", [[5 / 9, 5.0], [0.5, 1.5]])
+def test_all_image_trainers_consume_weights(family, weight_values):
     import importlib
 
     classes = {
@@ -82,7 +84,7 @@ def test_all_image_trainers_consume_weights(family):
     host = object.__new__(trainer_cls)
     host.model = torch.nn.Linear(3, 2)
     host.wrapper_model = SimpleNamespace(task="classify")
-    host.class_weights = torch.tensor([5 / 9, 5.0])
+    host.class_weights = torch.tensor(weight_values)
     images = torch.randn(4, 3)
     targets = torch.tensor([0, 0, 0, 1])
     for labels in (targets, torch.nn.functional.one_hot(targets, 2).float()):
@@ -95,10 +97,11 @@ def test_all_image_trainers_consume_weights(family):
     if family not in ("rfdetr", "dinov2"):
         spec = host.cuda_graph_train_spec()
         flat = spec.network(images)
-        torch.testing.assert_close(
-            spec.assemble(flat, images, targets)["total_loss"],
-            host.on_forward(images, targets)["total_loss"],
-        )
+        for labels in (targets, torch.nn.functional.one_hot(targets, 2).float()):
+            torch.testing.assert_close(
+                spec.assemble(flat, images, labels)["total_loss"],
+                host.on_forward(images, labels)["total_loss"],
+            )
     else:
         assert host.cuda_graph_train_spec() is None
 
@@ -106,8 +109,18 @@ def test_all_image_trainers_consume_weights(family):
 @pytest.mark.parametrize(
     "rank,mixup,cutmix", [(None, 0.0, 0.0), (0, 1.0, 0.0), (1, 0.0, 1.0)]
 )
+@pytest.mark.parametrize(
+    "options,expected_weights",
+    [
+        ({"class_weights": True}, [5 / 9, 5.0]),
+        ({"class_weights": True, "cls_pw": 0.0}, [5 / 9, 5.0]),
+        ({"cls_pw": 0.0}, None),
+        ({"cls_pw": 0.5}, [0.5, 1.5]),
+        ({"cls_pw": 1.0}, [0.2, 1.8]),
+    ],
+)
 def test_full_training_counts_and_public_keyword(
-    tmp_path, monkeypatch, rank, mixup, cutmix
+    tmp_path, monkeypatch, rank, mixup, cutmix, options, expected_weights
 ):
     from libreyolo import LibreResNet
     from libreyolo.models.resnet.trainer import ResNetTrainer
@@ -136,7 +149,7 @@ def test_full_training_counts_and_public_keyword(
     model = LibreResNet(size="18", device="cpu")
     model.train(
         data=str(tmp_path / "data"),
-        class_weights=True,
+        **options,
         device="cpu",
         batch=4,
         mixup=mixup,
@@ -146,29 +159,34 @@ def test_full_training_counts_and_public_keyword(
         project=str(tmp_path),
         name="run",
     )
-    torch.testing.assert_close(observed["weights"], torch.tensor([5 / 9, 5.0]))
+    if expected_weights is None:
+        assert observed["weights"] is None
+    else:
+        torch.testing.assert_close(observed["weights"], torch.tensor(expected_weights))
     assert observed["targets"].count(0) == 9
     assert observed["targets"].count(1) == 1
     assert observed["batch_labels"].ndim == (2 if mixup or cutmix else 1)
 
 
-def test_non_classification_rejected_before_setup():
+@pytest.mark.parametrize("options", [{"class_weights": True}, {"cls_pw": 0.5}])
+def test_non_classification_rejected_before_setup(options):
     from libreyolo.models.resnet.trainer import ResNetTrainer
 
     with pytest.raises(ValueError, match="image-classification"):
         ResNetTrainer(
             model=torch.nn.Linear(2, 2),
             wrapper_model=SimpleNamespace(task="detect"),
-            class_weights=True,
+            **options,
         )
 
 
-def test_validation_loss_uses_training_weights():
+@pytest.mark.parametrize("weight_values", [[5 / 9, 5.0], [0.5, 1.5]])
+def test_validation_loss_uses_training_weights(weight_values):
     from libreyolo.models.base.classify_validation_loss import ClassifyValidationLoss
 
     logits = torch.tensor([[1.0, -1.0], [1.0, -1.0]])
     labels = torch.tensor([0, 1])
-    weights = torch.tensor([5 / 9, 5.0])
+    weights = torch.tensor(weight_values)
     adapter = ClassifyValidationLoss(
         device=torch.device("cpu"), family="resnet", weights=weights
     )
@@ -234,3 +252,74 @@ def test_weighted_loss_precision_and_gradients(dtype):
     assert torch.isfinite(loss)
     loss.backward()
     assert torch.isfinite(logits.grad).all()
+
+
+def test_cls_pw_config_defaults_strength_and_conflict():
+    assert TrainConfig().cls_pw == 0.0
+    assert TrainConfig.from_kwargs(cls_pw=0.5).to_dict()["cls_pw"] == 0.5
+    assert TrainConfig.from_kwargs(cls_pw=1).cls_pw == 1.0
+    assert TrainConfig.from_kwargs(cls_pw=0, class_weights=True).class_weights
+    assert TrainConfig.from_kwargs(cls_pw=0.5, class_weights=False).cls_pw == 0.5
+    with pytest.raises(ValueError, match="not both"):
+        TrainConfig.from_kwargs(cls_pw=0.5, class_weights=True)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        -0.1,
+        1.1,
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        None,
+        "0.5",
+        True,
+        False,
+        [0.5],
+    ],
+)
+def test_cls_pw_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="cls_pw must be a finite number"):
+        TrainConfig.from_kwargs(cls_pw=value)
+
+
+@pytest.mark.parametrize(
+    "saved,current",
+    [({"cls_pw": 0.5}, {}), ({"cls_pw": 0.5}, {"cls_pw": 1.0}), ({}, {"cls_pw": 0.5})],
+)
+def test_resume_rejects_changed_cls_pw_before_loading_weights(tmp_path, saved, current):
+    from libreyolo.models.resnet.trainer import ResNetTrainer
+
+    path = tmp_path / "checkpoint.pt"
+    torch.save({"config": saved, "model": {}}, path)
+    host = object.__new__(ResNetTrainer)
+    host.device = torch.device("cpu")
+    host.config = TrainConfig(**current)
+    with pytest.raises(ValueError, match="saved cls_pw setting"):
+        host.resume(str(path))
+
+
+@pytest.mark.parametrize(
+    "saved,current",
+    [
+        ({}, {}),
+        ({"class_weights": True}, {"class_weights": True}),
+        ({"cls_pw": 0.5}, {"cls_pw": 0.5}),
+    ],
+)
+def test_resume_accepts_legacy_and_matching_settings(tmp_path, saved, current):
+    from libreyolo.models.resnet.trainer import ResNetTrainer
+
+    host = ResNetTrainer(
+        model=torch.nn.Linear(2, 2),
+        wrapper_model=SimpleNamespace(task="classify"),
+        device="cpu",
+        project=str(tmp_path),
+        name="run",
+        **current,
+    )
+    path = tmp_path / "checkpoint.pt"
+    torch.save({"config": saved, "model": host.model.state_dict(), "epoch": 2}, path)
+    host.resume(str(path))
+    assert host.start_epoch == 3


### PR DESCRIPTION
- Refs #839; follow-up to #841. Add `cls_pw` power in `[0, 1]` to Python and both CLI grammars for the five supported image-classification families.
- Match the [documented parameter and mean-one weight contract](https://docs.ultralytics.com/modes/train/), including partial strength; this does not claim standalone-classification or whole-library numerical parity.
- Preserve `class_weights=True` normalization; reject enabling both forms and reject changed settings on resume. Reuse existing hard/soft-label, CNN graph/validation, and RF-DETR/DINOv2 loss paths.
- Verified: 6,653 local gate tests passed; three export failures match unchanged dev. ResNet-18 CPU `cls_pw=0.5` with MixUp and checkpoint/resume reached 100% train top-1 on a tiny fixture.
- Not verified: actual CUDA capture/AMP, weighting-specific multi-process DDP training, pretrained/transformer convergence, or external numerical parity. Greptile CLI unavailable.
- Opened by an agent; CI and automatic review pending.

## Code provenance
Original changes to LibreYOLO's first-party code using a sanitized public behavioral specification for the argument and mathematical weight definition. No third-party implementation was consulted, ported, or adapted by the implementing agent. This continues the maintainer-authorized independent provenance boundary disclosed in #841; no implementation was carried from the coordinating session.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61808193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/libreyolo/-/pull-requests/libreyolo/libreyolo/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

<details><summary><h3>Summary</h3></summary>

- Validates a finite power in `[0, 1]` and rejects conflicting weighting modes.
- Computes mean-one class weights from the complete classification training split.
- Propagates the option through Python, YAML, both CLI grammars, supported classifier trainers, validation loss, DDP, and checkpoints.
- Enforces an unchanged weighting policy when resuming and documents the numerical contract and compatibility behavior.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Python, YAML, or CLI cls_pw] --> B[Validate range and exclusivity]
    B --> C[Resolved TrainConfig]
    C --> D[Read complete training class counts]
    D --> E[Compute count^-cls_pw]
    E --> F[Normalize class-weight mean to one]
    F --> G[Classification loss]
    G --> H[Hard or soft labels]
    G --> I[Eager or CUDA-graph assembly]
    G --> J[Optional validation loss]
    C --> K[Checkpoint config]
    K --> L[Resume compatibility check]
```
</details>

<!-- /greptile_comment -->