### PR TITLE
Fix training monitor epoch off-by-one (#829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ before 1.4.0 are documented in the
 
 ### Fixed
 
+- **Training monitor no longer reports epochs off by one (#829).** The status
+  writer counted the one-based epoch number as a zero-based index, so
+  `status.json` claimed one more completed epoch than had run, and the monitor
+  page added another one on top: the first epoch was charted as 2 and a run
+  showed 100 % with ETA 0 while its last epoch was still training. Epoch
+  numbers are now one-based end to end (`current_epoch`, `best_epoch`, and
+  `metrics.jsonl` rows), and the page displays them as they are.
+
 - **RF-DETR, DINOv2 and VLM training no longer overwrite the previous run
   (#833).** Through the Python API, `train()` now increments the run
   directory like every other family (`exist_ok=False` by default) instead of

--- a/docs/training_loggers.md
+++ b/docs/training_loggers.md
@@ -269,7 +269,7 @@ without a third-party account or tailing the full log.
 
 | File | Written | Contents |
 |---|---|---|
-| `status.json` | rewritten atomically every epoch (+ on start/end/failure) | live snapshot: `state` (`running`/`completed`/`failed`), `current_epoch`, `total_epochs`, `progress`, `eta_seconds`, latest `metrics`, `best_metric`/`best_epoch`, and on failure an `error` `{type, message}` |
+| `status.json` | rewritten atomically every epoch (+ on start/end/failure) | live snapshot: `state` (`running`/`completed`/`failed`), `current_epoch` (one-based, the epoch that last finished), `completed_epochs`, `total_epochs`, `progress`, `eta_seconds`, latest `metrics`, `best_metric`/`best_epoch`, and on failure an `error` `{type, message}` |
 | `metrics.jsonl` | appended once per epoch | one JSON row per epoch (same schema as the family `results.csv`), the full history for charts |
 | `train.log` | tee'd live | the run's `libreyolo` console output |
 

--- a/libreyolo/training/artifacts.py
+++ b/libreyolo/training/artifacts.py
@@ -423,7 +423,9 @@ class TrainingStatusCallback:
         self._epoch_time_sum += event.epoch_seconds
         self._epoch_time_count += 1
         mean_epoch = self._epoch_time_sum / max(self._epoch_time_count, 1)
-        completed = event.epoch + 1
+        # ``event.epoch`` is the one-based number of the epoch that just
+        # finished, so it is also the count of completed epochs.
+        completed = event.epoch
         remaining = max(event.total_epochs - completed, 0)
         metrics = {
             name.removeprefix("metrics/"): value

--- a/libreyolo/ui/train_monitor_page.py
+++ b/libreyolo/ui/train_monitor_page.py
@@ -193,7 +193,7 @@ async function renderIndex() {
   $("runlist").innerHTML = runs.map(r => {
     const st = (r.state || "unknown").toLowerCase();
     const ep = r.total_epochs != null
-      ? `${r.current_epoch != null ? r.current_epoch + 1 : (r.state === 'completed' ? r.total_epochs : 0)}/${r.total_epochs}` : "-";
+      ? `${r.current_epoch != null ? r.current_epoch : (r.state === 'completed' ? r.total_epochs : 0)}/${r.total_epochs}` : "-";
     const best = r.best_metric != null ? `${r.best_metric_name || "best"} ${fmtNum(r.best_metric)}` : "";
     return `<a class="runcard" href="/?run=${encodeURIComponent(r.id)}">
       <div class="top"><span class="badge ${st}">${st}</span>
@@ -219,14 +219,14 @@ async function refreshStatus() {
   $("runpath").textContent = s.save_dir || RUN;
 
   const cards = [];
-  const cur = s.current_epoch != null ? s.current_epoch + 1 : (s.completed_epochs || 0);
+  const cur = s.current_epoch != null ? s.current_epoch : (s.completed_epochs || 0);
   cards.push(card("Epoch", `${cur} / ${s.total_epochs ?? "-"}`,
     s.mean_epoch_seconds ? `${fmtSecs(s.mean_epoch_seconds)}/epoch` : ""));
   cards.push(card("ETA", state === "running" ? fmtSecs(s.eta_seconds) : "-",
     `elapsed ${fmtSecs(s.elapsed_seconds)}`));
   const metricName = s.best_metric_name || s.current_metric_name || "metric";
   cards.push(card(`Best ${metricName}`, fmtNum(s.best_metric),
-    s.best_epoch != null ? `epoch ${s.best_epoch + 1}` : ""));
+    s.best_epoch != null ? `epoch ${s.best_epoch}` : ""));
   cards.push(card("Train loss", fmtNum(s.train_loss, 4),
     s.model_family ? `${s.model_family}${s.model_size || ""} ${s.task || ""}` : ""));
   if (s.metrics && s.metrics.loss != null) {
@@ -301,7 +301,7 @@ async function refreshMetrics() {
   const rows = m.rows || [];
   if (!rows.length) { $("metrics-empty").style.display = "block"; return; }
   $("metrics-empty").style.display = "none";
-  const xs = rows.map(r => r.epoch != null ? r.epoch + 1 : 0);
+  const xs = rows.map(r => r.epoch != null ? r.epoch : 0);
   const lossCols = (m.columns || []).filter(c => c.startsWith("train/") && c.includes("loss"));
   const primaryLoss = lossCols.includes("train/loss") ? "train/loss" : lossCols[0];
   const valLoss = (m.columns || []).includes("metrics/loss") ? "metrics/loss" : null;

--- a/tests/unit/test_training_status.py
+++ b/tests/unit/test_training_status.py
@@ -31,7 +31,7 @@ def _start(save_dir, *, start_epoch=1):
     )
 
 
-def _epoch(save_dir, *, epoch=0, metric=0.5, best_epoch=0):
+def _epoch(save_dir, *, epoch=1, metric=0.5, best_epoch=1):
     return TrainEpochEvent(
         epoch=epoch,
         total_epochs=4,
@@ -85,10 +85,11 @@ def test_status_running_then_completed(tmp_path):
     assert running["total_epochs"] == 4
     assert running["pid"] > 0
 
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0, metric=0.5))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1, metric=0.5))
     mid = _load(tmp_path)
     assert mid["state"] == "running"
-    assert mid["current_epoch"] == 0
+    # Epoch numbers are one-based end to end: the first completed epoch is 1.
+    assert mid["current_epoch"] == 1
     assert mid["completed_epochs"] == 1
     assert mid["progress"] == pytest.approx(0.25)
     assert mid["metrics"]["mAP50-95"] == pytest.approx(0.5)
@@ -105,7 +106,7 @@ def test_status_running_then_completed(tmp_path):
 def test_status_failed_records_error(tmp_path):
     cb = TrainingStatusCallback()
     cb.on_train_start(_start(tmp_path))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1))
     exc = RuntimeError("CUDA out of memory")
     cb.on_train_exception(
         TrainExceptionEvent(
@@ -131,7 +132,7 @@ def test_status_atomic_write_is_valid_json_every_time(tmp_path):
     """status.json must always parse; never a half-written file."""
     cb = TrainingStatusCallback(write_log=False)
     cb.on_train_start(_start(tmp_path))
-    for e in range(4):
+    for e in range(1, 5):
         cb.on_train_epoch_end(_epoch(tmp_path, epoch=e))
         json.loads((tmp_path / "status.json").read_text())  # raises if corrupt
 
@@ -168,8 +169,8 @@ def test_metrics_jsonl_written_and_read(tmp_path):
     """Every family gets a universal, chart-ready metrics.jsonl history."""
     cb = TrainingStatusCallback(write_log=False)
     cb.on_train_start(_start(tmp_path))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0, metric=0.5))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1, metric=0.55))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1, metric=0.5))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=2, metric=0.55))
 
     lines = (tmp_path / "metrics.jsonl").read_text().strip().splitlines()
     assert len(lines) == 2
@@ -184,10 +185,10 @@ def test_metrics_jsonl_written_and_read(tmp_path):
 def test_metrics_jsonl_reset_on_fresh_run(tmp_path):
     cb = TrainingStatusCallback(write_log=False)
     cb.on_train_start(_start(tmp_path))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1))
     # A new fresh run (start_epoch=1) must clear stale history.
     cb.on_train_start(_start(tmp_path, start_epoch=1))
-    cb.on_train_epoch_end(_epoch(tmp_path, epoch=0))
+    cb.on_train_epoch_end(_epoch(tmp_path, epoch=1))
     lines = (tmp_path / "metrics.jsonl").read_text().strip().splitlines()
     assert len(lines) == 1
 


### PR DESCRIPTION
Fixes #829. Supersedes #831 by fixing the consumers instead of the shared event contract.

`TrainEpochEvent.epoch` is the one-based number of the epoch that just finished, and callbacks, CSV artifacts and experiment loggers already rely on that. `TrainingStatusCallback` treated it as a zero-based index (`completed = event.epoch + 1`), so `status.json` claimed one more completed epoch than had run, and the monitor page added another `+ 1` when rendering `current_epoch`, `best_epoch` and the chart x-axis. Net effect: first epoch charted as 2, and 5/5 with ETA 0 while the last epoch was still training.

- `TrainingStatusCallback.on_train_epoch_end`: `completed_epochs = event.epoch`.
- Monitor page: render `current_epoch`, `best_epoch` and `metrics.jsonl` epochs as-is (all one-based).
- Status tests now feed one-based epochs and assert the one-based snapshot; docs and changelog updated.

Checked: 155 unit tests across status, artifacts, callbacks and loggers pass. Not verified: a live monitor session against a real run.
Opened by an agent.

## Code provenance

Original code written for this PR. No third-party code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GK4cMFoN3zyaqAitmd8D95

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61816977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/libreyolo/-/pull-requests/libreyolo/libreyolo/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation appears safe to merge, with a non-blocking test-coverage gap around the corrected monitor rendering.

<h2><a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fui%2Ftrain_monitor_page.py%3A196%0AThe%20updated%20status%20tests%20verify%20that%20artifacts%20contain%20one-based%20epoch%20values%2C%20but%20they%20do%20not%20cover%20the%20run-card%20label%2C%20status%20card%2C%20best-epoch%20label%2C%20or%20chart%20x-axis%20changed%20here%20and%20at%20lines%20222%2C%20229%2C%20and%20304.%20Add%20assertions%20against%20%60INDEX_HTML%60%2C%20following%20the%20existing%20monitor-page%20test%20pattern%2C%20so%20a%20future%20offset%20change%20cannot%20silently%20recreate%20the%20display%20bug.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=843&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Monitor Fix Lacks Coverage** <a href="https://github.com/LibreYOLO/libreyolo/pull/843#discussion_r3962467786">▶</a>

<details><summary><h3>Summary</h3></summary>

- Counts completed epochs directly from `TrainEpochEvent.epoch`.
- Removes redundant display offsets from current epoch, best epoch, and chart data.
- Updates status tests, documentation, and the changelog to describe the contract.
- The changed monitor expressions still lack direct regression coverage.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[Trainer epoch loop] -->|one-based TrainEpochEvent.epoch| C[TrainingStatusCallback]
  C -->|current_epoch and completed_epochs| S[status.json]
  C -->|epoch| M[metrics.jsonl]
  S --> U[Training monitor]
  M --> U
  U -->|render values without offset| D[Epoch labels and chart x-axis]
```
</details>

<!-- /greptile_comment -->