### PR TITLE
Add native FCOS3D inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Panoptic segmentation** | EoMT |
 | **Pose** | RF-DETR, YOLO-NAS, HRNet, DEKR, EC |
 | **Oriented boxes** | RF-DETR, RT-DETRv2, YOLO-NAS-R |
-| **3D detection** | WildDet3D, 3D-MOOD |
+| **3D detection** | WildDet3D, 3D-MOOD, FCOS3D |
 | **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, DINOv2 |
 | **Depth** | Depth Anything 3, Depth Anything V2, ZipDepth, MiDaS |
 | **Surface normals** | MoGe-2 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,7 +110,7 @@ libreyolo predict --model yolo9-t --source screen            # 屏幕捕获
 | **全景分割** | EoMT |
 | **姿态** | RF-DETR、YOLO-NAS、HRNet、DEKR、EC |
 | **旋转框（OBB）** | RF-DETR、RT-DETRv2、YOLO-NAS-R |
-| **三维检测** | WildDet3D、3D-MOOD |
+| **三维检测** | WildDet3D、3D-MOOD、FCOS3D |
 | **分类** | MobileNetV4、ConvNeXt、EfficientNetV2、ResNet、ViT、Swin、DeiT、VGG、AlexNet、CLIP、SigLIP2、DINOv2 |
 | **深度估计** | Depth Anything 3、Depth Anything V2、ZipDepth、MiDaS |
 | **表面法线** | MoGe-2 |

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -2231,3 +2231,228 @@ Used for: OpenCV cuboid dimension-to-axis mapping and corner ordering in
 libreyolo/utils/results.py::Boxes3D.corners and the associated wireframe edges.
 Reference: vis4d/op/box/box3d.py::boxes3d_to_corners, AxisMode.OPENCV.
 The implementation remains numpy-based; vis4d is not a core dependency.
+
+
+FCOS3D inference implementation
+
+Derived from OpenMMLab, Apache License 2.0:
+- https://github.com/open-mmlab/mmdetection3d
+  Revision: fe25f7a51d36e3702f961e198894580d83c4387b
+  Source: FCOSMono3DHead, AnchorFreeMono3DHead, FCOS3DBBoxCoder, FCOS3D configs.
+- https://github.com/open-mmlab/mmdetection
+  Revision: cfd5d3a985b0249de009b67d04f37263e11cdf3d
+  Source: ResNet, ResLayer and FPN.
+Copyright (c) OpenMMLab. All rights reserved.
+
+LibreYOLO changes: standalone PyTorch network, no framework registry or
+training dependencies, torchvision deform_conv2d, camera Results mapping.
+The torchvision operator is a separately installed BSD-3-Clause dependency.
+No third-party C++/CUDA operator source is bundled.
+
+This notice covers code, not the official nuScenes checkpoint. Its separate
+redistribution terms have not been established; no weights are bundled or
+hosted by this port.
+
+Copyright 2018-2019 Open-MMLab. All rights reserved.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2019 Open-MMLab.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/adr/0023-fcos3d-inference.md
+++ b/docs/adr/0023-fcos3d-inference.md
@@ -47,7 +47,8 @@ Ranking confidence is sigmoid(class logit) times sigmoid(centerness).
 `conf2d` stores that joint score and `conf3d` is 1, a neutral factor rather
 than an independently predicted confidence. Velocity and attribute logits
 are not exposed. Suppression is per-class rotated bird's-eye-view IoU,
-with default threshold 0.8, followed by a global `max_det` cap. Returned rows
+with default threshold 0.8, followed by a global `max_det` cap. Equality
+with the IoU threshold suppresses a box, matching upstream CPU NMS. Returned rows
 are sorted by descending score. CPU polygon intersection uses OpenCV.
 
 ## Checkpoints and provenance

--- a/docs/adr/0023-fcos3d-inference.md
+++ b/docs/adr/0023-fcos3d-inference.md
@@ -1,0 +1,90 @@
+# ADR 0023: Native FCOS3D inference
+
+Status: implemented; CPU inference validated
+Date: 2026-09-10
+
+## Interface
+
+`LibreFCOS3D` is a native PyTorch implementation of FCOS3D R101-DCN for the
+ten nuScenes classes. It uses the `detect3d` and `Results.boxes3d` contracts
+in ADR 0021. It is a sibling API because prediction requires camera
+calibration that the generic factory and GUI do not currently carry.
+
+```python
+import numpy as np
+from libreyolo import LibreFCOS3D
+
+model = LibreFCOS3D("fcos3d-official.pth", device="cpu")
+result = model("image.jpg", intrinsics=np.load("intrinsics.npy"), conf=0.15)
+result.plot().save("cuboids.png")
+```
+
+```sh
+libreyolo fcos3d model=fcos3d-official.pth source=image.jpg \
+  intrinsics=intrinsics.npy conf=0.15 save=true --json
+```
+
+The CLI also accepts `--key value`. A single image returns `Results`, a list
+or directory returns a list, and `stream=True` returns a generator. Shared
+calibration applies to all images in a multi-image call. The calibration
+must describe each original image, with positive focal lengths and zero
+skew. Pixels are not resized: BGR Caffe mean subtraction and right/bottom
+padding to a multiple of 32 match the official test pipeline.
+
+CPU and CUDA are callable; CUDA has not been validated. MPS is rejected
+because torchvision's deformable convolution has no MPS kernel. The runtime
+requires neither MMCV nor a separate model environment.
+
+## Geometry and score contract
+
+The head predicts gravity-center xyz, local xyz extents, and camera yaw.
+The adapter stores dimensions as wlh = (z extent, x extent, y extent) and a
+scalar-first quaternion rotating around camera y. Centres and dimensions
+are in metres. The 2D boxes are clipped projected cuboid hulls, aligned with
+the 3D rows. Cuboids crossing the near plane are clipped before projection.
+
+Ranking confidence is sigmoid(class logit) times sigmoid(centerness).
+`conf2d` stores that joint score and `conf3d` is 1, a neutral factor rather
+than an independently predicted confidence. Velocity and attribute logits
+are not exposed. Suppression is per-class rotated bird's-eye-view IoU,
+with default threshold 0.8, followed by a global `max_det` cap. Returned rows
+are sorted by descending score. CPU polygon intersection uses OpenCV.
+
+## Checkpoints and provenance
+
+The constructor requires the unchanged official R101 nuScenes checkpoint
+with a `state_dict` wrapper. It validates the class order when supplied and
+loads all tensors strictly. There is no automatic download or converted
+LibreYOLO checkpoint for this family yet.
+
+Implementation sources are Apache-2.0, pinned in the family NOTICE:
+MMDetection3D `fe25f7a51d36e3702f961e198894580d83c4387b` and MMDetection
+`cfd5d3a985b0249de009b67d04f37263e11cdf3d`. No C++ or CUDA source is vendored.
+
+The official model is listed in the
+[FCOS3D model zoo](https://github.com/open-mmlab/mmdetection3d/tree/fe25f7a51d36e3702f961e198894580d83c4387b/configs/fcos3d).
+The code license does not establish a separate checkpoint redistribution
+license. nuScenes also has
+[non-commercial dataset terms](https://www.nuscenes.org/terms-of-use).
+Checkpoint rehosting remains unresolved; no Hugging Face upload is made.
+No dataset images, annotations, checkpoint bytes, or validation artifacts
+are distributed with this implementation.
+
+## Validation and limits
+
+The official finetuned checkpoint (published July 2021) loads with every
+state-dict key and shape matching. Native backbone, FPN and all five head
+output groups match the pinned upstream Python implementation exactly on
+seeded 128x256 and 160x224 inputs. That comparison uses MMCV-lite Python
+layers and torchvision deformable convolution on both sides. It verifies
+the inference graph, not numerical parity with MMCV's compiled CUDA kernel.
+
+A real 1600x900 nuScenes front-camera sample with its provided calibration
+runs on CPU and produces a projected cuboid overlay. This is a smoke and
+rendering check, not an accuracy benchmark. Unit tests cover preprocessing,
+deformable-convolution baseline behaviour, camera decoding, axis mapping,
+NMS class isolation, empty outputs, slicing, multi-input calls and the CLI.
+
+Training, generic validation, export and tracking raise explicit unsupported
+errors. There is no nuScenes mAP claim, no CUDA validation, and no generic
+GUI registration because the GUI does not supply calibration.

--- a/docs/adr/0023-fcos3d-inference.md
+++ b/docs/adr/0023-fcos3d-inference.md
@@ -74,17 +74,51 @@ are distributed with this implementation.
 
 The official finetuned checkpoint (published July 2021) loads with every
 state-dict key and shape matching. Native backbone, FPN and all five head
-output groups match the pinned upstream Python implementation exactly on
-seeded 128x256 and 160x224 inputs. That comparison uses MMCV-lite Python
-layers and torchvision deformable convolution on both sides. It verifies
-the inference graph, not numerical parity with MMCV's compiled CUDA kernel.
+output groups match the pinned upstream Python implementation exactly.
 
-A real 1600x900 nuScenes front-camera sample with its provided calibration
-runs on CPU and produces a projected cuboid overlay. This is a smoke and
-rendering check, not an accuracy benchmark. Unit tests cover preprocessing,
-deformable-convolution baseline behaviour, camera decoding, axis mapping,
-NMS class isolation, empty outputs, slicing, multi-input calls and the CLI.
+Final detections were compared on six calibrated nuScenes camera views at
+confidence thresholds 0.05, 0.15 and 0.30 (18 comparisons), using IoU 0.8 and
+max_det 200. The reference uses the original upstream inference methods and
+MMCV C++ CPU implementations of modulated deformable convolution and rotated
+NMS, compiled without modifying their source. Training-only registry imports
+are replaced by a minimal harness; inference method bodies are unchanged.
+The native path uses torchvision deformable convolution and OpenCV NMS.
 
+All 18 comparisons match detection counts, class ids, scores and dimensions.
+Preprocessed pixels and raw network outputs match exactly. Maximum center
+drift is 0.000005723 metres; maximum matched-corner distance is 0.000006671
+metres. These are rounding differences from camera-coordinate conversion.
+Rows are compared after sorting the upstream results by score. This proves
+CPU parity on the recorded images, not CUDA parity or benchmark accuracy.
+
+The reference operator revision is MMCV
+`a8073c74bf83d62ec36a103f835faa4837fb6585` (Apache-2.0). Its rotated-IoU
+implementation credits Detectron2 (Apache-2.0); its CPU NMS also credits
+torchvision (BSD-3-Clause). These reference sources and compiled binaries
+are not bundled in the library.
+
+The manual parity test replays locally staged upstream outputs:
+
+```sh
+LIBREYOLO_FCOS3D_CHECKPOINT=/path/to/fcos3d-official.pth \
+LIBREYOLO_FCOS3D_REFERENCE=/path/to/detection-parity-reference.json \
+  pytest tests/e2e/test_fcos3d.py -m e2e -q
+```
+
+The JSON reference bundle has `schema_version: 1`, `checkpoint_sha256`,
+`reference` revision identifiers (`mmdetection3d`, `mmdetection`, `mmcv`),
+and 18 `cases`. Each case records its `camera`, `conf`, `count`, image
+basename and SHA-256, original-image `intrinsics`, and `expected` arrays:
+`labels`, `scores`, gravity `centers`, wlh `dimensions`, and camera-frame
+`corners`. Cases cover all six standard camera names at the three thresholds
+above. Images sit beside the JSON. The test checks checkpoint/image hashes,
+coverage, labels, scores and physical cuboid geometry. Neither this dataset
+bundle nor the checkpoint has an automatic download route; the test is not
+in the gated nightly.
+
+Unit tests cover preprocessing, deformable-convolution baseline behaviour,
+camera decoding, axis mapping, NMS class isolation, empty outputs, slicing,
+multi-input calls and the CLI. A real-image CPU overlay was visually checked.
 Training, generic validation, export and tracking raise explicit unsupported
 errors. There is no nuScenes mAP claim, no CUDA validation, and no generic
 GUI registration because the GUI does not supply calibration.

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -47,6 +47,7 @@ in preflight.
 | faster_rcnn | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
 | fcn | semantic | ✓ | ✓ |  | ✓ | ✓ |  |  |  |  |  |  |  |
 | fcos | detect | ✓ | ✓ |  |  | available |  |  |  |  |  |  |  |
+| fcos3d | detect3d |  |  |  |  |  |  |  |  |  |  |  |  |
 | feynobg | matte | available | ✓ |  |  |  |  |  |  |  |  |  |  |
 | florence2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | fomo | point | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  | ✓ |  |  | ✓ |
@@ -896,6 +897,18 @@ These converter paths are callable with the recorded validation context.
 - `fcos` / `detect` / `tflite`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
 - `fcos` / `detect` / `coreml`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
 - `fcos` / `detect` / `coreai`: No runtime parity contract exists for FCOS dynamic anchor grids and variable padded spatial shapes in this format.
+- `fcos3d` / `detect3d` / `onnx`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `torchscript`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `executorch`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `tensorrt`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `openvino`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `paddle`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `mnn`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `rknn`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `ncnn`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `tflite`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `coreml`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `fcos3d` / `detect3d` / `coreai`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
 - `feynobg` / `matte` / `executorch`: The fixed 1024x1024 large graph exceeded the local conversion timebox while its working set grew past 4.7 GB; no .pte artifact was produced, so runtime parity remains untested.
 - `feynobg` / `matte` / `tensorrt`: TensorRT 10.16 reaches the shared ONNX DeformConv node but cannot parse it because ModulatedDeformConv2d is absent from the plugin registry.
 - `feynobg` / `matte` / `openvino`: OpenVINO 2026.2 cannot lower the shared matte decoder's standard ONNX DeformConv-19 operation.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -1006,3 +1006,11 @@ coordinates in results.
 It shares the `detect3d` result and camera convention, adds
 `Results.depth_map`, and is invoked through `libreyolo 3dmood`. It is not part
 of the generic checkpoint factory. See ADR 0022.
+
+### FCOS3D
+
+`LibreFCOS3D` (`fcos3d`, group `s`, variant `r101`) is a native inference-only
+sibling for calibrated monocular `detect3d`. It accepts the unchanged local
+R101 nuScenes checkpoint. No canonical downloadable filename is registered
+while checkpoint redistribution terms remain unresolved. See
+[ADR 0023](adr/0023-fcos3d-inference.md) for API and evidence.

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -214,6 +214,7 @@ def __getattr__(name):
         "LibreSenseNovaVision": (".models.sensenova", "LibreSenseNovaVision"),
         "LibreMODUS": (".models.modus", "LibreMODUS"),
         "LibreModus": (".models.modus", "LibreModus"),
+        "LibreFCOS3D": (".models.fcos3d", "LibreFCOS3D"),
         "LibreWildDet3D": (".models.wilddet3d", "LibreWildDet3D"),
         "Libre3DMOOD": (".models.mood3d", "Libre3DMOOD"),
         "LibreSAM": (".models.sam", "LibreSAM"),
@@ -361,6 +362,8 @@ __all__ = [
     "LibreModus",
     # OpenAI-compatible LLM client (optional, requires libreyolo[llm])
     "LibreLLM",
+    # Calibrated native monocular 3D detection
+    "LibreFCOS3D",
     # Promptable 3D detection (separately installed upstream runtime)
     "LibreWildDet3D",
     "Libre3DMOOD",

--- a/libreyolo/cli/__init__.py
+++ b/libreyolo/cli/__init__.py
@@ -118,6 +118,9 @@ def entrypoint() -> None:
     # Face identification: build a gallery from a folder-per-person tree.
     app.command("enroll", cls=KeyValueCommand)(special.enroll_cmd)
 
+    from .commands.fcos3d import fcos3d_cmd
+
+    app.command("fcos3d", cls=KeyValueCommand)(fcos3d_cmd)
     from .commands.wilddet3d import wilddet3d_cmd
 
     app.command("wilddet3d", cls=KeyValueCommand)(wilddet3d_cmd)

--- a/libreyolo/cli/commands/fcos3d.py
+++ b/libreyolo/cli/commands/fcos3d.py
@@ -1,0 +1,88 @@
+"""Calibrated monocular 3D detection with native FCOS3D."""
+
+import typer
+
+from ..command_utils import exit_with_error, help_json_callback
+from ..output import OutputHandler
+
+
+def fcos3d_cmd(
+    source: str = typer.Option(..., help="Image path or directory"),
+    model: str = typer.Option(
+        ..., help="Local official FCOS3D R101 nuScenes checkpoint"
+    ),
+    intrinsics: str = typer.Option(
+        ..., help="Original-image 3x3 camera calibration .npy file"
+    ),
+    device: str = typer.Option("auto", help="auto, cpu, or a CUDA device"),
+    conf: float | None = typer.Option(None, help="Joint confidence threshold"),
+    iou: float | None = typer.Option(
+        None, help="Rotated bird's-eye-view NMS threshold"
+    ),
+    max_det: int = typer.Option(200, help="Maximum number of detections per image"),
+    save: bool = typer.Option(False, help="Save projected cuboids"),
+    output_path: str | None = typer.Option(None, help="Single-image output filename"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output to stdout"),
+    quiet: bool = typer.Option(False, "--quiet", help="Suppress stderr"),
+    help_json: bool = typer.Option(
+        False,
+        "--help-json",
+        is_eager=True,
+        callback=help_json_callback,
+        help="Dump command schema as JSON",
+    ),
+) -> None:
+    """Detect metric 3D boxes with a known camera calibration."""
+    import os
+    import sys
+    from contextlib import ExitStack, redirect_stderr, redirect_stdout
+
+    import numpy as np
+
+    out = OutputHandler(json_mode=json_output, quiet=quiet)
+    try:
+        calibration = np.load(intrinsics, allow_pickle=False)
+        thresholds = {
+            key: value
+            for key, value in (("conf", conf), ("iou", iou))
+            if value is not None
+        }
+        with ExitStack() as stack:
+            destination = (
+                stack.enter_context(open(os.devnull, "w")) if quiet else sys.stderr
+            )
+            stack.enter_context(redirect_stdout(destination))
+            if quiet:
+                stack.enter_context(redirect_stderr(destination))
+            from libreyolo import LibreFCOS3D
+
+            model_obj = LibreFCOS3D(model, device=device)
+            results = model_obj.predict(
+                source,
+                intrinsics=calibration,
+                max_det=max_det,
+                save=save,
+                output_path=output_path,
+                **thresholds,
+            )
+        results = results if isinstance(results, list) else [results]
+        out.result(
+            {
+                "task": "detect3d",
+                "model": model,
+                "results": [
+                    {
+                        "path": r.path,
+                        "detections": r.summary(),
+                        "intrinsics": r.boxes3d.numpy().intrinsics.tolist(),
+                    }
+                    for r in results
+                ],
+            }
+        )
+    except (ValueError, TypeError) as exc:
+        exit_with_error(out, "config_type_error", str(exc))
+    except (ImportError, RuntimeError) as exc:
+        exit_with_error(out, "model_load_failed", str(exc))
+    except OSError as exc:
+        exit_with_error(out, "io_error", str(exc))

--- a/libreyolo/models/fcos3d/LICENSE
+++ b/libreyolo/models/fcos3d/LICENSE
@@ -1,0 +1,203 @@
+Copyright 2018-2019 Open-MMLab. All rights reserved.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2019 Open-MMLab.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libreyolo/models/fcos3d/NOTICE
+++ b/libreyolo/models/fcos3d/NOTICE
@@ -1,0 +1,19 @@
+FCOS3D inference implementation
+
+Derived from OpenMMLab, Apache License 2.0:
+- https://github.com/open-mmlab/mmdetection3d
+  Revision: fe25f7a51d36e3702f961e198894580d83c4387b
+  Source: FCOSMono3DHead, AnchorFreeMono3DHead, FCOS3DBBoxCoder, FCOS3D configs.
+- https://github.com/open-mmlab/mmdetection
+  Revision: cfd5d3a985b0249de009b67d04f37263e11cdf3d
+  Source: ResNet, ResLayer and FPN.
+Copyright (c) OpenMMLab. All rights reserved.
+
+LibreYOLO changes: standalone PyTorch network, no framework registry or
+training dependencies, torchvision deform_conv2d, camera Results mapping.
+The torchvision operator is a separately installed BSD-3-Clause dependency.
+No third-party C++/CUDA operator source is bundled.
+
+This notice covers code, not the official nuScenes checkpoint. Its separate
+redistribution terms have not been established; no weights are bundled or
+hosted by this port.

--- a/libreyolo/models/fcos3d/__init__.py
+++ b/libreyolo/models/fcos3d/__init__.py
@@ -1,0 +1,5 @@
+"""Native FCOS3D monocular 3D detection."""
+
+from .model import LibreFCOS3D
+
+__all__ = ["LibreFCOS3D"]

--- a/libreyolo/models/fcos3d/model.py
+++ b/libreyolo/models/fcos3d/model.py
@@ -1,0 +1,180 @@
+"""Native FCOS3D inference with camera calibration and standard Results."""
+
+import time
+from pathlib import Path
+from typing import ClassVar
+
+import numpy as np
+import torch
+
+from ...utils.image_loader import SUPPORTED_EXTENSIONS, ImageLoader
+from ...utils.results import Results
+from ...utils.serialization import load_untrusted_torch_file
+from .nn import FCOS3DNetwork
+from .utils import NAMES, calibration, decode, payloads, preprocess
+
+
+class LibreFCOS3D:
+    """FCOS3D R101-DCN for the ten nuScenes classes, inference-only.
+
+    Supply a local official checkpoint and original-image pinhole intrinsics.
+    Images retain their resolution; padding is only on the right and bottom.
+    Single images return Results; sequences/directories return lists and
+    stream=True returns a generator. NumPy input color follows ImageLoader.
+    The aligned 2D boxes are projected cuboid hulls, not a separate 2D head.
+    Training, validation, tracking and export are not implemented.
+    """
+
+    FAMILY = "fcos3d"
+    CLI_COMMAND = "fcos3d"
+    FILENAME_PREFIX = "LibreFCOS3D"
+    SUPPORTED_TASKS = ("detect3d",)
+    DEFAULT_TASK = "detect3d"
+    INPUT_SIZES: ClassVar[dict[str, int]] = {"r101": 1600}
+    TASK_INPUT_SIZES: ClassVar[dict] = {}
+    DEFAULT_CONF = 0.05
+    DEFAULT_IOU = 0.8
+
+    def __init__(self, model_path, *, device="auto"):
+        self.model_path = Path(model_path).expanduser()
+        if not self.model_path.is_file():
+            raise FileNotFoundError(
+                f"FCOS3D requires a local official R101 nuScenes checkpoint: {self.model_path}"
+            )
+        if isinstance(device, int) or str(device).isdigit():
+            device = f"cuda:{device}"
+        if device == "auto":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = torch.device(device)
+        if self.device.type not in {"cpu", "cuda"}:
+            raise ValueError(
+                "FCOS3D supports cpu or cuda; torchvision deform_conv2d does not support MPS."
+            )
+        checkpoint = load_untrusted_torch_file(self.model_path, map_location="cpu")
+        if not isinstance(checkpoint, dict) or not isinstance(
+            checkpoint.get("state_dict"), dict
+        ):
+            raise TypeError(
+                "Expected an official FCOS3D checkpoint with a state_dict."
+            )
+        metadata = checkpoint.get("meta", {})
+        if not isinstance(metadata, dict):
+            raise TypeError("FCOS3D checkpoint meta must be a dictionary.")
+        classes = metadata.get("CLASSES")
+        if classes is not None and tuple(classes) != tuple(NAMES.values()):
+            raise ValueError(
+                "FCOS3D checkpoint classes do not match the supported nuScenes class order."
+            )
+        self.model = FCOS3DNetwork()
+        self.model.load_state_dict(checkpoint["state_dict"], strict=True)
+        self.model.to(self.device).eval()
+        self.names = NAMES.copy()
+        self.task = self.DEFAULT_TASK
+        self.size = "r101"
+
+    @classmethod
+    def get_download_url(cls, filename):
+        """No hosted checkpoint until redistribution terms are established."""
+        return None
+
+    @staticmethod
+    def _threshold(value, name):
+        if isinstance(value, bool) or not np.isfinite(value) or not 0 <= value <= 1:
+            raise ValueError(f"{name} must be a finite number in [0, 1].")
+        return float(value)
+
+    def predict(
+        self,
+        source,
+        *,
+        intrinsics,
+        conf=DEFAULT_CONF,
+        iou=DEFAULT_IOU,
+        max_det=200,
+        stream=False,
+        save=False,
+        output_path=None,
+        color_format="auto",
+    ):
+        """Predict metric cuboids with known original-image camera calibration."""
+        k = calibration(intrinsics)
+        conf = self._threshold(conf, "conf")
+        iou = self._threshold(iou, "iou")
+        if isinstance(max_det, bool) or not isinstance(max_det, int) or max_det <= 0:
+            raise ValueError("max_det must be a positive integer.")
+        many = isinstance(source, (list, tuple))
+        if isinstance(source, (str, Path)) and Path(source).is_dir():
+            source = sorted(
+                p
+                for p in Path(source).iterdir()
+                if p.suffix.lower() in SUPPORTED_EXTENSIONS
+            )
+            many = True
+        sources = list(source) if many else [source]
+        if output_path is not None and (not save or len(sources) != 1):
+            raise ValueError("output_path requires save=True with a single image.")
+
+        def generate():
+            save_dir = None
+            for index, item in enumerate(sources):
+                start = time.perf_counter()
+                image = ImageLoader.load(item, color_format=color_format)
+                shape = (image.height, image.width)
+                tensor = preprocess(image).to(self.device)
+                ready = time.perf_counter()
+                with torch.inference_mode():
+                    raw = self.model(tensor)
+                    if self.device.type == "cuda":
+                        torch.cuda.synchronize(self.device)
+                    inferred = time.perf_counter()
+                    boxes, scores, labels = decode(raw, k, conf, iou, max_det)
+                boxes2d, boxes3d = payloads(boxes, scores, labels, k, shape)
+                result = Results(
+                    boxes2d,
+                    shape,
+                    path=str(item) if isinstance(item, (str, Path)) else None,
+                    names=self.names.copy(),
+                    boxes3d=boxes3d,
+                    speed={
+                        "preprocess": (ready - start) * 1000,
+                        "inference": (inferred - ready) * 1000,
+                        "postprocess": (time.perf_counter() - inferred) * 1000,
+                    },
+                )
+                if save:
+                    if output_path:
+                        target = Path(output_path)
+                    else:
+                        if save_dir is None:
+                            from ...utils.general import increment_path
+
+                            save_dir = increment_path(
+                                Path("runs/detect3d/predict"), mkdir=True
+                            )
+                        target = save_dir / f"image_{index}.png"
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    result.plot(image).save(target)
+                yield result
+
+        output = generate()
+        return output if stream else (list(output) if many else next(output))
+
+    __call__ = predict
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError(
+            "FCOS3D training requires a dedicated 3D dataset and trainer."
+        )
+
+    def val(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Use the upstream nuScenes evaluator for FCOS3D accuracy; 2D mAP is not 3D evaluation."
+        )
+
+    def export(self, *args, **kwargs):
+        raise NotImplementedError(
+            "FCOS3D export has not been implemented or validated."
+        )
+
+    def track(self, *args, **kwargs):
+        raise NotImplementedError("FCOS3D tracking is not implemented.")

--- a/libreyolo/models/fcos3d/nn.py
+++ b/libreyolo/models/fcos3d/nn.py
@@ -1,0 +1,218 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""FCOS3D ResNet101-DCN inference network.
+
+Adapted from OpenMMLab's Apache-2.0 implementations; see NOTICE for pins.
+LibreYOLO removes framework registries and uses torchvision's deformable op.
+State-dict names match the official nuScenes checkpoint.
+"""
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torchvision.ops import deform_conv2d
+
+
+class ModulatedConv(nn.Conv2d):
+    """DCNv2 with a learned offset/mask convolution."""
+
+    def __init__(self, channels, *, bias=False):
+        super().__init__(channels, channels, 3, padding=1, bias=bias)
+        self.conv_offset = nn.Conv2d(channels, 27, 3, padding=1)
+        nn.init.zeros_(self.conv_offset.weight)
+        nn.init.zeros_(self.conv_offset.bias)
+
+    def forward(self, x):
+        offset_mask = self.conv_offset(x)
+        return deform_conv2d(
+            x,
+            offset_mask[:, :18],
+            self.weight,
+            self.bias,
+            padding=(1, 1),
+            mask=offset_mask[:, 18:].sigmoid(),
+        )
+
+
+class Bottleneck(nn.Module):
+    def __init__(self, in_channels, channels, stride=1, deform=False):
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels, channels, 1, stride=stride, bias=False)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.conv2 = (
+            ModulatedConv(channels)
+            if deform
+            else nn.Conv2d(channels, channels, 3, padding=1, bias=False)
+        )
+        self.bn2 = nn.BatchNorm2d(channels)
+        self.conv3 = nn.Conv2d(channels, channels * 4, 1, bias=False)
+        self.bn3 = nn.BatchNorm2d(channels * 4)
+        self.downsample = None
+        if stride != 1 or in_channels != channels * 4:
+            self.downsample = nn.Sequential(
+                nn.Conv2d(in_channels, channels * 4, 1, stride=stride, bias=False),
+                nn.BatchNorm2d(channels * 4),
+            )
+
+    def forward(self, x):
+        identity = x if self.downsample is None else self.downsample(x)
+        x = F.relu(self.bn1(self.conv1(x)))
+        x = F.relu(self.bn2(self.conv2(x)))
+        return F.relu(self.bn3(self.conv3(x)) + identity)
+
+
+class Backbone(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 64, 7, stride=2, padding=3, bias=False)
+        self.bn1 = nn.BatchNorm2d(64)
+        in_channels = 64
+        for i, (channels, count) in enumerate(zip((64, 128, 256, 512), (3, 4, 23, 3))):
+            blocks = []
+            for j in range(count):
+                blocks.append(
+                    Bottleneck(in_channels, channels, 2 if i and j == 0 else 1, i >= 2)
+                )
+                in_channels = channels * 4
+            setattr(self, f"layer{i + 1}", nn.Sequential(*blocks))
+
+    def forward(self, x):
+        x = F.max_pool2d(F.relu(self.bn1(self.conv1(x))), 3, stride=2, padding=1)
+        outputs = []
+        for i in range(1, 5):
+            x = getattr(self, f"layer{i}")(x)
+            outputs.append(x)
+        return outputs
+
+
+class ConvModule(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel=3, stride=1, norm=False, deform=False
+    ):
+        super().__init__()
+        self.conv = (
+            ModulatedConv(in_channels, bias=True)
+            if deform
+            else nn.Conv2d(
+                in_channels, out_channels, kernel, stride=stride, padding=kernel // 2
+            )
+        )
+        if norm:
+            self.gn = nn.GroupNorm(32, out_channels)
+
+    def forward(self, x):
+        x = self.conv(x)
+        return F.relu(self.gn(x)) if hasattr(self, "gn") else x
+
+
+class FPN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lateral_convs = nn.ModuleList(
+            [ConvModule(c, 256, 1) for c in (512, 1024, 2048)]
+        )
+        self.fpn_convs = nn.ModuleList(
+            [ConvModule(256, 256) for _ in range(3)]
+            + [ConvModule(256, 256, stride=2) for _ in range(2)]
+        )
+
+    def forward(self, features):
+        laterals = [conv(x) for conv, x in zip(self.lateral_convs, features[1:])]
+        for i in (2, 1):
+            laterals[i - 1] = laterals[i - 1] + F.interpolate(
+                laterals[i], size=laterals[i - 1].shape[-2:], mode="nearest"
+            )
+        outputs = [conv(x) for conv, x in zip(self.fpn_convs, laterals)]
+        outputs.append(self.fpn_convs[3](outputs[-1]))
+        outputs.append(self.fpn_convs[4](F.relu(outputs[-1])))
+        return outputs
+
+
+class Scale(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.scale = nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, x):
+        return x * self.scale
+
+
+def _branch(out_channels=256):
+    return nn.ModuleList([ConvModule(256, out_channels, norm=True)])
+
+
+def _run(layers, x):
+    if layers is not None:
+        for layer in layers:
+            x = layer(x)
+    return x
+
+
+class Head(nn.Module):
+    strides = (8, 16, 32, 64, 128)
+
+    def __init__(self):
+        super().__init__()
+        self.cls_convs = nn.ModuleList(
+            [ConvModule(256, 256, norm=True, deform=i == 1) for i in range(2)]
+        )
+        self.reg_convs = nn.ModuleList(
+            [ConvModule(256, 256, norm=True, deform=i == 1) for i in range(2)]
+        )
+        self.conv_cls_prev = _branch()
+        self.conv_cls = nn.Conv2d(256, 10, 1)
+        self.conv_reg_prevs = nn.ModuleList([_branch() for _ in range(4)] + [None])
+        self.conv_regs = nn.ModuleList([nn.Conv2d(256, n, 1) for n in (2, 1, 3, 1, 2)])
+        self.conv_dir_cls_prev = _branch()
+        self.conv_dir_cls = nn.Conv2d(256, 2, 1)
+        self.conv_attr_prev = _branch()
+        self.conv_attr = nn.Conv2d(256, 9, 1)
+        self.conv_centerness_prev = _branch(64)
+        self.conv_centerness = nn.Conv2d(64, 1, 1)
+        self.scales = nn.ModuleList(
+            [nn.ModuleList([Scale() for _ in range(3)]) for _ in self.strides]
+        )
+
+    def forward(self, features):
+        outputs = []
+        for x, stride, scales in zip(features, self.strides, self.scales):
+            cls = _run(self.cls_convs, x)
+            reg = _run(self.reg_convs, x)
+            bbox = torch.cat(
+                [
+                    conv(_run(prev, reg))
+                    for prev, conv in zip(self.conv_reg_prevs, self.conv_regs)
+                ],
+                1,
+            )
+            bbox = torch.cat(
+                (
+                    scales[0](bbox[:, :2]).float() * stride,
+                    scales[1](bbox[:, 2:3]).float().exp(),
+                    scales[2](bbox[:, 3:6]).float().exp(),
+                    bbox[:, 6:],
+                ),
+                1,
+            )
+            outputs.append(
+                (
+                    self.conv_cls(_run(self.conv_cls_prev, cls)),
+                    bbox,
+                    self.conv_dir_cls(_run(self.conv_dir_cls_prev, reg)),
+                    self.conv_attr(_run(self.conv_attr_prev, cls)),
+                    self.conv_centerness(_run(self.conv_centerness_prev, reg)),
+                )
+            )
+        return tuple(map(list, zip(*outputs)))
+
+
+class FCOS3DNetwork(nn.Module):
+    """Inference architecture for the official R101 nuScenes checkpoint."""
+
+    def __init__(self):
+        super().__init__()
+        self.backbone = Backbone()
+        self.neck = FPN()
+        self.bbox_head = Head()
+
+    def forward(self, x):
+        return self.bbox_head(self.neck(self.backbone(x)))

--- a/libreyolo/models/fcos3d/utils.py
+++ b/libreyolo/models/fcos3d/utils.py
@@ -129,7 +129,8 @@ def decode(raw, k, conf=0.05, iou=0.8, max_det=200):
                     else abs(cv2.contourArea(cv2.convexHull(polygon)))
                 )
                 union = area + float(boxes[other, 3] * boxes[other, 5]) - intersection
-                if intersection / max(union, 1e-8) <= iou:
+                # Upstream CPU NMS suppresses equality as well.
+                if intersection / max(union, 1e-8) < iou:
                     rest.append(other)
             order = np.asarray(rest, dtype=np.int64)
     selected_scores = np.asarray(selected_scores, np.float32)

--- a/libreyolo/models/fcos3d/utils.py
+++ b/libreyolo/models/fcos3d/utils.py
@@ -1,0 +1,177 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""FCOS3D camera decoding, adapted from OpenMMLab (Apache-2.0; see NOTICE).
+
+The CPU BEV suppression and Results conversion are LibreYOLO additions.
+"""
+
+import math
+
+import cv2
+import numpy as np
+import torch
+
+from ...utils.results import Boxes, Boxes3D
+
+NAMES = dict(
+    enumerate(
+        (
+            "car",
+            "truck",
+            "trailer",
+            "bus",
+            "construction_vehicle",
+            "bicycle",
+            "motorcycle",
+            "pedestrian",
+            "traffic_cone",
+            "barrier",
+        )
+    )
+)
+STRIDES = (8, 16, 32, 64, 128)
+
+
+def calibration(intrinsics):
+    k = np.asarray(intrinsics, dtype=np.float32)
+    if (
+        k.shape != (3, 3)
+        or not np.isfinite(k).all()
+        or k[0, 0] <= 0
+        or k[1, 1] <= 0
+        or not np.allclose(k[2], [0, 0, 1])
+        or not np.allclose([k[0, 1], k[1, 0]], 0)
+    ):
+        raise ValueError(
+            "intrinsics must be a finite (3, 3) pinhole matrix with positive focal lengths and zero skew."
+        )
+    return k.copy()
+
+
+def preprocess(image):
+    """Native image size, BGR Caffe mean, right/bottom zero padding."""
+    bgr = np.asarray(image, dtype=np.float32)[..., ::-1].copy()
+    bgr -= np.array([103.530, 116.280, 123.675], dtype=np.float32)
+    h, w = bgr.shape[:2]
+    padded = np.zeros(((h + 31) // 32 * 32, (w + 31) // 32 * 32, 3), np.float32)
+    padded[:h, :w] = bgr
+    return torch.from_numpy(padded.transpose(2, 0, 1).copy()).unsqueeze(0)
+
+
+def decode(raw, k, conf=0.05, iou=0.8, max_det=200):
+    """Return center xyz, dimensions xyz, camera yaw, scores and class ids."""
+    boxes, scores = [], []
+    kt = raw[0][0].new_tensor(k)
+    for stride, (cls, box, direction, _attr, center) in zip(STRIDES, zip(*raw)):
+        h, w = cls.shape[-2:]
+        cls = cls[0].permute(1, 2, 0).reshape(-1, 10).sigmoid()
+        score = cls * center[0].reshape(-1, 1).sigmoid()
+        box = box[0].permute(1, 2, 0).reshape(-1, 9).clone()
+        direction = direction[0].argmax(0).reshape(-1)
+        y, x = torch.meshgrid(
+            torch.arange(h, device=box.device),
+            torch.arange(w, device=box.device),
+            indexing="ij",
+        )
+        points = torch.stack((x.flatten(), y.flatten()), -1) * stride + stride // 2
+        if len(score) > 1000:
+            idx = score.max(1).values.topk(1000).indices
+            box, score, direction, points = (
+                box[idx],
+                score[idx],
+                direction[idx],
+                points[idx],
+            )
+        uv = points - box[:, :2]
+        box[:, 0] = (uv[:, 0] - kt[0, 2]) * box[:, 2] / kt[0, 0]
+        box[:, 1] = (uv[:, 1] - kt[1, 2]) * box[:, 2] / kt[1, 1]
+        yaw = box[:, 6] - 0.7854
+        box[:, 6] = (
+            yaw
+            - torch.floor(yaw / math.pi) * math.pi
+            + 0.7854
+            + direction * math.pi
+            + torch.atan2(uv[:, 0] - kt[0, 2], kt[0, 0])
+        )
+        boxes.append(box[:, :7])
+        scores.append(score)
+    boxes = torch.cat(boxes).float().cpu().numpy()
+    scores = torch.cat(scores).float().cpu().numpy()
+    valid = np.isfinite(boxes).all(1) & (boxes[:, 3:6] > 0).all(1)
+    boxes, scores = boxes[valid], scores[valid]
+    selected, selected_scores, labels = [], [], []
+    for label in range(10):
+        indices = np.flatnonzero(scores[:, label] > conf)
+        order = indices[np.argsort(-scores[indices, label], kind="stable")]
+        rects = {
+            int(i): (
+                (float(boxes[i, 0]), float(boxes[i, 2])),
+                (float(boxes[i, 3]), float(boxes[i, 5])),
+                float(-boxes[i, 6] * 180 / math.pi),
+            )
+            for i in order
+        }
+        class_count = 0
+        while len(order) and class_count < max_det:
+            first = int(order[0])
+            selected.append(first)
+            class_count += 1
+            selected_scores.append(scores[first, label])
+            labels.append(label)
+            rest = []
+            area = float(boxes[first, 3] * boxes[first, 5])
+            for other in order[1:]:
+                _, polygon = cv2.rotatedRectangleIntersection(
+                    rects[first], rects[int(other)]
+                )
+                intersection = (
+                    0.0
+                    if polygon is None
+                    else abs(cv2.contourArea(cv2.convexHull(polygon)))
+                )
+                union = area + float(boxes[other, 3] * boxes[other, 5]) - intersection
+                if intersection / max(union, 1e-8) <= iou:
+                    rest.append(other)
+            order = np.asarray(rest, dtype=np.int64)
+    selected_scores = np.asarray(selected_scores, np.float32)
+    order = np.argsort(-selected_scores, kind="stable")[:max_det]
+    return (
+        boxes[np.asarray(selected, dtype=np.int64)[order]],
+        selected_scores[order],
+        np.asarray(labels, dtype=np.int64)[order],
+    )
+
+
+def payloads(boxes, scores, labels, k, shape):
+    """Map xyz dimensions/yaw to the existing wlh/quaternion cuboid contract."""
+    data = np.zeros((len(boxes), 14), dtype=np.float32)
+    data[:, :3] = boxes[:, :3]
+    data[:, 3:6] = boxes[:, [5, 3, 4]]
+    data[:, 6] = np.cos(boxes[:, 6] / 2)
+    data[:, 8] = np.sin(boxes[:, 6] / 2)
+    data[:, 10] = scores
+    data[:, 11] = labels
+    # FCOS3D has one joint score, no separately calibrated 2D/3D scores.
+    data[:, 12] = scores
+    data[:, 13] = 1.0
+    cuboids = Boxes3D(data, shape, k)
+    corners = cuboids.corners
+    hulls = np.zeros((len(boxes), 6), np.float32)
+    for i, points in enumerate(corners):
+        near = 1e-5
+        visible = [point for point in points if point[2] >= near]
+        for a in range(8):
+            for bit in (1, 2, 4):
+                b = a ^ bit
+                if a < b and (points[a, 2] >= near) != (points[b, 2] >= near):
+                    t = (near - points[a, 2]) / (points[b, 2] - points[a, 2])
+                    visible.append(points[a] + t * (points[b] - points[a]))
+        if not visible:
+            continue
+        projected = np.asarray(visible) @ k.T
+        xy = projected[:, :2] / projected[:, 2:3]
+        hulls[i, :4] = [xy[:, 0].min(), xy[:, 1].min(), xy[:, 0].max(), xy[:, 1].max()]
+    hulls[:, [0, 2]] = hulls[:, [0, 2]].clip(0, shape[1])
+    hulls[:, [1, 3]] = hulls[:, [1, 3]].clip(0, shape[0])
+    hulls[:, 4] = scores
+    hulls[:, 5] = labels
+    return Boxes(hulls[:, :4], scores, labels, orig_shape=shape), cuboids

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -10,6 +10,7 @@ import textwrap
 
 
 OPTIONAL_MODELS = (
+    ("libreyolo.models.fcos3d", "LibreFCOS3D", None, None),
     ("libreyolo.models.wilddet3d", "LibreWildDet3D", None, "wilddet3d"),
     ("libreyolo.models.mood3d", "Libre3DMOOD", None, "opendet3d"),
     ("libreyolo.models.sam.model", "LibreSAM1", "sam", "transformers"),

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -110,6 +110,7 @@ MODEL_GROUPS: dict[str, str] = {
     "sam": "s",
     "sam2": "s",
     "sam3": "s",
+    "fcos3d": "s",
     "wilddet3d": "s",
     "3dmood": "s",
     "edgetam": "s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -459,6 +459,7 @@ testpaths = ["tests"]
 # the e2e target sets, so unit runs stay unbounded.
 timeout_method = "thread"
 markers = [
+    "fcos3d: native FCOS3D calibrated 3D detection",
     "wilddet3d: optional WildDet3D 3D detection integration",
     "mood3d: optional 3D-MOOD open-set 3D detection integration",
     "unit: fast tests that avoid external weights or large files",

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -749,6 +749,25 @@
     "available": true,
     "group": "g3"
   },
+  "fcos3d": {
+    "class": "libreyolo.models.fcos3d.model.LibreFCOS3D",
+    "tasks": [
+      "detect3d"
+    ],
+    "default_task": "detect3d",
+    "sizes": {
+      "r101": 1600
+    },
+    "default_imgsz": {
+      "r101": 1600
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": null,
+    "available": true,
+    "group": "s",
+    "cli_command": "fcos3d"
+  },
   "feynobg": {
     "class": "libreyolo.models.feynobg.model.LibreFeyNobg",
     "tasks": [

--- a/tests/e2e/test_fcos3d.py
+++ b/tests/e2e/test_fcos3d.py
@@ -1,0 +1,97 @@
+"""Replay final-detection parity against locally staged upstream CPU outputs.
+
+Set LIBREYOLO_FCOS3D_CHECKPOINT and LIBREYOLO_FCOS3D_REFERENCE. The latter
+is the JSON bundle described in ADR 0023, beside its six source images.
+Reference outputs and dataset images are not redistributed by LibreYOLO.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.e2e.conftest import require_test_weights
+
+pytestmark = [pytest.mark.e2e, pytest.mark.fcos3d, pytest.mark.external_data]
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def test_upstream_cpu_detections():
+    checkpoint_ref = os.environ.get("LIBREYOLO_FCOS3D_CHECKPOINT")
+    reference_ref = os.environ.get("LIBREYOLO_FCOS3D_REFERENCE")
+    if not checkpoint_ref or not reference_ref:
+        pytest.skip("Set LIBREYOLO_FCOS3D_CHECKPOINT and LIBREYOLO_FCOS3D_REFERENCE.")
+    checkpoint = Path(
+        require_test_weights(str(Path(checkpoint_ref).expanduser().resolve()))
+    )
+    reference_path = Path(reference_ref).expanduser().resolve()
+    reference = json.loads(reference_path.read_text())
+    assert reference["schema_version"] == 1
+    assert reference["checkpoint_sha256"] == _sha256(checkpoint)
+    assert (
+        reference["reference"]["mmdetection3d"]
+        == "fe25f7a51d36e3702f961e198894580d83c4387b"
+    )
+    assert reference["reference"]["mmcv"] == "a8073c74bf83d62ec36a103f835faa4837fb6585"
+    cameras = {
+        "CAM_FRONT",
+        "CAM_FRONT_LEFT",
+        "CAM_FRONT_RIGHT",
+        "CAM_BACK",
+        "CAM_BACK_LEFT",
+        "CAM_BACK_RIGHT",
+    }
+    cases = reference["cases"]
+    assert len(cases) == 18
+    assert {(case["camera"], case["conf"]) for case in cases} == {
+        (camera, conf) for camera in cameras for conf in (0.05, 0.15, 0.3)
+    }
+
+    from libreyolo import LibreFCOS3D
+
+    model = LibreFCOS3D(checkpoint, device="cpu")
+    for case in cases:
+        image = reference_path.parent / case["image"]
+        assert _sha256(image) == case["image_sha256"]
+        result = model(
+            image,
+            intrinsics=case["intrinsics"],
+            conf=case["conf"],
+            iou=0.8,
+            max_det=200,
+        )
+        expected = case["expected"]
+        assert len(result) == case["count"]
+        np.testing.assert_array_equal(result.boxes.cls, expected["labels"])
+        np.testing.assert_allclose(
+            result.boxes.conf, expected["scores"], atol=1e-5, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            result.boxes3d.xyz,
+            np.asarray(expected["centers"]).reshape(-1, 3),
+            atol=2e-4,
+            rtol=1e-5,
+        )
+        np.testing.assert_allclose(
+            result.boxes3d.dimensions,
+            np.asarray(expected["dimensions"]).reshape(-1, 3),
+            atol=1e-4,
+            rtol=1e-5,
+        )
+        if len(result):
+            corners = np.asarray(expected["corners"])
+            distance = np.linalg.norm(
+                result.boxes3d.corners[:, :, None] - corners[:, None], axis=-1
+            )
+            assert distance.min(axis=1).max() < 3e-4
+            assert distance.min(axis=2).max() < 3e-4

--- a/tests/unit/cli/commands/test_fcos3d.py
+++ b/tests/unit/cli/commands/test_fcos3d.py
@@ -1,0 +1,74 @@
+"""Both FCOS3D CLI grammars and machine output."""
+
+import json
+
+import numpy as np
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from libreyolo.cli.commands.fcos3d import fcos3d_cmd
+from libreyolo.cli.parsing import KeyValueCommand
+
+pytestmark = pytest.mark.unit
+
+
+def app():
+    application = typer.Typer()
+    application.command("fcos3d", cls=KeyValueCommand)(fcos3d_cmd)
+    return application
+
+
+@pytest.mark.parametrize("key_value", [False, True])
+def test_grammars(tmp_path, monkeypatch, key_value):
+    from libreyolo import LibreFCOS3D
+    from libreyolo.utils.results import Boxes, Boxes3D, Results
+
+    calls = []
+    k = np.eye(3, dtype=np.float32)
+    np.save(tmp_path / "k.npy", k)
+    monkeypatch.setattr(LibreFCOS3D, "__init__", lambda self, path, **kwargs: None)
+
+    def predict(self, source, **kwargs):
+        calls.append(kwargs)
+        print("loading progress")
+        return Results(
+            Boxes(np.empty((0, 4)), np.empty(0), np.empty(0)),
+            (32, 32),
+            boxes3d=Boxes3D(np.empty((0, 14)), (32, 32), k),
+        )
+
+    monkeypatch.setattr(LibreFCOS3D, "predict", predict)
+    pairs = {
+        "source": "image.jpg",
+        "model": "weights.pth",
+        "intrinsics": str(tmp_path / "k.npy"),
+        "conf": "0.42",
+    }
+    args = (
+        [f"{key}={val}" for key, val in pairs.items()]
+        if key_value
+        else [token for key, val in pairs.items() for token in (f"--{key}", val)]
+    )
+    args += (
+        ["json=true", "save=false", "quiet=true"]
+        if key_value
+        else ["--json", "--quiet"]
+    )
+    result = CliRunner().invoke(app(), args)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["task"] == "detect3d"
+    assert calls[0]["conf"] == 0.42
+    assert calls[0]["save"] is False
+    assert result.stderr == ""
+
+
+def test_help_and_error():
+    result = CliRunner().invoke(app(), ["--help-json"])
+    assert result.exit_code == 0
+    assert "intrinsics" in json.loads(result.stdout).__str__()
+    result = CliRunner().invoke(
+        app(), ["source=x.jpg", "model=x.pth", "intrinsics=missing.npy", "--json"]
+    )
+    assert result.exit_code != 0
+    assert "io_error" in result.stdout

--- a/tests/unit/test_fcos3d.py
+++ b/tests/unit/test_fcos3d.py
@@ -87,6 +87,7 @@ def test_cuboid_axes_projection_alignment_and_slicing():
     assert not b.is_track
     assert b.orig_shape == (100, 100)
     np.testing.assert_allclose(cuboids.dimensions, [[6, 4, 2]])
+    np.testing.assert_allclose(cuboids.corners[0, 0], [-3, 1, 8], atol=1e-6)
     extent = np.ptp(cuboids.corners[0], axis=0)
     np.testing.assert_allclose(extent, [6, 2, 4], atol=1e-6)
     np.testing.assert_allclose(cuboids[0].intrinsics, K)

--- a/tests/unit/test_fcos3d.py
+++ b/tests/unit/test_fcos3d.py
@@ -1,0 +1,136 @@
+"""Camera geometry and native FCOS3D inference contracts; no external bytes."""
+
+import math
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.fcos3d import LibreFCOS3D
+from libreyolo.models.fcos3d.nn import ModulatedConv
+from libreyolo.models.fcos3d.utils import calibration, decode, payloads, preprocess
+
+pytestmark = pytest.mark.unit
+K = np.array([[100, 0, 4], [0, 100, 4], [0, 0, 1]], np.float32)
+
+
+def raw_prediction():
+    # One stride-eight point (4,4), offset (0,0), depth 10, xyz dimensions 4,2,6.
+    return (
+        [torch.tensor([10.0] + [-100.0] * 9).reshape(1, 10, 1, 1)],
+        [
+            torch.tensor([0.0, 0.0, 10.0, 4.0, 2.0, 6.0, 0.0, 0.0, 0.0]).reshape(
+                1, 9, 1, 1
+            )
+        ],
+        [torch.tensor([10.0, -10.0]).reshape(1, 2, 1, 1)],
+        [torch.zeros(1, 9, 1, 1)],
+        [torch.full((1, 1, 1, 1), 10.0)],
+    )
+
+
+def test_preprocess_caffe_channels_padding_and_no_resize():
+    image = Image.new("RGB", (33, 17), (10, 20, 30))
+    x = preprocess(image)
+    assert x.shape == (1, 3, 32, 64)
+    torch.testing.assert_close(
+        x[0, :, 0, 0], torch.tensor([30 - 103.530, 20 - 116.280, 10 - 123.675])
+    )
+    assert torch.count_nonzero(x[:, :, 17:]) == 0
+    assert torch.count_nonzero(x[:, :, :, 33:]) == 0
+
+
+def test_deformable_zero_offset_half_mask():
+    torch.manual_seed(1)
+    conv = ModulatedConv(2, bias=True)
+    x = torch.randn(1, 2, 5, 7)
+    expected = (
+        torch.nn.functional.conv2d(x, conv.weight, None, padding=1) * 0.5
+        + conv.bias[None, :, None, None]
+    )
+    torch.testing.assert_close(conv(x), expected)
+
+
+def test_decode_projected_center_and_direction():
+    raw = raw_prediction()
+    boxes, scores, labels = decode(raw, K)
+    np.testing.assert_allclose(boxes[0, :6], [0, 0, 10, 4, 2, 6])
+    # Local yaw 0 is placed in the [pi/4, pi+pi/4) bin: yaw becomes pi.
+    assert boxes[0, 6] == pytest.approx(math.pi)
+    assert labels.tolist() == [0]
+    assert scores[0] == pytest.approx(torch.sigmoid(torch.tensor(10.0)).item() ** 2)
+    raw[1][0][:, 0] = -10
+    raw[2][0][:, 0] = -10
+    raw[2][0][:, 1] = 10
+    moved, _, _ = decode(raw, K)
+    np.testing.assert_allclose(moved[0, :3], [1, 0, 10])
+    assert moved[0, 6] == pytest.approx(2 * math.pi + math.atan(0.1))
+
+
+def test_rotated_nms_suppresses_same_class_not_other_class():
+    raw = raw_prediction()
+    raw = tuple([torch.cat([group[0], group[0]], -1)] for group in raw)
+    # Point 2 is x=12, so offset eight maps it onto the same 3D center.
+    raw[1][0][0, 0, 0, 1] = 8
+    raw[0][0][0, 1, 0, 1] = 9
+    boxes, _, labels = decode(raw, K)
+    assert len(boxes) == 2
+    assert labels.tolist() == [0, 1]
+    assert len(decode(raw, K, max_det=1)[0]) == 1
+    assert len(decode(raw, K, conf=1)[0]) == 0
+
+
+def test_cuboid_axes_projection_alignment_and_slicing():
+    boxes = np.array([[0, 0, 10, 4, 2, 6, math.pi / 2]], np.float32)
+    b, cuboids = payloads(boxes, np.array([0.8]), np.array([2]), K, (100, 100))
+    assert not b.is_track
+    assert b.orig_shape == (100, 100)
+    np.testing.assert_allclose(cuboids.dimensions, [[6, 4, 2]])
+    extent = np.ptp(cuboids.corners[0], axis=0)
+    np.testing.assert_allclose(extent, [6, 2, 4], atol=1e-6)
+    np.testing.assert_allclose(cuboids[0].intrinsics, K)
+    np.testing.assert_allclose(cuboids.conf, b.conf)
+    assert np.isfinite(b.xyxy).all()
+
+
+@pytest.mark.parametrize(
+    "k",
+    [
+        np.eye(4),
+        np.zeros((3, 3)),
+        [[1, 0.1, 0], [0, 1, 0], [0, 0, 1]],
+        [[float("nan"), 0, 0], [0, 1, 0], [0, 0, 1]],
+    ],
+)
+def test_bad_calibration(k):
+    with pytest.raises(ValueError, match="intrinsics"):
+        calibration(k)
+
+
+def test_single_list_stream_and_validation_without_weights(tmp_path):
+    class Network:
+        def __call__(self, x):
+            return raw_prediction()
+
+    model = LibreFCOS3D.__new__(LibreFCOS3D)
+    model.model = Network()
+    model.device = torch.device("cpu")
+    model.names = {0: "car"}
+    image = Image.new("RGB", (32, 32))
+    result = model(image, intrinsics=K, save=True, output_path=tmp_path / "out.png")
+    assert result.boxes3d.data.shape == (1, 14)
+    assert (tmp_path / "out.png").is_file()
+    assert len(model([image, image], intrinsics=K)) == 2
+    assert len(list(model([image], intrinsics=K, stream=True))) == 1
+    for kw in (
+        {"conf": float("nan")},
+        {"iou": -1},
+        {"max_det": 0},
+        {"output_path": "x.png"},
+    ):
+        with pytest.raises(ValueError):
+            model(image, intrinsics=K, **kw)
+    for method in ("train", "val", "export", "track"):
+        with pytest.raises(NotImplementedError):
+            getattr(model, method)()

--- a/tests/unit/test_fcos3d.py
+++ b/tests/unit/test_fcos3d.py
@@ -81,6 +81,16 @@ def test_rotated_nms_suppresses_same_class_not_other_class():
     assert len(decode(raw, K, conf=1)[0]) == 0
 
 
+def test_nms_threshold_equality_matches_upstream_cpu():
+    # MMCV CPU nms_rotated uses overlap >= threshold for suppression.
+    # Thus even disjoint same-class boxes suppress each other at iou=0.
+    raw = raw_prediction()
+    raw = tuple([torch.cat([group[0], group[0]], -1)] for group in raw)
+    raw[1][0][0, 0, 0, 1] = -100
+    assert len(decode(raw, K, iou=0.0)[0]) == 1
+    assert len(decode(raw, K, iou=0.01)[0]) == 2
+
+
 def test_cuboid_axes_projection_alignment_and_slicing():
     boxes = np.array([[0, 0, 10, 4, 2, 6, math.pi / 2]], np.float32)
     b, cuboids = payloads(boxes, np.array([0.8]), np.array([2]), K, (100, 100))

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -810,3 +810,11 @@ WildDet3D (LibreYOLO/LibreWildDet3D; byte-identical upstream mirror)
     Swin-B: Libre3DMOODb.pt
       Mirror revision: a4f6115d285a6983439f0e54f20c44b0ce87c261
       SHA-256: 834c976df385610bba105c7d4ea3e2d7b57dabd69dee2b61397ae398de67a677
+
+FCOS3D
+------
+Code source: https://github.com/open-mmlab/mmdetection3d (Apache-2.0).
+The official R101 nuScenes checkpoint is accepted locally, unchanged.
+Separate checkpoint redistribution terms have not been established.
+No LibreYOLO-hosted weights or automatic weight download are provided.
+nuScenes dataset terms: https://www.nuscenes.org/terms-of-use


### PR DESCRIPTION
- Add native FCOS3D R101 inference and `fcos3d` CLI for calibrated camera-frame cuboids.
- Accept local official nuScenes checkpoints; no rehosting pending clarification of checkpoint redistribution terms.
- Verified: 145 focused/integration tests plus final-detection replay, strict checkpoint loading, real-image CPU inference and CLI JSON.
- Match upstream CPU NMS suppression at threshold equality.
- Final CPU detections match upstream across six calibrated views and three confidence thresholds; reference uses independent MMCV C++ CPU kernels. Added a replayable parity test.
- Not verified: CUDA parity or nuScenes accuracy. Training, export and tracking remain unsupported.
- Full local gate: 6,900 passed; five ONNX export failures also reproduce on unchanged `dev` (`b06ec9d3`).
- Opened by an agent.

## Code provenance
- Adapted Apache-2.0 code from https://github.com/open-mmlab/mmdetection3d at `fe25f7a51d36e3702f961e198894580d83c4387b` and https://github.com/open-mmlab/mmdetection at `cfd5d3a985b0249de009b67d04f37263e11cdf3d`; attribution and license files included. No upstream C++/CUDA code vendored.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62546636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with only a non-blocking reproducibility concern remaining in the existing parity-test thread.

<h2><a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atests%2Fe2e%2Ftest_fcos3d.py%3A41-45%0AThe%20parity%20replay%20checks%20the%20MMDetection3D%20and%20MMCV%20revisions%20but%20not%20the%20MMDetection%20revision%2C%20even%20though%20MMDetection%20supplies%20the%20reference%20ResNet%20and%20FPN%20and%20the%20documented%20bundle%20includes%20this%20identifier.%20A%20bundle%20produced%20from%20a%20different%20MMDetection%20revision%20can%20therefore%20pass%20these%20provenance%20checks%2C%20making%20the%20pinned-reference%20comparison%20less%20reproducible.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=847&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Unpinned MMDetection reference** <a href="https://github.com/LibreYOLO/libreyolo/pull/847#discussion_r3979188298">▶</a>

<details><summary><h3>Summary</h3></summary>

- Introduces the PyTorch network, checkpoint loading, preprocessing, camera-frame decoding, rotated BEV NMS, and standard `Results` conversion.
- Adds a dedicated Python API and `fcos3d` CLI accepting local official checkpoints and camera intrinsics.
- Registers FCOS3D in model and export inventories while explicitly marking training, validation, tracking, and export unsupported.
- Documents provenance, licensing, geometry contracts, validation evidence, and checkpoint redistribution limits.
- Adds unit, CLI, and opt-in parity replay coverage.
- Since the previous review, adds FCOS3D to the existing 3D-detection rows in both READMEs.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Image source] --> B[ImageLoader]
    K[3x3 camera intrinsics] --> E[FCOS3D decoder]
    B --> C[Caffe preprocessing and padding]
    C --> D[ResNet101-DCN, FPN, FCOS3D head]
    D --> E
    E --> F[Per-class rotated BEV NMS]
    F --> G[Camera-frame cuboids]
    G --> H[Projected 2D hulls]
    G --> I[Results.boxes3d]
    H --> J[Results.boxes]
    I --> R[Python API or CLI JSON/overlay]
    J --> R
```
</details>

<sub>Reviews (4) · Last reviewed commit: ["List FCOS3D in supported models"](https://github.com/libreyolo/libreyolo/commit/f5e41c492bd0034a5e63aa79261045c7219d211c)</sub>

<!-- /greptile_comment -->