### PR TITLE
Add DetAny3D runtime adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Panoptic segmentation** | EoMT |
 | **Pose** | RF-DETR, YOLO-NAS, HRNet, DEKR, EC |
 | **Oriented boxes** | RF-DETR, RT-DETRv2, YOLO-NAS-R |
-| **3D detection** | WildDet3D, 3D-MOOD |
+| **3D detection** | WildDet3D, 3D-MOOD, DetAny3D (separate runtime) |
 | **Classification** | MobileNetV4, ConvNeXt, EfficientNetV2, ResNet, ViT, Swin, DeiT, VGG, AlexNet, CLIP, SigLIP2, DINOv2 |
 | **Depth** | Depth Anything 3, Depth Anything V2, ZipDepth, MiDaS |
 | **Surface normals** | MoGe-2 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,7 +110,7 @@ libreyolo predict --model yolo9-t --source screen            # 屏幕捕获
 | **全景分割** | EoMT |
 | **姿态** | RF-DETR、YOLO-NAS、HRNet、DEKR、EC |
 | **旋转框（OBB）** | RF-DETR、RT-DETRv2、YOLO-NAS-R |
-| **三维检测** | WildDet3D、3D-MOOD |
+| **三维检测** | WildDet3D、3D-MOOD、DetAny3D（独立运行环境） |
 | **分类** | MobileNetV4、ConvNeXt、EfficientNetV2、ResNet、ViT、Swin、DeiT、VGG、AlexNet、CLIP、SigLIP2、DINOv2 |
 | **深度估计** | Depth Anything 3、Depth Anything V2、ZipDepth、MiDaS |
 | **表面法线** | MoGe-2 |

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -2231,3 +2231,230 @@ Used for: OpenCV cuboid dimension-to-axis mapping and corner ordering in
 libreyolo/utils/results.py::Boxes3D.corners and the associated wireframe edges.
 Reference: vis4d/op/box/box3d.py::boxes3d_to_corners, AxisMode.OPENCV.
 The implementation remains numpy-based; vis4d is not a core dependency.
+
+
+DetAny3D runtime adapter
+
+The worker input recipe and decoding interface are adapted from:
+https://github.com/OpenDriveLab/DetAny3D
+Revision: 10e484be0837d80aa33cff6ed95a9be834a3f794
+Apache License 2.0. Source: deploy.py, wrap_model.py and train_utils.py.
+LibreYOLO changes: typed-array worker boundary, CPU compatibility, original-image
+coordinate mapping, canonical cuboid axes, input validation and CLI integration.
+
+CPU attention compatibility implements the documented xFormers 0.0.16 API:
+https://github.com/facebookresearch/xformers
+Revision: 6f3c20f223c0f051e4b2dc744cc7591591ee04c4
+BSD 3-Clause. Copyright (c) Facebook, Inc. and its affiliates.
+The xFormers Python package is separately installed. No xFormers kernels are
+bundled. Deformable attention reuses LibreYOLO's existing Apache-2.0 implementation.
+
+The model implementation and checkpoint are not bundled. The separately
+installed upstream runtime includes UniDepth under CC BY-NC 4.0:
+https://github.com/lpiccinelli-eth/UniDepth
+Revision checked: 8d8cfe4c7ee15297099983607febf0d4f32eb3d6
+No UniDepth implementation was used to write or copied into this adapter.
+This does not grant commercial-use rights to the external runtime.
+Checkpoint redistribution terms have not been established; no mirror is provided.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/adr/0024-detany3d-adapter.md
+++ b/docs/adr/0024-detany3d-adapter.md
@@ -51,8 +51,10 @@ libreyolo detany3d model=/models/detany3d.pth source=street.jpg \
 ```
 
 `DETANY3D_PATH` and `DETANY3D_PYTHON` are environment alternatives. CLI options
-also accept `--key value`. Box and point coordinates refer to original image
-pixels. `(N,2)` points describe one object, while `(G,N,2)` describes G objects;
+also accept `--key value`. Inventory availability describes the built-in adapter;
+it does not probe or certify a separately configured runtime. Construction checks
+that runtime by loading the actual model. Box and point coordinates refer to
+original image pixels. `(N,2)` points describe one object, while `(G,N,2)` describes G objects;
 all points are positive. Points cannot be combined with boxes or text. Boxes
 and text can be combined. `set_classes()` stores a reusable text vocabulary.
 

--- a/docs/adr/0024-detany3d-adapter.md
+++ b/docs/adr/0024-detany3d-adapter.md
@@ -1,0 +1,94 @@
+# ADR 0024: DetAny3D runtime adapter
+
+Status: implemented and CPU runtime-validated
+Date: 2026-09-10
+
+## Decision
+
+Expose `LibreDetAny3D` and `libreyolo detany3d` for box, positive-point and
+text-prompted `detect3d` inference. The full upstream model is listed as size
+`h` at 896 pixels. It predicts camera calibration. It is a sibling API,
+outside the generic `LibreYOLO(...)` checkpoint factory.
+
+The adapter follows the Apache-2.0 public inference interfaces in
+`OpenDriveLab/DetAny3D` revision
+`10e484be0837d80aa33cff6ed95a9be834a3f794`. The separately installed runtime
+includes UniDepth under CC BY-NC 4.0. LibreYOLO does not bundle or derive its
+implementation, and this adapter grants no commercial-use rights to that
+runtime. The original full checkpoint is loaded strictly without conversion.
+Checkpoint redistribution terms remain unresolved, so there is no automatic
+download or Hugging Face mirror.
+
+## Runtime and public contract
+
+Provide the upstream checkout, its dedicated Python interpreter and the full
+official checkpoint. The interpreter must contain the upstream dependencies,
+including SAM, DINOv2, UniDepth and xFormers interfaces. The complete checkpoint
+already contains the learned parameters for these components; redundant
+backbone checkpoint loading is disabled. Text prompts additionally require
+GroundingDINO Swin-B and its checkpoint. The pinned upstream checkout contains
+an absolute GroundingDINO symlink; install GroundingDINO into the runtime
+environment separately instead of relying on that link.
+
+```python
+from libreyolo import LibreDetAny3D
+
+with LibreDetAny3D(
+    "/models/detany3d.pth",
+    runtime_path="/runtimes/DetAny3D",
+    runtime_python="/runtimes/venv/bin/python",
+    grounding_checkpoint="/models/groundingdino_swinb_cogcoor.pth",
+    device="cpu",
+) as model:
+    result = model("street.jpg", text=["car", "person"])
+    result.plot().save("cuboids.png")
+```
+
+```sh
+libreyolo detany3d model=/models/detany3d.pth source=street.jpg \
+  runtime_path=/runtimes/DetAny3D runtime_python=/runtimes/venv/bin/python \
+  'bboxes=[[200,150,600,500]]' device=cpu --json
+```
+
+`DETANY3D_PATH` and `DETANY3D_PYTHON` are environment alternatives. CLI options
+also accept `--key value`. Box and point coordinates refer to original image
+pixels. `(N,2)` points describe one object, while `(G,N,2)` describes G objects;
+all points are positive. Points cannot be combined with boxes or text. Boxes
+and text can be combined. `set_classes()` stores a reusable text vocabulary.
+
+Single images return one `Results`; lists and directories return lists;
+`stream=True` yields results. `Results.boxes` and `Results.boxes3d` are aligned.
+The estimated intrinsics and refined 2D boxes are mapped back through the
+upstream resize and central crop to the original canvas. Cuboids follow ADR
+0021: metres, gravity centres, OpenCV camera axes, width/length/height, and
+quaternion wxyz. The source local width/height/length basis is transformed into
+the canonical length/height/width basis before quaternion construction.
+
+Text scores are the upstream 2D detector scores, controlled by `conf=0.37` and
+`text_threshold=0.25`. Geometric prompts have score 1. The upstream quality head
+selects candidates but is not its exported detection confidence; `conf3d` is
+therefore neutral 1. Class names are registered consistently across calls.
+Training, validation, export and tracking raise explicit unsupported errors.
+
+## Evidence and limits
+
+Nine CPU cases matched a direct upstream reference using its original public
+preprocessing, decoder and corner utilities: boxes, positive points, text,
+combined boxes/text, grouped points, an empty text result, and three modes on
+an asymmetric crop. Labels and counts matched exactly. Checks cover scores
+(absolute tolerance 1e-5), 2D boxes (0.05 pixels), centres (0.002 metres),
+dimensions (0.001 metres), calibration (0.01 pixels), and corner-set distance
+(0.005 metres). Relative tolerances are recorded in the manual e2e test.
+An extracted wheel also completed a real box-prompt prediction.
+
+The CPU worker uses PyTorch attention through the public xFormers API and the
+existing permissive LibreYOLO deformable-attention implementation. The
+reference uses explicit attention and MMCV's portable deformable attention.
+These substitutions leave upstream model code and learned parameters intact.
+They are installed only in the child process. The worker exposes only its own
+LibreYOLO package to avoid shadowing the separate interpreter's dependencies.
+
+CUDA requires the upstream compiled runtime and has not been validated. MPS,
+benchmark accuracy, training and export are not claimed. Manual parity requires
+locally staged weights and reference outputs; it is not part of the nightly
+download catalogue. No model weights or reference images are included here.

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -26,6 +26,7 @@ in preflight.
 | dekr | pose | ✓ | ✓ |  | ✓ | ✓ |  |  |  |  |  |  |  |
 | depth_anything | depth | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  | ✓ |
 | depth_anything3 | depth | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  |  |
+| detany3d | detect3d |  |  |  |  |  |  |  |  |  |  |  |  |
 | detr | detect | ✓ | ✓ | available | available | available |  |  |  |  |  |  |  |
 | dexined | edge | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
 | dfine | detect | ✓ | ✓ |  | available | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
@@ -734,6 +735,18 @@ These converter paths are callable with the recorded validation context.
 - `depth_anything3` / `depth` / `tflite`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `coreml`: Depth Anything 3 currently rejects export for every format; its depth graph has not been added to the exported-runtime contract.
 - `depth_anything3` / `depth` / `coreai`: The model raises NotImplementedError for every format: depth export is out of scope per ADR 0006, the depth task contract. Depth Anything V2 exports and validates at 5.2e-06, so this is specific to the V3 family and not a Core AI limitation.
+- `detany3d` / `detect3d` / `onnx`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `torchscript`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `executorch`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `tensorrt`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `openvino`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `paddle`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `mnn`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `rknn`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `ncnn`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `tflite`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `coreml`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `detany3d` / `detect3d` / `coreai`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
 - `detr` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
 - `detr` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `detr` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -1006,3 +1006,9 @@ coordinates in results.
 It shares the `detect3d` result and camera convention, adds
 `Results.depth_map`, and is invoked through `libreyolo 3dmood`. It is not part
 of the generic checkpoint factory. See ADR 0022.
+
+`LibreDetAny3D` (`detany3d`, coverage group `s`) is a box-, point- and
+text-prompted sibling with predicted calibration. Its full upstream model is
+listed as size `h` with an 896-pixel canvas. It takes an unchanged local upstream
+checkpoint and a separate runtime; no canonical weight mirror or generic
+factory route is provided. The CLI is `libreyolo detany3d`. See ADR 0024.

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -214,6 +214,7 @@ def __getattr__(name):
         "LibreSenseNovaVision": (".models.sensenova", "LibreSenseNovaVision"),
         "LibreMODUS": (".models.modus", "LibreMODUS"),
         "LibreModus": (".models.modus", "LibreModus"),
+        "LibreDetAny3D": (".models.detany3d", "LibreDetAny3D"),
         "LibreWildDet3D": (".models.wilddet3d", "LibreWildDet3D"),
         "Libre3DMOOD": (".models.mood3d", "Libre3DMOOD"),
         "LibreSAM": (".models.sam", "LibreSAM"),
@@ -362,6 +363,7 @@ __all__ = [
     # OpenAI-compatible LLM client (optional, requires libreyolo[llm])
     "LibreLLM",
     # Promptable 3D detection (separately installed upstream runtime)
+    "LibreDetAny3D",
     "LibreWildDet3D",
     "Libre3DMOOD",
     # Promptable-segmentation tier (optional, requires libreyolo[sam])

--- a/libreyolo/cli/__init__.py
+++ b/libreyolo/cli/__init__.py
@@ -118,6 +118,9 @@ def entrypoint() -> None:
     # Face identification: build a gallery from a folder-per-person tree.
     app.command("enroll", cls=KeyValueCommand)(special.enroll_cmd)
 
+    from .commands.detany3d import detany3d_cmd
+
+    app.command("detany3d", cls=KeyValueCommand)(detany3d_cmd)
     from .commands.wilddet3d import wilddet3d_cmd
 
     app.command("wilddet3d", cls=KeyValueCommand)(wilddet3d_cmd)

--- a/libreyolo/cli/commands/detany3d.py
+++ b/libreyolo/cli/commands/detany3d.py
@@ -1,0 +1,109 @@
+"""Promptable 3D detection through the optional DetAny3D runtime."""
+
+import typer
+
+from ..command_utils import exit_with_error, help_json_callback
+from ..output import OutputHandler
+
+
+def detany3d_cmd(
+    source: str = typer.Option(..., help="Image path or directory"),
+    model: str = typer.Option(..., help="Local official full DetAny3D checkpoint"),
+    runtime_path: str | None = typer.Option(
+        None, help="DetAny3D checkout; defaults to DETANY3D_PATH"
+    ),
+    runtime_python: str | None = typer.Option(
+        None, help="Interpreter for the separate runtime environment"
+    ),
+    text: str | None = typer.Option(None, help="JSON category list or a text caption"),
+    bboxes: str | None = typer.Option(None, help="JSON original-pixel xyxy box list"),
+    points: str | None = typer.Option(
+        None, help="JSON positive points, optionally grouped by object"
+    ),
+    conf: float | None = typer.Option(
+        None, help="Text detector box-confidence threshold"
+    ),
+    text_threshold: float | None = typer.Option(
+        None, help="Text token-confidence threshold"
+    ),
+    grounding_checkpoint: str | None = typer.Option(
+        None, help="Optional GroundingDINO Swin-B checkpoint path"
+    ),
+    grounding_config: str | None = typer.Option(
+        None, help="Optional GroundingDINO Swin-B config path"
+    ),
+    device: str = typer.Option("auto", help="auto, cpu, or CUDA device"),
+    save: bool = typer.Option(False, help="Save projected cuboids"),
+    output_path: str | None = typer.Option(None, help="Single-image output filename"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output to stdout"),
+    quiet: bool = typer.Option(False, "--quiet", help="Suppress stderr"),
+    help_json: bool = typer.Option(
+        False,
+        "--help-json",
+        is_eager=True,
+        callback=help_json_callback,
+        help="Dump command schema as JSON",
+    ),
+) -> None:
+    """Detect metric cuboids from text, boxes or points with predicted calibration."""
+    import json
+    import os
+    import sys
+    from contextlib import ExitStack, redirect_stderr, redirect_stdout
+
+    out = OutputHandler(json_mode=json_output, quiet=quiet)
+    try:
+        prompt = {
+            key: json.loads(value)
+            for key, value in (("bboxes", bboxes), ("points", points))
+            if value is not None
+        }
+        if text is not None:
+            prompt["text"] = json.loads(text) if text.lstrip().startswith("[") else text
+        thresholds = {
+            key: value
+            for key, value in (("conf", conf), ("text_threshold", text_threshold))
+            if value is not None
+        }
+        with ExitStack() as stack:
+            destination = (
+                stack.enter_context(open(os.devnull, "w")) if quiet else sys.stderr
+            )
+            stack.enter_context(redirect_stdout(destination))
+            if quiet:
+                stack.enter_context(redirect_stderr(destination))
+            from libreyolo import LibreDetAny3D
+
+            with LibreDetAny3D(
+                model,
+                runtime_path=runtime_path,
+                runtime_python=runtime_python,
+                grounding_checkpoint=grounding_checkpoint,
+                grounding_config=grounding_config,
+                device=device,
+                **thresholds,
+            ) as detector:
+                results = detector.predict(
+                    source, save=save, output_path=output_path, **prompt
+                )
+        results = results if isinstance(results, list) else [results]
+        out.result(
+            {
+                "task": "detect3d",
+                "model": model,
+                "results": [
+                    {
+                        "path": result.path,
+                        "detections": result.summary(),
+                        "intrinsics": result.boxes3d.numpy().intrinsics.tolist(),
+                    }
+                    for result in results
+                ],
+            }
+        )
+    except (ValueError, TypeError) as exc:
+        exit_with_error(out, "config_type_error", str(exc))
+    except (ImportError, RuntimeError) as exc:
+        exit_with_error(out, "model_load_failed", str(exc))
+    except OSError as exc:
+        exit_with_error(out, "io_error", str(exc))

--- a/libreyolo/models/detany3d/LICENSE
+++ b/libreyolo/models/detany3d/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libreyolo/models/detany3d/NOTICE
+++ b/libreyolo/models/detany3d/NOTICE
@@ -1,0 +1,23 @@
+DetAny3D runtime adapter
+
+The worker input recipe and decoding interface are adapted from:
+https://github.com/OpenDriveLab/DetAny3D
+Revision: 10e484be0837d80aa33cff6ed95a9be834a3f794
+Apache License 2.0. Source: deploy.py, wrap_model.py and train_utils.py.
+LibreYOLO changes: typed-array worker boundary, CPU compatibility, original-image
+coordinate mapping, canonical cuboid axes, input validation and CLI integration.
+
+CPU attention compatibility implements the documented xFormers 0.0.16 API:
+https://github.com/facebookresearch/xformers
+Revision: 6f3c20f223c0f051e4b2dc744cc7591591ee04c4
+BSD 3-Clause. Copyright (c) Facebook, Inc. and its affiliates.
+The xFormers Python package is separately installed. No xFormers kernels are
+bundled. Deformable attention reuses LibreYOLO's existing Apache-2.0 implementation.
+
+The model implementation and checkpoint are not bundled. The separately
+installed upstream runtime includes UniDepth under CC BY-NC 4.0:
+https://github.com/lpiccinelli-eth/UniDepth
+Revision checked: 8d8cfe4c7ee15297099983607febf0d4f32eb3d6
+No UniDepth implementation was used to write or copied into this adapter.
+This does not grant commercial-use rights to the external runtime.
+Checkpoint redistribution terms have not been established; no mirror is provided.

--- a/libreyolo/models/detany3d/__init__.py
+++ b/libreyolo/models/detany3d/__init__.py
@@ -1,0 +1,5 @@
+"""DetAny3D through a separately installed upstream runtime."""
+
+from .model import LibreDetAny3D
+
+__all__ = ["LibreDetAny3D"]

--- a/libreyolo/models/detany3d/model.py
+++ b/libreyolo/models/detany3d/model.py
@@ -1,0 +1,319 @@
+"""DetAny3D integration through a separately installed upstream runtime.
+
+The runtime contains UniDepth under CC BY-NC 4.0. That implementation is not
+bundled in LibreYOLO. This adapter uses the upstream Apache-2.0 inference
+interface and converts its outputs to the existing camera-frame contract.
+"""
+
+import os
+from pathlib import Path
+from typing import ClassVar
+
+import numpy as np
+import torch
+from scipy.spatial.transform import Rotation
+
+from ...utils.image_loader import SUPPORTED_EXTENSIONS, ImageLoader
+from ...utils.results import Boxes, Boxes3D, Results
+from .runtime import RuntimeWorker
+
+
+class LibreDetAny3D:
+    """Box-, point- and text-prompted 3D detection with predicted calibration.
+
+    Supply the official full checkpoint and the separately installed runtime.
+    Point arrays (N,2) describe one object; (G,N,2) describes G objects. All
+    points are positive prompts. Text can be combined with box prompts, while
+    point prompts are exclusive. conf/text_threshold configure the text detector;
+    geometric prompts retain one prediction per prompt group.
+    """
+
+    FAMILY = "detany3d"
+    CLI_COMMAND = "detany3d"
+    FILENAME_PREFIX = "LibreDetAny3D"
+    SUPPORTED_TASKS = ("detect3d",)
+    DEFAULT_TASK = "detect3d"
+    INPUT_SIZES: ClassVar[dict[str, int]] = {"h": 896}
+    TASK_INPUT_SIZES: ClassVar[dict] = {}
+    DEFAULT_CONF = 0.37
+    DEFAULT_TEXT_THRESHOLD = 0.25
+
+    def __init__(
+        self,
+        model_path,
+        *,
+        runtime_path=None,
+        runtime_python=None,
+        device="auto",
+        conf=DEFAULT_CONF,
+        text_threshold=DEFAULT_TEXT_THRESHOLD,
+        grounding_checkpoint=None,
+        grounding_config=None,
+    ):
+        checkpoint = Path(model_path).expanduser().resolve()
+        if not checkpoint.is_file():
+            raise FileNotFoundError(f"DetAny3D checkpoint not found: {checkpoint}")
+        runtime_path = runtime_path or os.environ.get("DETANY3D_PATH")
+        if not runtime_path:
+            raise ImportError(
+                "Pass runtime_path= or set DETANY3D_PATH to a separately installed DetAny3D checkout."
+            )
+        root = Path(runtime_path).expanduser().resolve()
+        if not (root / "wrap_model.py").is_file():
+            raise FileNotFoundError(f"DetAny3D runtime has no wrap_model.py: {root}")
+        if isinstance(device, int) or str(device).isdigit():
+            device = f"cuda:{device}"
+        if device != "auto" and torch.device(device).type not in {"cpu", "cuda"}:
+            raise ValueError(
+                "DetAny3D supports CPU or CUDA; MPS has not been validated."
+            )
+        for name, value in (("conf", conf), ("text_threshold", text_threshold)):
+            if isinstance(value, bool) or not np.isfinite(value) or not 0 <= value <= 1:
+                raise ValueError(f"{name} must be in [0, 1].")
+        self.model_path = checkpoint
+        self._root = root
+        self._python = runtime_python or os.environ.get("DETANY3D_PYTHON")
+        self._config = {
+            "checkpoint": str(checkpoint),
+            "runtime_path": str(root),
+            "device": str(device),
+            "conf": float(conf),
+            "text_threshold": float(text_threshold),
+            "grounding_checkpoint": str(
+                Path(grounding_checkpoint).expanduser().resolve()
+            )
+            if grounding_checkpoint
+            else None,
+            "grounding_config": str(Path(grounding_config).expanduser().resolve())
+            if grounding_config
+            else None,
+        }
+        self._backend = None
+        self._classes = None
+        self.names = {}
+        self._label_ids = {}
+        self.task = "detect3d"
+        self.size = "h"
+        self._ensure_backend()
+
+    @classmethod
+    def get_download_url(cls, filename):
+        """No checkpoint mirror until redistribution terms are established."""
+        return
+
+    def _ensure_backend(self):
+        if self._backend is None or self._backend.closed:
+            self._backend = RuntimeWorker(
+                config=self._config,
+                runtime_path=self._root,
+                runtime_python=self._python,
+            )
+            self.device = torch.device(self._backend.device)
+        return self._backend
+
+    @staticmethod
+    def _text(value):
+        if isinstance(value, str):
+            value = [value]
+        if (
+            not isinstance(value, (list, tuple))
+            or not value
+            or any(not isinstance(x, str) or not x.strip() for x in value)
+        ):
+            raise ValueError(
+                "text must be a nonempty string or list of nonempty strings."
+            )
+        return [x.strip() for x in value]
+
+    def _register_labels(self, labels):
+        for label in labels:
+            key = label.lower()
+            if key not in self._label_ids:
+                index = len(self.names)
+                self._label_ids[key] = index
+                self.names[index] = key
+
+    def set_classes(self, names):
+        self._classes = self._text(names)
+        self.names = {}
+        self._label_ids = {}
+        self._register_labels(self._classes)
+        return self
+
+    def predict(
+        self,
+        source,
+        *,
+        text=None,
+        bboxes=None,
+        points=None,
+        stream=False,
+        save=False,
+        output_path=None,
+        color_format="auto",
+    ):
+        if text is None and bboxes is None and points is None:
+            text = self._classes
+        if text is None and bboxes is None and points is None:
+            raise ValueError("Supply text, bboxes, or points.")
+        if points is not None and (bboxes is not None or text is not None):
+            raise ValueError("Point prompts cannot be combined with boxes or text.")
+        prompt = {}
+        if text is not None:
+            prompt["text"] = self._text(text)
+            self._register_labels(prompt["text"])
+        if bboxes is not None:
+            boxes = np.asarray(bboxes, np.float32)
+            if boxes.ndim == 1:
+                boxes = boxes[None]
+            if (
+                boxes.ndim != 2
+                or boxes.shape[1] != 4
+                or not len(boxes)
+                or not np.isfinite(boxes).all()
+                or (boxes[:, 2:] <= boxes[:, :2]).any()
+            ):
+                raise ValueError("bboxes must be a nonempty finite (N,4) xyxy array.")
+            prompt["bboxes"] = boxes.tolist()
+        if points is not None:
+            xy = np.asarray(points, np.float32)
+            if xy.ndim == 1:
+                xy = xy[None]
+            if xy.ndim == 2:
+                xy = xy[None]
+            if (
+                xy.ndim != 3
+                or xy.shape[2] != 2
+                or not xy.shape[0]
+                or not xy.shape[1]
+                or not np.isfinite(xy).all()
+            ):
+                raise ValueError(
+                    "points must be finite (N,2) or (G,N,2) pixel coordinates."
+                )
+            prompt["points"] = xy.tolist()
+        many = isinstance(source, (list, tuple))
+        if isinstance(source, (str, Path)) and Path(source).is_dir():
+            source = sorted(
+                p
+                for p in Path(source).iterdir()
+                if p.suffix.lower() in SUPPORTED_EXTENSIONS
+            )
+            many = True
+        sources = list(source) if many else [source]
+        if output_path is not None and (not save or len(sources) != 1):
+            raise ValueError("output_path requires save=True with one image.")
+
+        def generate():
+            save_dir = None
+            for index, item in enumerate(sources):
+                image = ImageLoader.load(item, color_format=color_format)
+                try:
+                    arrays, labels = self._ensure_backend().predict(
+                        np.asarray(image, dtype=np.uint8), prompt
+                    )
+                    self._register_labels(labels)
+                    result = self._result(
+                        arrays,
+                        labels,
+                        (image.height, image.width),
+                        str(item) if isinstance(item, (str, Path)) else None,
+                        names=self.names.copy(),
+                    )
+                except Exception:
+                    self.close()
+                    raise
+                if save:
+                    if output_path:
+                        target = Path(output_path)
+                    else:
+                        if save_dir is None:
+                            from ...utils.general import increment_path
+
+                            save_dir = increment_path(
+                                Path("runs/detect3d/predict"), mkdir=True
+                            )
+                        target = save_dir / f"image_{index}.png"
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    result.plot(image).save(target)
+                yield result
+
+        iterator = generate()
+        return iterator if stream else (list(iterator) if many else next(iterator))
+
+    __call__ = predict
+
+    @staticmethod
+    def _result(arrays, labels, shape, path, names=None):
+        centers, dims, rotations = (
+            arrays["centers"],
+            arrays["dimensions"],
+            arrays["rotations"],
+        )
+        n = len(centers)
+        if (
+            centers.shape != (n, 3)
+            or dims.shape != (n, 3)
+            or rotations.shape != (n, 3, 3)
+            or len(labels) != n
+        ):
+            raise ValueError("DetAny3D returned misaligned geometry.")
+        if names is None:
+            names = dict(enumerate(dict.fromkeys(label.lower() for label in labels)))
+        lookup = {label.lower(): index for index, label in names.items()}
+        ids = np.array([lookup[label.lower()] for label in labels], np.int64)
+        scores = arrays["scores"].reshape(-1)
+        if len(scores) != n or arrays["boxes"].shape != (n, 4):
+            raise ValueError("DetAny3D returned misaligned boxes or scores.")
+        transform = arrays["view_to_original"]
+        k = transform @ arrays["intrinsics"]
+        xywh = arrays["boxes"]
+        xyxy = np.concatenate(
+            (xywh[:, :2] - xywh[:, 2:] / 2, xywh[:, :2] + xywh[:, 2:] / 2), 1
+        )
+        xyxy[:, [0, 2]] = xyxy[:, [0, 2]] * transform[0, 0] + transform[0, 2]
+        xyxy[:, [1, 3]] = xyxy[:, [1, 3]] * transform[1, 1] + transform[1, 2]
+        data = np.zeros((n, 14), np.float32)
+        data[:, :3] = centers
+        data[:, 3:6] = dims[:, [0, 2, 1]]  # upstream w,h,l -> canonical w,l,h
+        if n:
+            # Canonical local +x is length; upstream local +z is length.
+            basis = np.array([[0, 0, -1], [0, 1, 0], [1, 0, 0]], np.float32)
+            q = Rotation.from_matrix(rotations @ basis).as_quat()
+            data[:, 6:10] = q[:, [3, 0, 1, 2]]
+        data[:, 10] = scores
+        data[:, 11] = ids
+        data[:, 12] = scores
+        data[:, 13] = (
+            1.0  # upstream exports the input detection score, not box-IoU logits
+        )
+        return Results(
+            Boxes(xyxy, scores, ids, orig_shape=shape),
+            shape,
+            path=path,
+            names=names,
+            boxes3d=Boxes3D(data, shape, k),
+        )
+
+    def close(self):
+        if self._backend is not None:
+            self._backend.close()
+            self._backend = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def train(self, *args, **kwargs):
+        raise NotImplementedError("DetAny3D training is not integrated.")
+
+    def val(self, *args, **kwargs):
+        raise NotImplementedError("Use upstream evaluation for DetAny3D 3D accuracy.")
+
+    def export(self, *args, **kwargs):
+        raise NotImplementedError("DetAny3D export is not integrated.")
+
+    def track(self, *args, **kwargs):
+        raise NotImplementedError("DetAny3D tracking is not integrated.")

--- a/libreyolo/models/detany3d/runtime.py
+++ b/libreyolo/models/detany3d/runtime.py
@@ -1,0 +1,29 @@
+"""Typed-array process boundary for the optional DetAny3D runtime."""
+
+from pathlib import Path
+
+from ..runtime_worker import RuntimeWorker as _RuntimeWorker
+from ..runtime_worker import decode_array, encode_array
+
+
+class RuntimeWorker(_RuntimeWorker):
+    def __init__(self, **kwargs):
+        super().__init__(
+            worker_path=Path(__file__).with_name("worker.py"),
+            runtime_name="DetAny3D",
+            **kwargs,
+        )
+
+    def _rpc(self, request):
+        reply = super()._rpc(request)
+        if request.get("action") == "load":
+            self.device = reply["device"]
+        return reply
+
+    def predict(self, image, prompt):
+        reply = self._rpc(
+            {"action": "predict", "image": encode_array(image), "prompt": prompt}
+        )
+        return {
+            key: decode_array(value) for key, value in reply["arrays"].items()
+        }, reply["labels"]

--- a/libreyolo/models/detany3d/worker.py
+++ b/libreyolo/models/detany3d/worker.py
@@ -1,0 +1,368 @@
+"""Private DetAny3D worker; no UniDepth implementation is bundled here.
+
+The input recipe follows OpenDriveLab/DetAny3D's Apache-2.0 deploy.py.
+CPU compatibility uses public xFormers interfaces and LibreYOLO's existing
+permissive deformable-attention implementation. It is installed only in this
+separate process. The upstream model and checkpoint remain unchanged.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import inspect
+import json
+import os
+import sys
+import types
+import warnings
+from pathlib import Path
+
+
+def _bootstrap_package():
+    """Expose this package without shadowing the external interpreter's deps."""
+    package = Path(__file__).resolve().parents[2]
+    initial = package / "__init__.py"
+    existing = sys.modules.get("libreyolo")
+    if existing is not None:
+        if Path(existing.__file__).resolve() != initial:
+            raise RuntimeError(
+                "The external interpreter preloaded a different LibreYOLO package."
+            )
+        return
+    spec = importlib.util.spec_from_file_location(
+        "libreyolo", initial, submodule_search_locations=[str(package)]
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["libreyolo"] = module
+    spec.loader.exec_module(module)
+
+
+def _portable_attention(
+    query, key, value, attn_bias=None, p=0.0, scale=None, *, op=None
+):
+    import torch
+    from torch.nn import functional as F
+
+    if op is not None:
+        raise NotImplementedError(
+            "The DetAny3D CPU worker cannot select a CUDA xFormers operator."
+        )
+    if attn_bias is not None and not isinstance(attn_bias, torch.Tensor):
+        raise NotImplementedError(
+            "Structured xFormers attention masks are not supported by this worker."
+        )
+    three = query.ndim == 3
+    if three:
+        query, key, value = (x.unsqueeze(2) for x in (query, key, value))
+    if query.ndim != 4:
+        raise ValueError("Expected xFormers [batch, sequence, heads, channels] inputs.")
+    output = F.scaled_dot_product_attention(
+        query.transpose(1, 2),
+        key.transpose(1, 2),
+        value.transpose(1, 2),
+        attn_mask=attn_bias,
+        dropout_p=p,
+        scale=scale,
+    ).transpose(1, 2)
+    return output.squeeze(2) if three else output
+
+
+def _install_portable_ops():
+    import xformers.ops as xops
+    from xformers.ops import fmha
+
+    xops.memory_efficient_attention = _portable_attention
+    fmha.memory_efficient_attention = _portable_attention
+    extension = types.ModuleType("mmcv._ext")
+    extension.__spec__ = importlib.machinery.ModuleSpec("mmcv._ext", loader=None)
+
+    def unavailable(*args, **kwargs):
+        raise NotImplementedError(
+            "This DetAny3D CPU worker supplies only portable multi-scale deformable attention."
+        )
+
+    def lookup(name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return unavailable
+
+    def deform(
+        value,
+        spatial_shapes,
+        level_start_index,
+        sampling_locations,
+        attention_weights,
+        im2col_step=64,
+    ):
+        from libreyolo.models.deformable_detr.ms_deform_attn import (
+            ms_deform_attn_core_pytorch,
+        )
+
+        return ms_deform_attn_core_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+
+    extension.__getattr__ = lookup
+    extension.ms_deform_attn_forward = deform
+    extension.ms_deform_attn_backward = unavailable
+    sys.modules["mmcv._ext"] = extension
+
+
+def _build(config):
+    import torch
+    import yaml
+    from box import Box
+
+    root = Path(config["runtime_path"]).resolve()
+    os.chdir(root)
+    sys.path.insert(0, str(root))
+    sys.path.insert(0, str(root / "GroundingDINO"))
+    device = config["device"]
+    if device == "auto":
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = torch.device(device)
+    if device.type == "cpu":
+        _install_portable_ops()
+    from wrap_model import WrapModel
+
+    cfg = Box(yaml.safe_load((root / "detect_anything/configs/demo.yaml").read_text()))
+    # The full checkpoint contains both backbones; skip redundant initialization.
+    cfg.model.checkpoint = None
+    cfg.dino_path = None
+    cfg.device = str(device)
+    model = WrapModel(cfg)
+    load_options = {"map_location": "cpu", "weights_only": True}
+    if "mmap" in inspect.signature(torch.load).parameters:
+        load_options["mmap"] = True
+    checkpoint = torch.load(config["checkpoint"], **load_options)
+    model.load_state_dict(checkpoint["state_dict"], strict=True)
+    del checkpoint
+    return {
+        "model": model.to(device).eval(),
+        "cfg": cfg,
+        "device": device,
+        "config": config,
+        "grounding": None,
+    }
+
+
+def _preprocess(image, cfg, device):
+    import numpy as np
+    import torch
+    from detect_anything.utils.transforms import ResizeLongestSide
+    from torch.nn import functional as F
+
+    height, width = image.shape[:2]
+    if cfg.model.pad <= 0 or cfg.model.pad % 112:
+        raise ValueError("DetAny3D canvas size must be a positive multiple of 112.")
+    transform = ResizeLongestSide(cfg.model.pad)
+    tensor = torch.from_numpy(image.copy()).permute(2, 0, 1).float()[None]
+    resized = transform.apply_image_torch(tensor)
+    rh, rw = resized.shape[-2:]
+    ch, cw = rh // 14 * 14, rw // 14 * 14
+    if ch == 0 or cw == 0:
+        raise ValueError("This image aspect ratio produces an empty DetAny3D crop.")
+    top, left = rh // 2 - ch // 2, rw // 2 - cw // 2
+    cropped = resized[:, :, top : top + ch, left : left + cw]
+    mean = cropped.new_tensor(cfg.dataset.pixel_mean).view(1, 3, 1, 1)
+    std = cropped.new_tensor(cfg.dataset.pixel_std).view(1, 3, 1, 1)
+    sam = F.pad((cropped - mean) / std, (0, cfg.model.pad - cw, 0, cfg.model.pad - ch))
+    dino = (
+        cropped / 255 - cropped.new_tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1)
+    ) / cropped.new_tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1)
+    patch = cfg.model.image_encoder.patch_size
+    vit_hw = (
+        (ch // patch, cw // patch)
+        if cfg.model.vit_pad_mask
+        else (cfg.model.pad // patch,) * 2
+    )
+    inputs = {
+        "images": sam.to(device),
+        "image_for_dino": dino.to(device),
+        "images_shape": torch.tensor([[ch, cw]], dtype=torch.float32, device=device),
+        "vit_pad_size": torch.tensor([vit_hw], device=device),
+    }
+    inverse = np.array(
+        [
+            [width / rw, 0, left * width / rw],
+            [0, height / rh, top * height / rh],
+            [0, 0, 1],
+        ],
+        np.float32,
+    )
+    return inputs, transform, inverse
+
+
+def _ground(state, image, texts):
+    import groundingdino
+    import numpy as np
+    import torch
+    from groundingdino.datasets import transforms
+    from groundingdino.util.inference import load_model, predict
+    from PIL import Image
+    from torchvision.ops import box_convert
+
+    config = state["config"]
+    root = Path(groundingdino.__file__).resolve().parent.parent
+    if state["grounding"] is None:
+        weights = Path(
+            config["grounding_checkpoint"]
+            or root / "weights/groundingdino_swinb_cogcoor.pth"
+        )
+        architecture = Path(
+            config["grounding_config"]
+            or root / "groundingdino/config/GroundingDINO_SwinB_cfg.py"
+        )
+        if not weights.is_file() or not architecture.is_file():
+            raise FileNotFoundError(
+                "Text prompts need the upstream GroundingDINO Swin-B config and checkpoint; set grounding_config and grounding_checkpoint."
+            )
+        state["grounding"] = load_model(
+            str(architecture), str(weights), device=str(state["device"])
+        )
+    transform = transforms.Compose(
+        [
+            transforms.RandomResize([800], max_size=1333),
+            transforms.ToTensor(),
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ]
+    )
+    transformed, _ = transform(Image.fromarray(image), None)
+    caption = " . ".join(texts)
+    boxes, scores, phrases = predict(
+        model=state["grounding"],
+        image=transformed,
+        caption=caption,
+        box_threshold=config["conf"],
+        text_threshold=config["text_threshold"],
+        remove_combined=False,
+        device=str(state["device"]),
+    )
+    h, w = image.shape[:2]
+    boxes = box_convert(
+        boxes * torch.tensor([w, h, w, h]), in_fmt="cxcywh", out_fmt="xyxy"
+    )
+    return (
+        boxes.to(torch.int).cpu().numpy().astype(np.float32),
+        scores.cpu().numpy().astype(np.float32),
+        phrases,
+    )
+
+
+def _predict(state, image, prompt):
+    import numpy as np
+    import torch
+    from detect_anything.datasets.utils import points_img2cam, rotation_6d_to_matrix
+
+    cfg, device = state["cfg"], state["device"]
+    inputs, resize, inverse = _preprocess(image, cfg, device)
+    labels, scores = [], []
+    with torch.no_grad():
+        if "points" in prompt:
+            points = torch.tensor(prompt["points"], dtype=torch.int)
+            inputs["point_coords"] = resize.apply_coords_torch(
+                points, image.shape[:2]
+            ).to(device)
+            labels = [f"prompt_{i}" for i in range(len(points))]
+            scores = [1.0] * len(points)
+        else:
+            boxes = list(prompt.get("bboxes", []))
+            labels = [f"prompt_{i}" for i in range(len(boxes))]
+            scores = [1.0] * len(boxes)
+            if "text" in prompt:
+                detected, confidence, phrases = _ground(state, image, prompt["text"])
+                boxes.extend(detected.tolist())
+                scores.extend(confidence.tolist())
+                labels.extend(phrases)
+            if boxes:
+                inputs["boxes_coords"] = (
+                    resize.apply_boxes_torch(torch.tensor(boxes), image.shape[:2])
+                    .to(torch.int)
+                    .to(device)
+                )
+        output = state["model"](inputs)
+        k = output["pred_K"][0]
+        if labels:
+            image_centers = torch.cat(
+                (
+                    output["pred_center_2d"] * cfg.model.pad,
+                    output["pred_bbox_3d_depth"].exp(),
+                ),
+                -1,
+            )
+            arrays = {
+                "boxes": output["pred_bbox_2d"] * cfg.model.pad,
+                "centers": points_img2cam(image_centers, k),
+                "dimensions": output["pred_bbox_3d_dims"].exp(),
+                "rotations": rotation_6d_to_matrix(output["pred_pose_6d"]),
+            }
+            arrays = {
+                key: value.detach().float().cpu().numpy()
+                for key, value in arrays.items()
+            }
+        else:
+            arrays = {
+                "boxes": np.empty((0, 4), np.float32),
+                "centers": np.empty((0, 3), np.float32),
+                "dimensions": np.empty((0, 3), np.float32),
+                "rotations": np.empty((0, 3, 3), np.float32),
+            }
+        arrays.update(
+            intrinsics=k.detach().float().cpu().numpy(),
+            view_to_original=inverse,
+            scores=np.asarray(scores, np.float32),
+        )
+    return arrays, labels
+
+
+def main():
+    protocol = sys.stdout
+    sys.stdout = sys.stderr
+    warnings.showwarning = (
+        lambda message, category, filename, lineno, file=None, line=None: print(
+            f"{category.__name__}: {message}", file=sys.stderr, flush=True
+        )
+    )
+    _bootstrap_package()
+    from libreyolo.models.runtime_worker import _PREFIX, decode_array, encode_array
+
+    state = None
+    for line in sys.stdin:
+        request = json.loads(line)
+        try:
+            if request["action"] == "load":
+                state = _build(request["config"])
+                reply = {"device": str(state["device"])}
+            elif request["action"] == "predict" and state is not None:
+                arrays, labels = _predict(
+                    state, decode_array(request["image"]), request["prompt"]
+                )
+                reply = {
+                    "arrays": {
+                        key: encode_array(value) for key, value in arrays.items()
+                    },
+                    "labels": labels,
+                }
+            else:
+                raise ValueError("Invalid DetAny3D worker request.")
+        except Exception as exc:  # noqa: BLE001 - external-runtime protocol boundary
+            frames = []
+            tb = exc.__traceback__
+            while tb:
+                frames.append(
+                    {
+                        "module": tb.tb_frame.f_globals.get("__name__"),
+                        "function": tb.tb_frame.f_code.co_name,
+                        "line": tb.tb_lineno,
+                    }
+                )
+                tb = tb.tb_next
+            reply = {"error": {"message": str(exc), "frames": frames}}
+        reply["id"] = request["id"]
+        protocol.write(_PREFIX + json.dumps(reply, allow_nan=False) + "\n")
+        protocol.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -10,6 +10,7 @@ import textwrap
 
 
 OPTIONAL_MODELS = (
+    ("libreyolo.models.detany3d", "LibreDetAny3D", None, "detect_anything"),
     ("libreyolo.models.wilddet3d", "LibreWildDet3D", None, "wilddet3d"),
     ("libreyolo.models.mood3d", "Libre3DMOOD", None, "opendet3d"),
     ("libreyolo.models.sam.model", "LibreSAM1", "sam", "transformers"),

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -8,9 +8,9 @@ import importlib.util
 import inspect
 import textwrap
 
-
 OPTIONAL_MODELS = (
-    ("libreyolo.models.detany3d", "LibreDetAny3D", None, "detect_anything"),
+    # The adapter is built in; its runtime is supplied to a separate interpreter.
+    ("libreyolo.models.detany3d", "LibreDetAny3D", None, None),
     ("libreyolo.models.wilddet3d", "LibreWildDet3D", None, "wilddet3d"),
     ("libreyolo.models.mood3d", "Libre3DMOOD", None, "opendet3d"),
     ("libreyolo.models.sam.model", "LibreSAM1", "sam", "transformers"),

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -110,6 +110,7 @@ MODEL_GROUPS: dict[str, str] = {
     "sam": "s",
     "sam2": "s",
     "sam3": "s",
+    "detany3d": "s",
     "wilddet3d": "s",
     "3dmood": "s",
     "edgetam": "s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -459,6 +459,7 @@ testpaths = ["tests"]
 # the e2e target sets, so unit runs stay unbounded.
 timeout_method = "thread"
 markers = [
+    "detany3d: optional DetAny3D promptable 3D detection integration",
     "wilddet3d: optional WildDet3D 3D detection integration",
     "mood3d: optional 3D-MOOD open-set 3D detection integration",
     "unit: fast tests that avoid external weights or large files",

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -376,7 +376,7 @@
     "task_sizes": {},
     "export_override": "blocked",
     "optional_extra": null,
-    "available": false,
+    "available": true,
     "group": "s",
     "cli_command": "detany3d"
   },

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -361,6 +361,25 @@
     "available": true,
     "group": "g3"
   },
+  "detany3d": {
+    "class": "libreyolo.models.detany3d.model.LibreDetAny3D",
+    "tasks": [
+      "detect3d"
+    ],
+    "default_task": "detect3d",
+    "sizes": {
+      "h": 896
+    },
+    "default_imgsz": {
+      "h": 896
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": null,
+    "available": false,
+    "group": "s",
+    "cli_command": "detany3d"
+  },
   "detr": {
     "class": "libreyolo.models.detr.model.LibreDETR",
     "tasks": [

--- a/tests/e2e/test_detany3d.py
+++ b/tests/e2e/test_detany3d.py
@@ -1,0 +1,120 @@
+"""Manual DetAny3D parity against locally staged upstream reference outputs.
+
+Set LIBREYOLO_DETANY3D_CHECKPOINT, _RUNTIME, _PYTHON, _REFERENCE and
+_GROUNDING_CHECKPOINT. The reference JSON sits beside its source images.
+No model weights, dataset images or reference-output arrays are redistributed.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.e2e.conftest import require_test_weights
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.detany3d,
+    pytest.mark.external_data,
+    pytest.mark.network,
+]
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def test_upstream_prompt_modes_and_geometry():
+    keys = ("CHECKPOINT", "RUNTIME", "PYTHON", "REFERENCE", "GROUNDING_CHECKPOINT")
+    paths = {key: os.environ.get("LIBREYOLO_DETANY3D_" + key) for key in keys}
+    if not all(paths.values()):
+        pytest.skip(
+            "Set LIBREYOLO_DETANY3D_CHECKPOINT, _RUNTIME, _PYTHON, _REFERENCE and _GROUNDING_CHECKPOINT."
+        )
+    checkpoint = Path(
+        require_test_weights(str(Path(paths["CHECKPOINT"]).expanduser().resolve()))
+    )
+    reference_path = Path(paths["REFERENCE"]).expanduser().resolve()
+    reference = json.loads(reference_path.read_text())
+    assert reference["schema_version"] == 1
+    assert reference["upstream_revision"] == "10e484be0837d80aa33cff6ed95a9be834a3f794"
+    assert reference["checkpoint_sha256"] == _sha256(checkpoint)
+    assert reference["grounding_sha256"] == _sha256(Path(paths["GROUNDING_CHECKPOINT"]))
+    assert reference["config_sha256"] == _sha256(
+        Path(paths["RUNTIME"]) / "detect_anything/configs/demo.yaml"
+    )
+    cases = reference["cases"]
+    assert len(cases) == 9
+    assert any(case["crop"][0] > 0 for case in cases)
+    assert any(not case["labels"] for case in cases)
+    assert any(
+        "bboxes" in case["prompt"] and "text" in case["prompt"] for case in cases
+    )
+    assert any("points" in case["prompt"] for case in cases)
+    from libreyolo import LibreDetAny3D
+
+    model = None
+    conf = None
+    try:
+        for case in cases:
+            if model is None or conf != case["conf"]:
+                if model is not None:
+                    model.close()
+                conf = case["conf"]
+                model = LibreDetAny3D(
+                    checkpoint,
+                    runtime_path=paths["RUNTIME"],
+                    runtime_python=paths["PYTHON"],
+                    grounding_checkpoint=paths["GROUNDING_CHECKPOINT"],
+                    device="cpu",
+                    conf=conf,
+                )
+                model.set_classes(["car", "person"])
+            assert Path(case["image"]).name == case["image"]
+            image = reference_path.parent / case["image"]
+            assert _sha256(image) == case["image_sha256"]
+            result = model(image, **case["prompt"])
+            labels = [result.names[int(index)] for index in result.boxes.cls]
+            assert labels == case["labels"]
+            np.testing.assert_allclose(
+                result.boxes.conf, case["scores"], atol=1e-5, rtol=1e-5
+            )
+            np.testing.assert_allclose(
+                result.boxes.xyxy,
+                np.asarray(case["boxes"]).reshape(-1, 4),
+                atol=0.05,
+                rtol=1e-5,
+            )
+            np.testing.assert_allclose(
+                result.boxes3d.xyz,
+                np.asarray(case["centers"]).reshape(-1, 3),
+                atol=0.002,
+                rtol=1e-4,
+            )
+            np.testing.assert_allclose(
+                result.boxes3d.dimensions,
+                np.asarray(case["dimensions"]).reshape(-1, 3),
+                atol=0.001,
+                rtol=1e-4,
+            )
+            np.testing.assert_allclose(
+                result.boxes3d.intrinsics, case["intrinsics"], atol=0.01, rtol=1e-5
+            )
+            if len(result):
+                distance = np.linalg.norm(
+                    result.boxes3d.corners[:, :, None]
+                    - np.asarray(case["corners"])[:, None],
+                    axis=-1,
+                )
+                assert distance.min(1).max() < 0.005
+                assert distance.min(2).max() < 0.005
+    finally:
+        if model is not None:
+            model.close()

--- a/tests/unit/cli/commands/test_detany3d.py
+++ b/tests/unit/cli/commands/test_detany3d.py
@@ -1,0 +1,78 @@
+"""DetAny3D CLI grammars, prompt forwarding and clean machine output."""
+
+import json
+
+import numpy as np
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from libreyolo.cli.commands.detany3d import detany3d_cmd
+from libreyolo.cli.parsing import KeyValueCommand
+
+pytestmark = pytest.mark.unit
+
+
+def app():
+    result = typer.Typer()
+    result.command("detany3d", cls=KeyValueCommand)(detany3d_cmd)
+    return result
+
+
+@pytest.mark.parametrize("key_value", [False, True])
+def test_grammars_and_json(monkeypatch, key_value):
+    from libreyolo import LibreDetAny3D
+    from libreyolo.utils.results import Boxes, Boxes3D, Results
+
+    calls = []
+
+    def init(self, path, **kwargs):
+        calls.append(("init", path, kwargs))
+        self._backend = None
+
+    def predict(self, source, **kwargs):
+        calls.append(("predict", source, kwargs))
+        print("runtime progress")
+        return Results(
+            Boxes(np.empty((0, 4)), np.empty(0), np.empty(0)),
+            (100, 100),
+            boxes3d=Boxes3D(np.empty((0, 14)), (100, 100), np.eye(3)),
+        )
+
+    monkeypatch.setattr(LibreDetAny3D, "__init__", init)
+    monkeypatch.setattr(LibreDetAny3D, "predict", predict)
+    pairs = {
+        "source": "image.jpg",
+        "model": "model.pth",
+        "runtime_path": "runtime",
+        "text": '["car","person"]',
+        "conf": "0.4",
+    }
+    args = (
+        [f"{k}={v}" for k, v in pairs.items()]
+        if key_value
+        else [
+            part for k, v in pairs.items() for part in (f"--{k.replace('_', '-')}", v)
+        ]
+    )
+    args += (
+        ["json=true", "quiet=true", "save=false"]
+        if key_value
+        else ["--json", "--quiet"]
+    )
+    result = CliRunner().invoke(app(), args)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["task"] == "detect3d"
+    assert result.stderr == ""
+    assert calls[0][2]["conf"] == 0.4
+    assert calls[1][2]["text"] == ["car", "person"]
+    assert calls[1][2]["save"] is False
+
+
+def test_help_and_bad_prompt():
+    result = CliRunner().invoke(app(), ["--help-json"])
+    assert result.exit_code == 0
+    assert "runtime_python" in str(json.loads(result.stdout))
+    result = CliRunner().invoke(app(), ["source=x", "model=x", "points=[bad", "--json"])
+    assert result.exit_code != 0
+    assert "config_type_error" in result.stdout

--- a/tests/unit/test_detany3d.py
+++ b/tests/unit/test_detany3d.py
@@ -1,0 +1,200 @@
+"""DetAny3D geometry, prompt routing and worker lifecycle without external data."""
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo.models.detany3d import LibreDetAny3D
+from libreyolo.models.detany3d.worker import _portable_attention
+
+pytestmark = pytest.mark.unit
+
+
+def arrays():
+    return {
+        "boxes": np.array([[8, 7, 4, 2]], np.float32),
+        "centers": np.array([[0, 0, 10]], np.float32),
+        "dimensions": np.array([[2, 4, 6]], np.float32),
+        "rotations": np.eye(3, dtype=np.float32)[None],
+        "scores": np.array([0.7], np.float32),
+        "intrinsics": np.array([[100, 0, 8], [0, 100, 7], [0, 0, 1]], np.float32),
+        "view_to_original": np.array([[2, 0, 10], [0, 3, 20], [0, 0, 1]], np.float32),
+    }
+
+
+def test_camera_and_local_axis_conversion():
+    output = LibreDetAny3D._result(arrays(), ["car"], (100, 200), None)
+    np.testing.assert_allclose(output.boxes.xyxy, [[22, 38, 30, 44]])
+    np.testing.assert_allclose(
+        output.boxes3d.intrinsics, [[200, 0, 26], [0, 300, 41], [0, 0, 1]]
+    )
+    np.testing.assert_allclose(output.boxes3d.dimensions, [[2, 6, 4]])
+    np.testing.assert_allclose(output.boxes3d.corners[0, 0], [1, 2, 13], atol=1e-6)
+    assert not output.boxes.is_track
+    assert output.names == {0: "car"}
+    assert output.boxes3d.conf3d[0] == 1
+    assert output.boxes3d.conf[0] == pytest.approx(0.7)
+
+
+def test_axis_change_is_applied_in_local_frame():
+    packet = arrays()
+    packet["rotations"][0] = [[0, -1, 0], [1, 0, 0], [0, 0, 1]]
+    output = LibreDetAny3D._result(packet, ["car"], (100, 200), None)
+    np.testing.assert_allclose(output.boxes3d.corners[0, 0], [-2, 1, 13], atol=1e-6)
+    selected = output._select([0])
+    np.testing.assert_array_equal(
+        selected.boxes3d.intrinsics, output.boxes3d.intrinsics
+    )
+
+
+@pytest.mark.parametrize("rank", [3, 4])
+def test_portable_attention_uniform_and_masked(rank):
+    q = torch.zeros(1, 2, 1, 2)
+    k = torch.zeros(1, 3, 1, 2)
+    v = torch.tensor([[[[1.0, 3.0]], [[7.0, 11.0]], [[16.0, 20.0]]]])
+    if rank == 3:
+        q, k, v = [x.squeeze(2) for x in (q, k, v)]
+    result = _portable_attention(q, k, v)
+    expected = torch.tensor([8.0, 34 / 3]).expand_as(result)
+    torch.testing.assert_close(result, expected)
+    bias = torch.tensor([[[[float("-inf"), 0, float("-inf")]]]])
+    result = _portable_attention(q, k, v, attn_bias=bias)
+    torch.testing.assert_close(result, torch.tensor([7.0, 11.0]).expand_as(result))
+
+
+@pytest.fixture
+def fake_model(tmp_path, monkeypatch):
+    import libreyolo.models.detany3d.model as module
+
+    instances = []
+    calls = []
+    replies = ["person", "car"]
+    failures = []
+
+    class FakeWorker:
+        device = "cpu"
+
+        def __init__(self, **kwargs):
+            self.closed = False
+            instances.append(self)
+
+        def predict(self, image, prompt):
+            calls.append(prompt)
+            if failures:
+                raise failures.pop()
+            return arrays(), [replies.pop(0) if replies else "car"]
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(module, "RuntimeWorker", FakeWorker)
+    (tmp_path / "model.pth").touch()
+    (tmp_path / "wrap_model.py").touch()
+    model = LibreDetAny3D(tmp_path / "model.pth", runtime_path=tmp_path)
+    yield model, instances, calls, failures
+    model.close()
+
+
+def test_vocabulary_ids_remain_stable(fake_model):
+    model, instances, calls, _ = fake_model
+    model.set_classes(["car", "person"])
+    image = Image.new("RGB", (100, 100))
+    first = model(image)
+    second = model(image)
+    assert first.boxes.cls.tolist() == [1]
+    assert second.boxes.cls.tolist() == [0]
+    assert len(instances) == 1
+    assert calls[0]["text"] == ["car", "person"]
+    assert model.names == {0: "car", 1: "person"}
+
+
+def test_prompt_shapes_multi_input_save_and_close(fake_model, tmp_path):
+    model, instances, calls, _ = fake_model
+    image = Image.new("RGB", (100, 100))
+    model(
+        image, points=[[10, 20], [11, 21]], save=True, output_path=tmp_path / "out.png"
+    )
+    assert calls[-1]["points"] == [[[10.0, 20.0], [11.0, 21.0]]]
+    assert (tmp_path / "out.png").is_file()
+    results = model([image, image], bboxes=[1, 2, 30, 40], stream=True)
+    assert len(list(results)) == 2
+    assert calls[-1]["bboxes"] == [[1.0, 2.0, 30.0, 40.0]]
+    model.close()
+    assert instances[0].closed
+
+
+def test_failed_prediction_restarts_worker(fake_model):
+    model, instances, _, failures = fake_model
+    image = Image.new("RGB", (100, 100))
+    failures.append(RuntimeError("failed upstream"))
+    with pytest.raises(RuntimeError, match="failed upstream"):
+        model(image, points=[10, 20])
+    assert instances[0].closed
+    model(image, points=[10, 20])
+    assert len(instances) == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"points": []},
+        {"bboxes": [1, 2, 1, 4]},
+        {"text": [""]},
+        {"points": [1, 2], "text": "car"},
+        {"points": [1, 2], "bboxes": [1, 2, 3, 4]},
+    ],
+)
+def test_invalid_prompts_fail_before_prediction(fake_model, kwargs):
+    model, _, calls, _ = fake_model
+    with pytest.raises(ValueError):
+        model(Image.new("RGB", (100, 100)), **kwargs)
+    assert calls == []
+
+
+def test_unsupported_workflows_and_no_download(fake_model):
+    model, *_ = fake_model
+    assert model.get_download_url("anything.pt") is None
+    for method in ("train", "val", "export", "track"):
+        with pytest.raises(NotImplementedError):
+            getattr(model, method)()
+
+
+def test_worker_bootstrap_preserves_runtime_dependencies(tmp_path):
+    """A parent wheel must not prepend its entire site-packages to the worker."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    from libreyolo.models.detany3d import worker
+
+    parent = tmp_path / "parent_site"
+    runtime = tmp_path / "runtime_site"
+    worker_path = parent / "libreyolo/models/detany3d/worker.py"
+    worker_path.parent.mkdir(parents=True)
+    runtime.mkdir()
+    worker_path.write_text(Path(worker.__file__).read_text())
+    (parent / "dependency.py").write_text('ORIGIN="parent"\n')
+    (runtime / "dependency.py").write_text('ORIGIN="runtime"\n')
+    (parent / "libreyolo/__init__.py").write_text(
+        "import dependency\nORIGIN=dependency.ORIGIN\n"
+    )
+    script = """
+import importlib.util,sys
+sys.path.insert(0,sys.argv[2])
+spec=importlib.util.spec_from_file_location('worker_probe',sys.argv[1])
+worker=importlib.util.module_from_spec(spec)
+spec.loader.exec_module(worker)
+worker._bootstrap_package()
+import libreyolo
+assert libreyolo.ORIGIN=='runtime',libreyolo.ORIGIN
+assert sys.argv[3] not in sys.path
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(worker_path), str(runtime), str(parent)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/test_detany3d.py
+++ b/tests/unit/test_detany3d.py
@@ -11,6 +11,22 @@ from libreyolo.models.detany3d.worker import _portable_attention
 pytestmark = pytest.mark.unit
 
 
+def test_inventory_does_not_require_runtime_in_parent_interpreter(monkeypatch):
+    from libreyolo.models import inventory
+
+    original = inventory.importlib.util.find_spec
+
+    def find_spec(name, *args, **kwargs):
+        if name == "detect_anything":
+            return None
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(inventory.importlib.util, "find_spec", find_spec)
+    metadata = inventory.collect_model_inventory()["detany3d"]
+    assert metadata["available"] is True
+    assert metadata["cli_command"] == "detany3d"
+
+
 def arrays():
     return {
         "boxes": np.array([[8, 7, 4, 2]], np.float32),

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -810,3 +810,10 @@ WildDet3D (LibreYOLO/LibreWildDet3D; byte-identical upstream mirror)
     Swin-B: Libre3DMOODb.pt
       Mirror revision: a4f6115d285a6983439f0e54f20c44b0ce87c261
       SHA-256: 834c976df385610bba105c7d4ea3e2d7b57dabd69dee2b61397ae398de67a677
+
+DetAny3D
+-------
+Official full checkpoint accepted locally without changing learned parameters.
+Source: https://github.com/OpenDriveLab/DetAny3D
+Checkpoint redistribution terms remain unresolved; no weights are hosted.
+The separate runtime includes UniDepth code under CC BY-NC 4.0.


### PR DESCRIPTION
- Add `LibreDetAny3D` and `libreyolo detany3d` for text, box and point prompts with estimated calibration.
- Keep the upstream runtime separate; no checkpoint mirror because redistribution terms are unresolved.
- Verified: nine upstream CPU parity cases, real prediction from the built wheel, 163 focused unit tests, 101 tests after inventory fixes, Ruff.
- Final CI: Linux/macOS 6,919 passed, Windows 6,920 passed; only five `cls_pw` CLI failures per OS, also present on unchanged dev (run 34449996916).
- Not verified: CUDA or benchmark accuracy. Training, validation, tracking and export are unsupported.
- Opened by an agent.

## Code provenance
Adapter/preprocessing follows OpenDriveLab/DetAny3D `10e484be0837d80aa33cff6ed95a9be834a3f794` (Apache-2.0). CPU compatibility follows facebookresearch/xformers `6f3c20f223c0f051e4b2dc744cc7591591ee04c4` public API (BSD-3-Clause) and reuses LibreYOLO's existing Apache-2.0 deformable attention. Notices updated. The external runtime includes CC BY-NC UniDepth; no UniDepth implementation is bundled or used to derive this adapter.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62658023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation does not show a confirmed runtime blocker, but the unrelated FCOS3D feature must be separated to satisfy the repository’s explicit PR-scope requirement before merging.

<h2><a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Fregistry.py%3Aundefined-113%0AThis%20registers%20%60detany3d%60%20as%20a%20new%20model%20family%20but%20does%20not%20add%20its%20required%20row%20to%20the%20existing%20README%20family-support%20table.%20The%20repository%20requires%20every%20new%20model%20family%20to%20add%20that%20single%20row%20and%20to%20mark%20only%20export%20formats%20that%20were%20actually%20tested.%20This%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=848&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**README family row missing** <a href="https://github.com/LibreYOLO/libreyolo/pull/848#discussion_r3981039255">▶</a>

<details><summary><h3>Summary</h3></summary>

- Exposes text, box, and point prompted DetAny3D inference through `LibreDetAny3D` and `libreyolo detany3d`.
- Keeps the upstream DetAny3D environment and checkpoint outside LibreYOLO.
- Adds original-image coordinate restoration and canonical `Boxes3D` results.
- Adds FCOS3D native inference, CLI integration, documentation, and validation as an unrelated second feature.
- The previous README family-table finding is fixed in the current code; the other previous thread was manually resolved.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    U[Python API or CLI] --> A[LibreDetAny3D adapter]
    A --> W[Runtime worker subprocess]
    W --> R[Separate DetAny3D interpreter and checkout]
    R --> C[Official checkpoint]
    R --> O[Raw 2D and 3D predictions]
    O --> M[Original-image coordinate and cuboid mapping]
    M --> X[Results with aligned boxes and boxes3d]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["Resolve DetAny3D conflicts with dev"](https://github.com/libreyolo/libreyolo/commit/401c368230eb546f091a58e266b9ce089c9910f8)</sub>

<!-- /greptile_comment -->