### PR TITLE
Host FCOS3D and DetAny3D checkpoint mirrors and wire auto-download

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -2249,9 +2249,15 @@ training dependencies, torchvision deform_conv2d, camera Results mapping.
 The torchvision operator is a separately installed BSD-3-Clause dependency.
 No third-party C++/CUDA operator source is bundled.
 
-This notice covers code, not the official nuScenes checkpoint. Its separate
-redistribution terms have not been established; no weights are bundled or
-hosted by this port.
+This notice covers code, not the official nuScenes checkpoint. No weights are
+bundled in this port. The official checkpoint is mirrored byte-for-byte at
+LibreYOLO/LibreFCOS3D revision af69c4abfb265f63695ecbaa68b4167f0c150605.
+OpenMMLab declares no per-object checkpoint license; LibreYOLO's maintainer
+approved that mirror by treating the project's Apache-2.0 statement as the
+redistribution basis, which is LibreYOLO's disclosed interpretation and not a
+clarification from the OpenMMLab authors. The weights are trained on nuScenes
+under non-commercial terms (https://www.nuscenes.org/terms-of-use) and are not
+covered by LibreYOLO's MIT license.
 
 Copyright 2018-2019 Open-MMLab. All rights reserved.
 
@@ -2480,7 +2486,16 @@ https://github.com/lpiccinelli-eth/UniDepth
 Revision checked: 8d8cfe4c7ee15297099983607febf0d4f32eb3d6
 No UniDepth implementation was used to write or copied into this adapter.
 This does not grant commercial-use rights to the external runtime.
-Checkpoint redistribution terms have not been established; no mirror is provided.
+The official full checkpoint is mirrored byte-for-byte at
+LibreYOLO/LibreDetAny3D revision eeb89d1b1d37ec5a361b1ec79b26ea0620d9f4c3.
+OpenDriveLab declares no per-object checkpoint license; LibreYOLO's maintainer
+approved that mirror by treating the project's Apache-2.0 statement as the
+redistribution basis for the parameters DetAny3D itself trained. This is
+LibreYOLO's disclosed interpretation and not a clarification from the DetAny3D
+authors. Upstream documents the checkpoint's depth branch as initialized from
+UniDepth v2, so LibreYOLO applies CC BY-NC 4.0 to the mirrored file as the
+strictest known term. The weights are non-commercial and are not covered by
+LibreYOLO's MIT license.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/docs/adr/0023-fcos3d-inference.md
+++ b/docs/adr/0023-fcos3d-inference.md
@@ -53,10 +53,11 @@ are sorted by descending score. CPU polygon intersection uses OpenCV.
 
 ## Checkpoints and provenance
 
-The constructor requires the unchanged official R101 nuScenes checkpoint
-with a `state_dict` wrapper. It validates the class order when supplied and
-loads all tensors strictly. There is no automatic download or converted
-LibreYOLO checkpoint for this family yet.
+The constructor takes the unchanged official R101 nuScenes checkpoint with a
+`state_dict` wrapper. It validates the class order when supplied and loads all
+tensors strictly. Omitting `model_path` downloads LibreYOLO's byte-identical,
+revision-pinned mirror and verifies its SHA-256. There is no converted
+LibreYOLO-schema checkpoint for this family.
 
 Implementation sources are Apache-2.0, pinned in the family NOTICE:
 MMDetection3D `fe25f7a51d36e3702f961e198894580d83c4387b` and MMDetection
@@ -65,11 +66,17 @@ MMDetection3D `fe25f7a51d36e3702f961e198894580d83c4387b` and MMDetection
 The official model is listed in the
 [FCOS3D model zoo](https://github.com/open-mmlab/mmdetection3d/tree/fe25f7a51d36e3702f961e198894580d83c4387b/configs/fcos3d).
 The code license does not establish a separate checkpoint redistribution
-license. nuScenes also has
-[non-commercial dataset terms](https://www.nuscenes.org/terms-of-use).
-Checkpoint rehosting remains unresolved; no Hugging Face upload is made.
-No dataset images, annotations, checkpoint bytes, or validation artifacts
-are distributed with this implementation.
+license, and OpenMMLab declares none per object. The maintainer approved
+rehosting by treating mmdetection3d's project-level Apache-2.0 statement as the
+redistribution basis; that is LibreYOLO's disclosed interpretation, not
+clarification from the OpenMMLab authors. nuScenes also has
+[non-commercial dataset terms](https://www.nuscenes.org/terms-of-use), which
+bind downstream users of the weights. The finetuned checkpoint is mirrored
+byte-for-byte at `LibreYOLO/LibreFCOS3D`
+(`af69c4abfb265f63695ecbaa68b4167f0c150605`) with a non-commercial banner on
+the card and a download notice in the loader. No dataset images, annotations,
+checkpoint bytes, or validation artifacts are distributed with this
+implementation.
 
 ## Validation and limits
 

--- a/docs/adr/0024-detany3d-adapter.md
+++ b/docs/adr/0024-detany3d-adapter.md
@@ -16,8 +16,14 @@ The adapter follows the Apache-2.0 public inference interfaces in
 includes UniDepth under CC BY-NC 4.0. LibreYOLO does not bundle or derive its
 implementation, and this adapter grants no commercial-use rights to that
 runtime. The original full checkpoint is loaded strictly without conversion.
-Checkpoint redistribution terms remain unresolved, so there is no automatic
-download or Hugging Face mirror.
+OpenDriveLab declares no per-object checkpoint license; the maintainer approved
+rehosting by treating the project's Apache-2.0 statement as the redistribution
+basis for the parameters DetAny3D itself trained, which is LibreYOLO's
+disclosed interpretation rather than upstream clarification. Upstream documents
+the depth branch as initialized from UniDepth v2, so CC BY-NC 4.0 is applied to
+the file as the strictest known term. The checkpoint is mirrored byte-for-byte
+at `LibreYOLO/LibreDetAny3D` (`eeb89d1b1d37ec5a361b1ec79b26ea0620d9f4c3`);
+omitting `model_path` downloads it behind a non-commercial download notice.
 
 ## Runtime and public contract
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -1022,14 +1022,22 @@ of the generic checkpoint factory. See ADR 0022.
 
 `LibreDetAny3D` (`detany3d`, coverage group `s`) is a box-, point- and
 text-prompted sibling with predicted calibration. Its full upstream model is
-listed as size `h` with an 896-pixel canvas. It takes an unchanged local upstream
-checkpoint and a separate runtime; no canonical weight mirror or generic
-factory route is provided. The CLI is `libreyolo detany3d`. See ADR 0024.
+listed as size `h` with an 896-pixel canvas. It takes an unchanged upstream
+checkpoint and a separate runtime. Omitting `model_path` downloads the
+byte-identical `detany3d.pth` mirror from `LibreYOLO/LibreDetAny3D`; those
+weights are non-commercial (CC BY-NC 4.0, UniDepth v2 depth lineage) and are
+announced by a download notice. This raw upstream checkpoint is not converted
+and is not registered in the `LibreYOLO(...)` state-dict factory. The CLI is
+`libreyolo detany3d`. See ADR 0024.
 
 ### FCOS3D
 
 `LibreFCOS3D` (`fcos3d`, group `s`, variant `r101`) is a native inference-only
-sibling for calibrated monocular `detect3d`. It accepts the unchanged local
-R101 nuScenes checkpoint. No canonical downloadable filename is registered
-while checkpoint redistribution terms remain unresolved. See
+sibling for calibrated monocular `detect3d`. It accepts the unchanged official
+R101 nuScenes checkpoint, or downloads the byte-identical finetuned mirror
+`fcos3d_r101_caffe_fpn_gn-head_dcn_2x8_1x_nus-mono3d_finetune_20210717_095645-8d806dc2.pth`
+from `LibreYOLO/LibreFCOS3D` when `model_path` is omitted. Those weights are
+non-commercial under nuScenes terms and are announced by a download notice.
+This raw upstream checkpoint is not converted and is not registered in the
+generic state-dict factory. See
 [ADR 0023](adr/0023-fcos3d-inference.md) for API and evidence.

--- a/libreyolo/cli/commands/detany3d.py
+++ b/libreyolo/cli/commands/detany3d.py
@@ -8,7 +8,9 @@ from ..output import OutputHandler
 
 def detany3d_cmd(
     source: str = typer.Option(..., help="Image path or directory"),
-    model: str = typer.Option(..., help="Local official full DetAny3D checkpoint"),
+    model: str = typer.Option(
+        "detany3d.pth", help="Local checkpoint or the mirrored default filename"
+    ),
     runtime_path: str | None = typer.Option(
         None, help="DetAny3D checkout; defaults to DETANY3D_PATH"
     ),

--- a/libreyolo/cli/commands/fcos3d.py
+++ b/libreyolo/cli/commands/fcos3d.py
@@ -9,7 +9,9 @@ from ..output import OutputHandler
 def fcos3d_cmd(
     source: str = typer.Option(..., help="Image path or directory"),
     model: str = typer.Option(
-        ..., help="Local official FCOS3D R101 nuScenes checkpoint"
+        "fcos3d_r101_caffe_fpn_gn-head_dcn_2x8_1x_nus-mono3d_finetune_"
+        "20210717_095645-8d806dc2.pth",
+        help="Local checkpoint or the mirrored default filename",
     ),
     intrinsics: str = typer.Option(
         ..., help="Original-image 3x3 camera calibration .npy file"

--- a/libreyolo/models/detany3d/NOTICE
+++ b/libreyolo/models/detany3d/NOTICE
@@ -20,4 +20,13 @@ https://github.com/lpiccinelli-eth/UniDepth
 Revision checked: 8d8cfe4c7ee15297099983607febf0d4f32eb3d6
 No UniDepth implementation was used to write or copied into this adapter.
 This does not grant commercial-use rights to the external runtime.
-Checkpoint redistribution terms have not been established; no mirror is provided.
+The official full checkpoint is mirrored byte-for-byte at
+LibreYOLO/LibreDetAny3D revision eeb89d1b1d37ec5a361b1ec79b26ea0620d9f4c3.
+OpenDriveLab declares no per-object checkpoint license; LibreYOLO's maintainer
+approved that mirror by treating the project's Apache-2.0 statement as the
+redistribution basis for the parameters DetAny3D itself trained. This is
+LibreYOLO's disclosed interpretation and not a clarification from the DetAny3D
+authors. Upstream documents the checkpoint's depth branch as initialized from
+UniDepth v2, so LibreYOLO applies CC BY-NC 4.0 to the mirrored file as the
+strictest known term. The weights are non-commercial and are not covered by
+LibreYOLO's MIT license.

--- a/libreyolo/models/detany3d/model.py
+++ b/libreyolo/models/detany3d/model.py
@@ -5,6 +5,8 @@ bundled in LibreYOLO. This adapter uses the upstream Apache-2.0 inference
 interface and converts its outputs to the existing camera-frame contract.
 """
 
+import hashlib
+import logging
 import os
 from pathlib import Path
 from typing import ClassVar
@@ -17,11 +19,22 @@ from ...utils.image_loader import SUPPORTED_EXTENSIONS, ImageLoader
 from ...utils.results import Boxes, Boxes3D, Results
 from .runtime import RuntimeWorker
 
+logger = logging.getLogger(__name__)
+HF_REPO = "LibreYOLO/LibreDetAny3D"
+HF_REVISION = "eeb89d1b1d37ec5a361b1ec79b26ea0620d9f4c3"
+WEIGHT_FILE = "detany3d.pth"
+WEIGHT_SHA256 = "cd5f737ddbf3ceb64f969141672d04c0a3d785ad3b8a72668619a530840cd217"
+
 
 class LibreDetAny3D:
     """Box-, point- and text-prompted 3D detection with predicted calibration.
 
-    Supply the official full checkpoint and the separately installed runtime.
+    ``model_path`` accepts an unchanged official full checkpoint. Omitting it
+    downloads LibreYOLO's byte-identical, revision-pinned mirror. Upstream
+    documents its depth branch as initialized from UniDepth v2 under
+    CC BY-NC 4.0, so the mirrored weights are non-commercial and are not
+    covered by LibreYOLO's MIT license.
+    Supply the separately installed runtime.
     Point arrays (N,2) describe one object; (G,N,2) describes G objects. All
     points are positive prompts. Text can be combined with box prompts, while
     point prompts are exclusive. conf/text_threshold configure the text detector;
@@ -40,7 +53,7 @@ class LibreDetAny3D:
 
     def __init__(
         self,
-        model_path,
+        model_path=None,
         *,
         runtime_path=None,
         runtime_python=None,
@@ -50,9 +63,7 @@ class LibreDetAny3D:
         grounding_checkpoint=None,
         grounding_config=None,
     ):
-        checkpoint = Path(model_path).expanduser().resolve()
-        if not checkpoint.is_file():
-            raise FileNotFoundError(f"DetAny3D checkpoint not found: {checkpoint}")
+        checkpoint = self._resolve_checkpoint(model_path)
         runtime_path = runtime_path or os.environ.get("DETANY3D_PATH")
         if not runtime_path:
             raise ImportError(
@@ -98,8 +109,65 @@ class LibreDetAny3D:
 
     @classmethod
     def get_download_url(cls, filename):
-        """No checkpoint mirror until redistribution terms are established."""
-        return
+        """Return the immutable byte-identical checkpoint mirror URL."""
+        if filename not in (None, WEIGHT_FILE):
+            return None
+        return f"https://huggingface.co/{HF_REPO}/resolve/{HF_REVISION}/{WEIGHT_FILE}"
+
+    @classmethod
+    def get_download_notice(cls, filename, url):
+        """Announce the non-commercial terms before an automatic download."""
+        return (
+            "DetAny3D weights are non-commercial: upstream documents the depth "
+            "branch as initialized from UniDepth v2 under CC BY-NC 4.0. They "
+            "are not covered by LibreYOLO's MIT license."
+        )
+
+    @classmethod
+    def _resolve_checkpoint(cls, model_path):
+        if model_path is not None:
+            candidate = Path(model_path).expanduser()
+            if candidate.is_file():
+                return candidate.resolve()
+            if str(model_path) != WEIGHT_FILE:
+                raise FileNotFoundError(
+                    f"DetAny3D checkpoint not found: {candidate.resolve()}"
+                )
+        return cls._download_checkpoint()
+
+    @classmethod
+    def _download_checkpoint(cls):
+        logger.warning(
+            "DetAny3D weights are non-commercial (UniDepth v2 depth lineage, "
+            "CC BY-NC 4.0) and are not covered by LibreYOLO's MIT license."
+        )
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as exc:
+            raise ImportError(
+                "DetAny3D automatic weights require huggingface_hub. Install "
+                "with: pip install huggingface_hub"
+            ) from exc
+        path = Path(
+            hf_hub_download(
+                repo_id=HF_REPO,
+                filename=WEIGHT_FILE,
+                revision=HF_REVISION,
+            )
+        )
+        cls._verify_mirrored_checkpoint(path)
+        return path.resolve()
+
+    @classmethod
+    def _verify_mirrored_checkpoint(cls, path):
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as checkpoint:
+            for chunk in iter(lambda: checkpoint.read(8 * 1024 * 1024), b""):
+                digest.update(chunk)
+        if digest.hexdigest() != WEIGHT_SHA256:
+            raise ValueError(
+                "Downloaded DetAny3D checkpoint failed its pinned SHA-256 check."
+            )
 
     def _ensure_backend(self):
         if self._backend is None or self._backend.closed:

--- a/libreyolo/models/fcos3d/NOTICE
+++ b/libreyolo/models/fcos3d/NOTICE
@@ -14,6 +14,12 @@ training dependencies, torchvision deform_conv2d, camera Results mapping.
 The torchvision operator is a separately installed BSD-3-Clause dependency.
 No third-party C++/CUDA operator source is bundled.
 
-This notice covers code, not the official nuScenes checkpoint. Its separate
-redistribution terms have not been established; no weights are bundled or
-hosted by this port.
+This notice covers code, not the official nuScenes checkpoint. No weights are
+bundled in this port. The official checkpoint is mirrored byte-for-byte at
+LibreYOLO/LibreFCOS3D revision af69c4abfb265f63695ecbaa68b4167f0c150605.
+OpenMMLab declares no per-object checkpoint license; LibreYOLO's maintainer
+approved that mirror by treating the project's Apache-2.0 statement as the
+redistribution basis, which is LibreYOLO's disclosed interpretation and not a
+clarification from the OpenMMLab authors. The weights are trained on nuScenes
+under non-commercial terms (https://www.nuscenes.org/terms-of-use) and are not
+covered by LibreYOLO's MIT license.

--- a/libreyolo/models/fcos3d/model.py
+++ b/libreyolo/models/fcos3d/model.py
@@ -1,5 +1,7 @@
 """Native FCOS3D inference with camera calibration and standard Results."""
 
+import hashlib
+import logging
 import time
 from pathlib import Path
 from typing import ClassVar
@@ -13,11 +15,25 @@ from ...utils.serialization import load_untrusted_torch_file
 from .nn import FCOS3DNetwork
 from .utils import NAMES, calibration, decode, payloads, preprocess
 
+logger = logging.getLogger(__name__)
+HF_REPO = "LibreYOLO/LibreFCOS3D"
+HF_REVISION = "af69c4abfb265f63695ecbaa68b4167f0c150605"
+WEIGHT_FILE = (
+    "fcos3d_r101_caffe_fpn_gn-head_dcn_2x8_1x_nus-mono3d_finetune_"
+    "20210717_095645-8d806dc2.pth"
+)
+WEIGHT_SHA256 = "8d806dc2ecae85bc8eaba1f16dccdf03459317ca6aed7984cfda33c2a2bc33a8"
+TERMS_URL = "https://www.nuscenes.org/terms-of-use"
+
 
 class LibreFCOS3D:
     """FCOS3D R101-DCN for the ten nuScenes classes, inference-only.
 
-    Supply a local official checkpoint and original-image pinhole intrinsics.
+    ``model_path`` accepts an unchanged official checkpoint. Omitting it
+    downloads LibreYOLO's byte-identical, revision-pinned mirror. Those
+    weights are trained on nuScenes under non-commercial terms and are not
+    covered by LibreYOLO's MIT license.
+    Supply original-image pinhole intrinsics to predict.
     Images retain their resolution; padding is only on the right and bottom.
     Single images return Results; sequences/directories return lists and
     stream=True returns a generator. NumPy input color follows ImageLoader.
@@ -35,12 +51,8 @@ class LibreFCOS3D:
     DEFAULT_CONF = 0.05
     DEFAULT_IOU = 0.8
 
-    def __init__(self, model_path, *, device="auto"):
-        self.model_path = Path(model_path).expanduser()
-        if not self.model_path.is_file():
-            raise FileNotFoundError(
-                f"FCOS3D requires a local official R101 nuScenes checkpoint: {self.model_path}"
-            )
+    def __init__(self, model_path=None, *, device="auto"):
+        self.model_path = self._resolve_checkpoint(model_path)
         if isinstance(device, int) or str(device).isdigit():
             device = f"cuda:{device}"
         if device == "auto":
@@ -54,9 +66,7 @@ class LibreFCOS3D:
         if not isinstance(checkpoint, dict) or not isinstance(
             checkpoint.get("state_dict"), dict
         ):
-            raise TypeError(
-                "Expected an official FCOS3D checkpoint with a state_dict."
-            )
+            raise TypeError("Expected an official FCOS3D checkpoint with a state_dict.")
         metadata = checkpoint.get("meta", {})
         if not isinstance(metadata, dict):
             raise TypeError("FCOS3D checkpoint meta must be a dictionary.")
@@ -74,8 +84,66 @@ class LibreFCOS3D:
 
     @classmethod
     def get_download_url(cls, filename):
-        """No hosted checkpoint until redistribution terms are established."""
-        return None
+        """Return the immutable byte-identical checkpoint mirror URL."""
+        if filename not in (None, WEIGHT_FILE):
+            return None
+        return f"https://huggingface.co/{HF_REPO}/resolve/{HF_REVISION}/{WEIGHT_FILE}"
+
+    @classmethod
+    def get_download_notice(cls, filename, url):
+        """Announce the non-commercial terms before an automatic download."""
+        return (
+            "FCOS3D weights are trained on nuScenes, whose terms are "
+            "non-commercial, and are not covered by LibreYOLO's MIT license. "
+            f"See {TERMS_URL}"
+        )
+
+    @classmethod
+    def _resolve_checkpoint(cls, model_path):
+        if model_path is not None:
+            candidate = Path(model_path).expanduser()
+            if candidate.is_file():
+                return candidate.resolve()
+            if str(model_path) != WEIGHT_FILE:
+                raise FileNotFoundError(
+                    f"FCOS3D requires a local official R101 nuScenes checkpoint: {candidate}"
+                )
+        return cls._download_checkpoint()
+
+    @classmethod
+    def _download_checkpoint(cls):
+        logger.warning(
+            "FCOS3D weights are trained on nuScenes under non-commercial terms "
+            "(%s) and are not covered by LibreYOLO's MIT license.",
+            TERMS_URL,
+        )
+        try:
+            from huggingface_hub import hf_hub_download
+        except ImportError as exc:
+            raise ImportError(
+                "FCOS3D automatic weights require huggingface_hub. Install "
+                "with: pip install huggingface_hub"
+            ) from exc
+        path = Path(
+            hf_hub_download(
+                repo_id=HF_REPO,
+                filename=WEIGHT_FILE,
+                revision=HF_REVISION,
+            )
+        )
+        cls._verify_mirrored_checkpoint(path)
+        return path.resolve()
+
+    @classmethod
+    def _verify_mirrored_checkpoint(cls, path):
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as checkpoint:
+            for chunk in iter(lambda: checkpoint.read(8 * 1024 * 1024), b""):
+                digest.update(chunk)
+        if digest.hexdigest() != WEIGHT_SHA256:
+            raise ValueError(
+                "Downloaded FCOS3D checkpoint failed its pinned SHA-256 check."
+            )
 
     @staticmethod
     def _threshold(value, name):

--- a/skills/libreyolo-upload-hf-model/SKILL.md
+++ b/skills/libreyolo-upload-hf-model/SKILL.md
@@ -111,8 +111,26 @@ hosting weights**: non-commercial but redistributable weights (CC-BY-NC, the
 NVIDIA Source Code License) are hosted — ship the upstream license verbatim,
 tag the card correctly, and lead with a non-commercial banner (SegFormer
 precedent); downstream users are responsible for complying with the weight
-license. Only weights whose terms forbid redistribution (L2CS) or whose
-license is unknown stay unhosted. The
+license. Only weights whose terms forbid redistribution (L2CS) stay unhosted.
+An *unknown* upstream weight license is not an automatic no: it is a
+**maintainer call**, and where the releasing project declares a permissive
+license at project level the maintainer has approved rehosting on that implied
+basis (EfficientDet, torchvision Faster R-CNN / FCOS / SSD, DOME-DETR, and the
+3D mirrors below). Every such card, LICENSE and NOTICE must say the grant is
+implied by the releasing project and is LibreYOLO's disclosed interpretation,
+never publisher-confirmed.
+
+The `detect3d` sibling families mirror the **raw upstream checkpoint
+byte-for-byte** under its original filename, rather than converting to the v1.0
+schema, because their loaders read the unchanged upstream format. They keep the
+5-file contract otherwise and pin `HF_REVISION` + `WEIGHT_SHA256` in the
+family's `model.py`: `LibreWildDet3D` (SAM License),
+`LibreFCOS3D` (`license: other` + `license_name: nuscenes-non-commercial`;
+implied Apache basis, nuScenes non-commercial training data) and
+`LibreDetAny3D` (`license: cc-by-nc-4.0`; implied Apache basis for DetAny3D's
+own parameters, CC BY-NC 4.0 applied as the strictest known term for its
+UniDepth v2 depth lineage). Their filenames are upstream's, so they are
+deliberately absent from the canonical whitelist below. The
 open-vocabulary and SAM/VLM tiers ship HF *snapshot directories*
 (`LibreGroundingDINOt`, `LibreOWLv2b16`, ...), not single `.pt` files; their
 repos mirror upstream snapshot layout plus card, so the 5-file contract below

--- a/tests/unit/test_detany3d.py
+++ b/tests/unit/test_detany3d.py
@@ -214,3 +214,83 @@ assert sys.argv[3] not in sys.path
         check=False,
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_mirror_download_url_is_revision_pinned():
+    from libreyolo.models.detany3d import model as adapter
+
+    assert LibreDetAny3D.get_download_url("unknown.pth") is None
+    url = LibreDetAny3D.get_download_url(adapter.WEIGHT_FILE)
+    assert adapter.HF_REVISION in url
+    assert url.endswith(adapter.WEIGHT_FILE)
+    notice = LibreDetAny3D.get_download_notice(adapter.WEIGHT_FILE, url)
+    assert "non-commercial" in notice and "MIT" in notice
+
+
+def test_default_checkpoint_uses_mirror(tmp_path, monkeypatch):
+    from libreyolo.models.detany3d import model as adapter
+
+    checkpoint = tmp_path / "mirrored.pth"
+    checkpoint.touch()
+    calls = []
+
+    def download(cls):
+        calls.append(True)
+        return checkpoint.resolve()
+
+    monkeypatch.setattr(LibreDetAny3D, "_download_checkpoint", classmethod(download))
+    assert LibreDetAny3D._resolve_checkpoint(None) == checkpoint.resolve()
+    assert (
+        LibreDetAny3D._resolve_checkpoint(adapter.WEIGHT_FILE) == checkpoint.resolve()
+    )
+    assert calls == [True, True]
+    with pytest.raises(FileNotFoundError, match="not found"):
+        LibreDetAny3D._resolve_checkpoint(tmp_path / "missing.pth")
+
+
+def test_mirror_hash_check(tmp_path, monkeypatch):
+    from libreyolo.models.detany3d import model as adapter
+
+    checkpoint = tmp_path / "mirrored.pth"
+    checkpoint.write_bytes(b"known checkpoint bytes")
+    monkeypatch.setattr(
+        adapter,
+        "WEIGHT_SHA256",
+        "a05545a7ab49d03ef298599bff5bcb657521bd52ef4d71e4b2c2330020492dfc",
+    )
+    LibreDetAny3D._verify_mirrored_checkpoint(checkpoint)
+    checkpoint.write_bytes(b"changed")
+    with pytest.raises(ValueError, match="SHA-256"):
+        LibreDetAny3D._verify_mirrored_checkpoint(checkpoint)
+
+
+def test_mirror_download_is_revision_pinned(tmp_path, monkeypatch):
+    import sys
+    from types import SimpleNamespace
+
+    from libreyolo.models.detany3d import model as adapter
+
+    checkpoint = tmp_path / "mirrored.pth"
+    checkpoint.write_bytes(b"known checkpoint bytes")
+    calls = []
+
+    def download(**kwargs):
+        calls.append(kwargs)
+        return str(checkpoint)
+
+    monkeypatch.setitem(
+        sys.modules, "huggingface_hub", SimpleNamespace(hf_hub_download=download)
+    )
+    monkeypatch.setattr(
+        adapter,
+        "WEIGHT_SHA256",
+        "a05545a7ab49d03ef298599bff5bcb657521bd52ef4d71e4b2c2330020492dfc",
+    )
+    assert LibreDetAny3D._download_checkpoint() == checkpoint.resolve()
+    assert calls == [
+        {
+            "repo_id": "LibreYOLO/LibreDetAny3D",
+            "filename": adapter.WEIGHT_FILE,
+            "revision": adapter.HF_REVISION,
+        }
+    ]

--- a/tests/unit/test_fcos3d.py
+++ b/tests/unit/test_fcos3d.py
@@ -145,3 +145,81 @@ def test_single_list_stream_and_validation_without_weights(tmp_path):
     for method in ("train", "val", "export", "track"):
         with pytest.raises(NotImplementedError):
             getattr(model, method)()
+
+
+def test_mirror_download_url_is_revision_pinned():
+    from libreyolo.models.fcos3d import model as adapter
+
+    assert LibreFCOS3D.get_download_url("unknown.pth") is None
+    url = LibreFCOS3D.get_download_url(adapter.WEIGHT_FILE)
+    assert adapter.HF_REVISION in url
+    assert url.endswith(adapter.WEIGHT_FILE)
+    notice = LibreFCOS3D.get_download_notice(adapter.WEIGHT_FILE, url)
+    assert "non-commercial" in notice and "MIT" in notice
+
+
+def test_default_checkpoint_uses_mirror(tmp_path, monkeypatch):
+    from libreyolo.models.fcos3d import model as adapter
+
+    checkpoint = tmp_path / "mirrored.pth"
+    checkpoint.touch()
+    calls = []
+
+    def download(cls):
+        calls.append(True)
+        return checkpoint.resolve()
+
+    monkeypatch.setattr(LibreFCOS3D, "_download_checkpoint", classmethod(download))
+    assert LibreFCOS3D._resolve_checkpoint(None) == checkpoint.resolve()
+    assert LibreFCOS3D._resolve_checkpoint(adapter.WEIGHT_FILE) == checkpoint.resolve()
+    assert calls == [True, True]
+    with pytest.raises(FileNotFoundError, match="local official"):
+        LibreFCOS3D._resolve_checkpoint(tmp_path / "missing.pth")
+
+
+def test_mirror_hash_check(tmp_path, monkeypatch):
+    from libreyolo.models.fcos3d import model as adapter
+
+    checkpoint = tmp_path / "mirrored.pth"
+    checkpoint.write_bytes(b"known checkpoint bytes")
+    monkeypatch.setattr(
+        adapter,
+        "WEIGHT_SHA256",
+        "a05545a7ab49d03ef298599bff5bcb657521bd52ef4d71e4b2c2330020492dfc",
+    )
+    LibreFCOS3D._verify_mirrored_checkpoint(checkpoint)
+    checkpoint.write_bytes(b"changed")
+    with pytest.raises(ValueError, match="SHA-256"):
+        LibreFCOS3D._verify_mirrored_checkpoint(checkpoint)
+
+
+def test_mirror_download_is_revision_pinned(tmp_path, monkeypatch):
+    import sys
+    from types import SimpleNamespace
+
+    from libreyolo.models.fcos3d import model as adapter
+
+    checkpoint = tmp_path / "mirrored.pth"
+    checkpoint.write_bytes(b"known checkpoint bytes")
+    calls = []
+
+    def download(**kwargs):
+        calls.append(kwargs)
+        return str(checkpoint)
+
+    monkeypatch.setitem(
+        sys.modules, "huggingface_hub", SimpleNamespace(hf_hub_download=download)
+    )
+    monkeypatch.setattr(
+        adapter,
+        "WEIGHT_SHA256",
+        "a05545a7ab49d03ef298599bff5bcb657521bd52ef4d71e4b2c2330020492dfc",
+    )
+    assert LibreFCOS3D._download_checkpoint() == checkpoint.resolve()
+    assert calls == [
+        {
+            "repo_id": "LibreYOLO/LibreFCOS3D",
+            "filename": adapter.WEIGHT_FILE,
+            "revision": adapter.HF_REVISION,
+        }
+    ]

--- a/weights/LICENSE_NOTICE.txt
+++ b/weights/LICENSE_NOTICE.txt
@@ -811,20 +811,35 @@ WildDet3D (LibreYOLO/LibreWildDet3D; byte-identical upstream mirror)
       Mirror revision: a4f6115d285a6983439f0e54f20c44b0ce87c261
       SHA-256: 834c976df385610bba105c7d4ea3e2d7b57dabd69dee2b61397ae398de67a677
 
-DetAny3D
--------
-Official full checkpoint accepted locally without changing learned parameters.
-Source: https://github.com/OpenDriveLab/DetAny3D
-Checkpoint redistribution terms remain unresolved; no weights are hosted.
-The separate runtime includes UniDepth code under CC BY-NC 4.0.
+DetAny3D (LibreYOLO/LibreDetAny3D; byte-identical upstream mirror)
+    Source: https://github.com/OpenDriveLab/DetAny3D revision
+            10e484be0837d80aa33cff6ed95a9be834a3f794, checkpoint published
+            through the project's Google Drive folder.
+    License: CC-BY-NC-4.0 applied by LibreYOLO as the strictest known term.
+    OpenDriveLab declares no per-object checkpoint license; the maintainer
+    approved this mirror by treating the project's Apache-2.0 statement as the
+    redistribution basis for the parameters DetAny3D itself trained. That is
+    LibreYOLO's disclosed interpretation, not upstream clarification. Upstream
+    documents the depth branch as initialized from UniDepth v2 (CC BY-NC 4.0),
+    which the repository LICENSE reproduces in full. These weights are not MIT.
+    The separate runtime also includes UniDepth code under CC BY-NC 4.0.
+    Filename: detany3d.pth
+    Mirror revision: eeb89d1b1d37ec5a361b1ec79b26ea0620d9f4c3
+    SHA-256: cd5f737ddbf3ceb64f969141672d04c0a3d785ad3b8a72668619a530840cd217
 
-FCOS3D
-------
-Code source: https://github.com/open-mmlab/mmdetection3d (Apache-2.0).
-The official R101 nuScenes checkpoint is accepted locally, unchanged.
-Separate checkpoint redistribution terms have not been established.
-No LibreYOLO-hosted weights or automatic weight download are provided.
-nuScenes dataset terms: https://www.nuscenes.org/terms-of-use
+FCOS3D (LibreYOLO/LibreFCOS3D; byte-identical upstream mirror)
+    Code source: https://github.com/open-mmlab/mmdetection3d (Apache-2.0).
+    Checkpoint source: the OpenMMLab model zoo, finetuned R101 nuScenes
+    variant published July 2021 (32.1 mAP, 39.5 NDS).
+    License: no per-object checkpoint license is declared upstream. The
+    maintainer approved this mirror by treating mmdetection3d's Apache-2.0
+    project statement as the redistribution basis. That is LibreYOLO's
+    disclosed interpretation, not upstream clarification. The weights are
+    trained on nuScenes under non-commercial terms and are not MIT.
+    nuScenes dataset terms: https://www.nuscenes.org/terms-of-use
+    Filename: fcos3d_r101_caffe_fpn_gn-head_dcn_2x8_1x_nus-mono3d_finetune_20210717_095645-8d806dc2.pth
+    Mirror revision: af69c4abfb265f63695ecbaa68b4167f0c150605
+    SHA-256: 8d806dc2ecae85bc8eaba1f16dccdf03459317ca6aed7984cfda33c2a2bc33a8
 
 Marigold V2
     Adapter source: https://huggingface.co/huawei-bayerlab/marigold-v2-0


### PR DESCRIPTION
- Mirror the official FCOS3D and DetAny3D checkpoints at `LibreYOLO/LibreFCOS3D` and `LibreYOLO/LibreDetAny3D`, and wire both families to auto-download them.
- Both previously required a local checkpoint and hosted nothing, because neither upstream declares a license for the weights *themselves*.
- Opened by an agent.

## Why these were unhosted, and what changed

The blocker was never non-commercial terms. LibreYOLO already hosts non-commercial weights (SegFormer, PPLiteSeg, DepthAnythingV2 b/l/g, the `-visdrone` variants) because redistributable is the only bar. The blocker was an *undeclared* weight license: OpenMMLab publishes the FCOS3D model-zoo object with no per-object license, and OpenDriveLab released `detany3d.pth` from Google Drive with no license metadata.

The maintainer approved rehosting on the **implied-license basis** already used for EfficientDet, torchvision (Faster R-CNN / FCOS / SSD) and DOME-DETR: treat the releasing project's Apache-2.0 statement as the redistribution basis, and disclose on every surface that this is LibreYOLO's interpretation, **not** upstream clarification.

## Mirrors

Both follow the WildDet3D raw-mirror pattern — byte-for-byte, original upstream filenames, **no** v1.0 schema conversion, because both loaders read the unchanged upstream format. Verified: remote LFS oid equals the local SHA-256 for both.

| Repo | File | Size | Card license |
|---|---|---|---|
| `LibreYOLO/LibreFCOS3D` | `fcos3d_r101…finetune_20210717_095645-8d806dc2.pth` | 220 MB | `other` + `nuscenes-non-commercial` |
| `LibreYOLO/LibreDetAny3D` | `detany3d.pth` | 4.33 GB | `cc-by-nc-4.0` |

FCOS3D is the **finetuned** variant (32.1 mAP / 39.5 NDS), confirmed by hash. DetAny3D is tagged `cc-by-nc-4.0` as the strictest known term: upstream documents its depth branch as initialized from UniDepth v2 (CC BY-NC 4.0), which permits redistribution but restricts use. That lineage is the authors' statement, not verified by key matching — every parameter sits under a `sam.` prefix with no `unidepth.*` subtree, and the cards say so.

## Changes

- `model_path` is now optional on both. Omitting it downloads the revision-pinned mirror and verifies its SHA-256, behind a non-commercial download notice.
- Both CLI `model` options default to the mirrored filenames.
- All four notice surfaces updated (family `NOTICE`s, `THIRD_PARTY_NOTICES.txt`, `weights/LICENSE_NOTICE.txt`), plus ADRs 0023/0024, `docs/nomenclature.md`, and the raw-mirror pattern recorded in the upload skill.
- 8 new unit tests: revision-pinned URL, download notice, mirror fallback, SHA-256 mismatch, and pinned `hf_hub_download` kwargs, per family.

## Verified

- `tests/unit/test_fcos3d.py`, `test_detany3d.py` and both CLI test files: 41 passed.
- Wider slice (`-k "fcos3d or detany3d or inventory or registry or nomenclature or notice or license"`): 137 passed, 7 skipped, 1 failed.
- The one failure is `test_export_support.py::test_committed_inventory_matches_runtime_inventory`, which **fails identically on unmodified `dev`** (verified in a pristine baseline worktree at `c8a005ab`). Its diff is the `lama` entry; no 3D family appears in it. The committed `reports/export_inventory.json` entries for `fcos3d`/`detany3d` are unchanged by this PR.
- `ruff check` and `ruff format --check`, scoped to the changed files: clean.
- Not verified: no live auto-download was exercised end to end, and no accuracy benchmark was run.

## Code provenance

No third-party code is ported, adapted, or derived in this PR. The download plumbing is original LibreYOLO code following the in-repo MIT `wilddet3d` and `mood3d` implementations; the rest is notice, ADR, doc, skill and test text.

The checkpoints this PR points at are redistributed unmodified from their publishers, with their license texts reproduced verbatim in the Hugging Face repositories: mmdetection3d (Apache-2.0, `fe25f7a5`) and mmdetection (Apache-2.0, `cfd5d3a9`) for FCOS3D; OpenDriveLab/DetAny3D (Apache-2.0, `10e484be`) plus UniDepth's CC BY-NC 4.0 text (`8d8cfe4c`) for DetAny3D. No checkpoint bytes, dataset images, or annotations are added to this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv7gzQ6AxNEt3Tf6RwzhU5

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63290901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until checkpoint redistribution complies with the repository's explicit-license requirement and the family-derived CLI-default rule is satisfied.

<h2><a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fmodels%2Ffcos3d%2Fmodel.py%3A18-27%0AThis%20adds%20automatic%20mirrors%20for%20FCOS3D%20and%20DetAny3D%20even%20though%20the%20notices%20acknowledge%20that%20neither%20checkpoint%20has%20a%20declared%20per-object%20license.%20The%20repository%20requires%20third-party%20material%20to%20have%20an%20explicit%20compatible%20license%20and%20states%20that%20an%20unknown%20or%20missing%20license%20is%20incompatible.%20LibreYOLO's%20interpretation%20of%20each%20project's%20code%20license%20does%20not%20satisfy%20that%20directive%2C%20so%20these%20checkpoints%20must%20not%20be%20redistributed%20unless%20an%20explicit%20redistribution%20grant%20is%20established.%20The%20same%20issue%20applies%20to%20%60libreyolo%2Fmodels%2Fdetany3d%2Fmodel.py%3A22-27%60.%0A%0A%23%23%23%20Issue%202%0Alibreyolo%2Fmodels%2Fdetany3d%2Fmodel.py%3A66%0AA%20normal%20%60LibreDetAny3D%28%29%60%20call%20or%20CLI%20invocation%20without%20%60DETANY3D_PATH%60%20resolves%2C%20downloads%2C%20and%20hashes%20the%20roughly%204.33%20GB%20checkpoint%20before%20checking%20whether%20the%20required%20runtime%20exists.%20The%20constructor%20then%20raises%20%60ImportError%60%2C%20wasting%20substantial%20bandwidth%2C%20disk%20space%2C%20and%20startup%20time.%20Validate%20%60runtime_path%60%20before%20resolving%20the%20checkpoint.%0A%0A%23%23%23%20Issue%203%0Alibreyolo%2Fmodels%2Fdetany3d%2Fmodel.py%3A157-159%0AEvery%20default%20model%20construction%20hashes%20the%20complete%20checkpoint%20returned%20from%20the%20cache%2C%20rather%20than%20limiting%20verification%20to%20a%20fresh%20download.%20For%20DetAny3D%20this%20adds%20a%20full%20read%20of%20approximately%204.33%20GB%20on%20every%20process%20start%2C%20causing%20avoidable%20startup%20latency%20and%20disk%20I%2FO.%20FCOS3D%20repeats%20the%20same%20behavior%20in%20%60libreyolo%2Fmodels%2Ffcos3d%2Fmodel.py%3A133-135%60%3B%20retain%20verified%20state%20or%20otherwise%20avoid%20rechecking%20an%20already%20validated%20immutable%20artifact.%0A%0A%23%23%23%20Issue%204%0Alibreyolo%2Fcli%2Fcommands%2Ffcos3d.py%3A11-15%0AThis%20default%20duplicates%20the%20checkpoint%20filename%20instead%20of%20deriving%20it%20from%20the%20family%20definition%2C%20contrary%20to%20the%20repository%20requirement%20that%20CLI%20defaults%20be%20family-derived.%20If%20%60WEIGHT_FILE%60%20changes%2C%20the%20stale%20CLI%20value%20will%20be%20treated%20as%20a%20missing%20local%20path%20instead%20of%20triggering%20the%20mirror.%20The%20same%20duplication%20exists%20in%20%60libreyolo%2Fcli%2Fcommands%2Fdetany3d.py%3A11-14%60%3B%20centralize%20both%20defaults%20and%20add%20a%20consistency%20test.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=851&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Checkpoint licenses remain undeclared** <a href="https://github.com/LibreYOLO/libreyolo/pull/851#discussion_r3993906224">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Download precedes runtime validation** <a href="https://github.com/LibreYOLO/libreyolo/pull/851#discussion_r3993906226">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Cached weights are rehashed** <a href="https://github.com/LibreYOLO/libreyolo/pull/851#discussion_r3993906229">▶</a>
4. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**CLI defaults duplicate filenames** <a href="https://github.com/LibreYOLO/libreyolo/pull/851#discussion_r3993906232">▶</a>

<details><summary><h3>Summary</h3></summary>

- Adds Hugging Face mirror resolution and integrity checks to both family adapters.
- Makes checkpoint paths optional and supplies default checkpoint filenames in both CLI commands.
- Updates notices, ADRs, nomenclature, upload guidance, and unit coverage.
- The mirrors conflict with the repository's explicit-license requirement; the DetAny3D initialization order and repeated full-file verification also create avoidable download and startup costs.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Python API or CLI] --> B{Local checkpoint exists?}
    B -->|Yes| C[Use local checkpoint]
    B -->|No or omitted| D[Download revision-pinned mirror]
    D --> E[Read complete file and verify SHA-256]
    E --> F{DetAny3D runtime configured?}
    F -->|No| G[Raise ImportError after download]
    F -->|Yes| H[Start runtime and load checkpoint]
    C --> F
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["Host FCOS3D and DetAny3D checkpoint mirr..."](https://github.com/libreyolo/libreyolo/commit/3e03138d7f53209e83f9af43cfa57eca12385da8)</sub>

<!-- /greptile_comment -->