### PR TITLE
Add best_metric to select the early-stopping and best.pt metric

### DIFF
--- a/docs/classification_training.md
+++ b/docs/classification_training.md
@@ -92,3 +92,36 @@ The four CNN trainers use the weighted loss in both eager and CUDA-graph
 assembly paths. DINOv2's RF-DETR classification trainer retains its existing
 eager fallback when CUDA-graph training is requested. Hardware and convergence
 validation evidence is recorded with the change, separately from this API.
+
+## Best checkpoint and early stopping
+
+The trainer compares one validation metric per epoch. The epoch that improves
+it is saved as `best.pt`, and `patience` counts epochs since that improvement.
+`best_metric` selects that metric with a short alias:
+
+```python
+model.train(data="/path/to/imagefolder", best_metric="f1", patience=20)
+```
+
+```bash
+libreyolo train model=LibreResNet18-cls.pt data=/path/to/imagefolder best_metric=f1 patience=20
+libreyolo train --model LibreResNet18-cls.pt --data /path/to/imagefolder --best-metric f1 --patience 20
+```
+
+Classification aliases: `top1` (default), `top5`, `f1`, `precision`, `recall`.
+`f1`, `precision` and `recall` are macro averages over the classes present in
+the validation split: per class, precision is `tp / (tp + fp)` (zero when the
+class is never predicted), recall is `tp / (tp + fn)`, and F1 is their
+harmonic mean. All three are also reported as `metrics/precision`,
+`metrics/recall` and `metrics/f1` next to the accuracies.
+
+Detection aliases: `map50-95` (default), `map50`, `map75`, `f1`. Detection
+`f1` is the maximum F1 over the confidence sweep at IoU 0.50, the same value
+reported as `metrics/best_conf_f1`. It is NaN for an epoch in which no
+threshold reaches F1 above zero; NaN epochs never count as an improvement,
+and a run that stays NaN throughout writes no best.pt.
+
+An unknown alias, or any alias on a task other than detect or classify, raises
+at trainer construction with the list of valid values. The resolved key is
+written to the checkpoint as `best_metric_key`; resuming with a different
+`best_metric` resets best tracking rather than comparing across metrics.

--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -423,6 +423,11 @@ def train_cmd(
         False, help="Save final validation plots during training"
     ),
     patience: int = typer.Option(50, help="Early stopping patience (0=disabled)"),
+    best_metric: Optional[str] = typer.Option(
+        None,
+        help="Metric for best.pt and early stopping. detect: map50-95|map50|map75|f1. "
+        "classify: top1|top5|f1|precision|recall. Default: the task's built-in metric",
+    ),
     # Output
     project: str = typer.Option("runs/train", help="Output directory root"),
     name: str = typer.Option("exp", help="Experiment name"),
@@ -675,6 +680,7 @@ def train_cmd(
         "faster_coco_eval": faster_coco_eval,
         "save_plots": save_plots,
         "patience": patience,
+        "best_metric": best_metric,
         "project": project,
         "name": name,
         "exist_ok": exist_ok,
@@ -888,7 +894,11 @@ def train_cmd(
         "epochs_completed": epochs_completed,
         "best_epoch": best_epoch,
         "best_metrics": (
-            {"mAP50": best_mAP50, "mAP50_95": best_mAP50_95}
+            {
+                "mAP50": best_mAP50,
+                "mAP50_95": best_mAP50_95,
+                "best_metric_key": results.get("best_metric_key"),
+            }
             if best_mAP50 is not None
             else None
         ),

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -456,6 +456,7 @@ def _build_rfdetr_train_kwargs(
         "average_best": "average_best",
         "export_check": "export_check",
         "precise_bn": "precise_bn",
+        "best_metric": "best_metric",
     }
 
     for cli_name, target_name in direct_mappings.items():

--- a/libreyolo/models/convnext/model.py
+++ b/libreyolo/models/convnext/model.py
@@ -210,6 +210,7 @@ class LibreConvNeXt(BaseModel):
         resume: bool = _TRAIN_DEFAULTS.resume,
         amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = _TRAIN_DEFAULTS.patience,
+        best_metric: Optional[str] = _TRAIN_DEFAULTS.best_metric,
         callbacks: TrainCallbacks = None,
         **kwargs: Any,
     ) -> dict:
@@ -225,6 +226,10 @@ class LibreConvNeXt(BaseModel):
         ``class_weights=True`` retains legacy sample-normalized weighting and
         cannot be combined with ``cls_pw>0``. Neither option changes sampling.
         See docs/classification_training.md for compatibility and resume rules.
+
+        ``best_metric`` picks the validation metric for best.pt and early
+        stopping: ``top1`` (default), ``top5``, ``f1``, ``precision`` or
+        ``recall``. F1, precision and recall are macro-averaged over classes.
         """
         from .trainer import ConvNeXtTrainer
 
@@ -251,6 +256,7 @@ class LibreConvNeXt(BaseModel):
             resume=resume,
             amp=amp,
             patience=patience,
+            best_metric=best_metric,
             callbacks=callbacks,
             **kwargs,
         )

--- a/libreyolo/models/efficientnetv2/model.py
+++ b/libreyolo/models/efficientnetv2/model.py
@@ -202,6 +202,7 @@ class LibreEfficientNetV2(BaseModel):
         resume: bool = _TRAIN_DEFAULTS.resume,
         amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = _TRAIN_DEFAULTS.patience,
+        best_metric: Optional[str] = _TRAIN_DEFAULTS.best_metric,
         callbacks: TrainCallbacks = None,
         **kwargs: Any,
     ) -> dict:
@@ -217,6 +218,10 @@ class LibreEfficientNetV2(BaseModel):
         ``class_weights=True`` retains legacy sample-normalized weighting and
         cannot be combined with ``cls_pw>0``. Neither option changes sampling.
         See docs/classification_training.md for compatibility and resume rules.
+
+        ``best_metric`` picks the validation metric for best.pt and early
+        stopping: ``top1`` (default), ``top5``, ``f1``, ``precision`` or
+        ``recall``. F1, precision and recall are macro-averaged over classes.
         """
         from .trainer import EfficientNetV2Trainer
 
@@ -243,6 +248,7 @@ class LibreEfficientNetV2(BaseModel):
             resume=resume,
             amp=amp,
             patience=patience,
+            best_metric=best_metric,
             callbacks=callbacks,
             **kwargs,
         )

--- a/libreyolo/models/fomo/trainer.py
+++ b/libreyolo/models/fomo/trainer.py
@@ -28,6 +28,17 @@ class FOMOTrainer(BaseTrainer):
 
     best_metric_key: str = "metrics/grid_F1"
 
+    def __init__(self, *args, **kwargs):
+        # FOMO overrides validation and only emits its grid metrics, so the
+        # generic detect aliases would silently resolve to keys it never
+        # produces. Reject up front rather than accept and ignore.
+        if kwargs.get("best_metric") not in (None, ""):
+            raise NotImplementedError(
+                "best_metric is not supported for FOMO; it always tracks "
+                "metrics/grid_F1."
+            )
+        super().__init__(*args, **kwargs)
+
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:
         return FOMOConfig

--- a/libreyolo/models/mobilenetv4/model.py
+++ b/libreyolo/models/mobilenetv4/model.py
@@ -202,6 +202,7 @@ class LibreMobileNetV4(BaseModel):
         resume: bool = _TRAIN_DEFAULTS.resume,
         amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = _TRAIN_DEFAULTS.patience,
+        best_metric: Optional[str] = _TRAIN_DEFAULTS.best_metric,
         callbacks: TrainCallbacks = None,
         **kwargs: Any,
     ) -> dict:
@@ -217,6 +218,10 @@ class LibreMobileNetV4(BaseModel):
         ``class_weights=True`` retains legacy sample-normalized weighting and
         cannot be combined with ``cls_pw>0``. Neither option changes sampling.
         See docs/classification_training.md for compatibility and resume rules.
+
+        ``best_metric`` picks the validation metric for best.pt and early
+        stopping: ``top1`` (default), ``top5``, ``f1``, ``precision`` or
+        ``recall``. F1, precision and recall are macro-averaged over classes.
         """
         from .trainer import MobileNetV4Trainer
 
@@ -243,6 +248,7 @@ class LibreMobileNetV4(BaseModel):
             resume=resume,
             amp=amp,
             patience=patience,
+            best_metric=best_metric,
             callbacks=callbacks,
             **kwargs,
         )

--- a/libreyolo/models/resnet/model.py
+++ b/libreyolo/models/resnet/model.py
@@ -213,6 +213,7 @@ class LibreResNet(BaseModel):
         resume: bool = _TRAIN_DEFAULTS.resume,
         amp: bool = _TRAIN_DEFAULTS.amp,
         patience: int = _TRAIN_DEFAULTS.patience,
+        best_metric: Optional[str] = _TRAIN_DEFAULTS.best_metric,
         callbacks: TrainCallbacks = None,
         **kwargs: Any,
     ) -> dict:
@@ -228,6 +229,10 @@ class LibreResNet(BaseModel):
         ``class_weights=True`` retains legacy sample-normalized weighting and
         cannot be combined with ``cls_pw>0``. Neither option changes sampling.
         See docs/classification_training.md for compatibility and resume rules.
+
+        ``best_metric`` picks the validation metric for best.pt and early
+        stopping: ``top1`` (default), ``top5``, ``f1``, ``precision`` or
+        ``recall``. F1, precision and recall are macro-averaged over classes.
         """
         from .trainer import ResNetTrainer
 
@@ -254,6 +259,7 @@ class LibreResNet(BaseModel):
             resume=resume,
             amp=amp,
             patience=patience,
+            best_metric=best_metric,
             callbacks=callbacks,
             **kwargs,
         )

--- a/libreyolo/models/rfdetr/model.py
+++ b/libreyolo/models/rfdetr/model.py
@@ -1205,6 +1205,7 @@ class LibreRFDETR(BaseModel):
         resume: str | Path | bool | None = None,
         callbacks: TrainCallbacks = None,
         loggers=None,
+        best_metric: Optional[str] = None,
         **kwargs,
     ) -> Dict:
         """Fine-tune RF-DETR through LibreYOLO's native trainer.
@@ -1222,6 +1223,8 @@ class LibreRFDETR(BaseModel):
             callbacks: Optional training callback or iterable of callbacks.
             loggers: Optional built-in experiment loggers: a registered name,
                 a configured logger instance, or an iterable mixing both.
+            best_metric: Metric that picks best.pt and feeds early stopping:
+                ``map50-95`` (default), ``map50``, ``map75`` or ``f1``.
         """
         train_kwargs = dict(kwargs)
         project = train_kwargs.pop("project", None)
@@ -1331,6 +1334,9 @@ class LibreRFDETR(BaseModel):
                 train_kwargs["imgsz"],
                 name="RF-DETR train imgsz",
             )
+
+        if best_metric is not None:
+            train_kwargs["best_metric"] = best_metric
 
         aliases = {
             "num_workers": "workers",

--- a/libreyolo/models/vjepa2/trainer.py
+++ b/libreyolo/models/vjepa2/trainer.py
@@ -50,6 +50,16 @@ class VJEPA2Trainer(ClassifyValidationLossMixin, BaseTrainer):
 
     best_metric_key = "metrics/accuracy_top1"
 
+    def __init__(self, *args, **kwargs):
+        # V-JEPA2 has no working per-epoch validation path yet, so a selected
+        # metric could never be honored. Reject rather than accept and ignore.
+        if str(kwargs.get("best_metric") or "").strip():
+            raise NotImplementedError(
+                "best_metric is not supported for V-JEPA2; its training run "
+                "does not validate, so no metric can drive best.pt or patience."
+            )
+        super().__init__(*args, **kwargs)
+
     @classmethod
     def _config_class(cls) -> Type[TrainConfig]:
         return VJEPA2Config

--- a/libreyolo/models/yolo9/model.py
+++ b/libreyolo/models/yolo9/model.py
@@ -622,6 +622,7 @@ class LibreYOLO9(BaseModel):
         amp: bool = _TRAIN_DEFAULTS.amp,
         amp_dtype: str = _TRAIN_DEFAULTS.amp_dtype,
         patience: int = _TRAIN_DEFAULTS.patience,
+        best_metric: Optional[str] = _TRAIN_DEFAULTS.best_metric,
         allow_download_scripts: bool = False,
         pretrained: bool | str | Path | None = None,
         callbacks: TrainCallbacks = None,
@@ -647,6 +648,8 @@ class LibreYOLO9(BaseModel):
             amp: Enable automatic mixed precision training.
             amp_dtype: CUDA AMP dtype, ``float16`` or ``bfloat16``.
             patience: Early stopping patience.
+            best_metric: Metric that picks best.pt and feeds early stopping:
+                ``map50-95`` (default), ``map50``, ``map75`` or ``f1``.
             pretrained: Optional training initialization weights. Use True to
                 load the matching LibreYOLO9 detect checkpoint for transfer
                 learning, or pass a checkpoint path/name.
@@ -752,6 +755,7 @@ class LibreYOLO9(BaseModel):
             amp=amp,
             amp_dtype=amp_dtype,
             patience=patience,
+            best_metric=best_metric,
             allow_download_scripts=allow_download_scripts,
             callbacks=callbacks,
             loggers=loggers,

--- a/libreyolo/training/best_metric.py
+++ b/libreyolo/training/best_metric.py
@@ -1,0 +1,65 @@
+"""User-selectable metric for best.pt selection and early stopping.
+
+The trainer compares one validation metric per epoch. That comparison
+decides both which epoch is saved as ``best.pt`` and when ``patience`` runs
+out. ``best_metric`` lets the user choose that metric by a short alias; the
+alias is resolved against the model task into the full metric key emitted
+by the task's validator.
+"""
+
+from __future__ import annotations
+
+# task -> alias -> metric key emitted by that task's validator.
+# Every value is higher-is-better; the trainer's strict ``>`` compare relies
+# on that. Detection ``f1`` is the maximum F1 over the confidence sweep at
+# IoU 0.50 (``metrics/best_conf_f1``), already computed every epoch.
+BEST_METRIC_ALIASES: dict[str, dict[str, str]] = {
+    "detect": {
+        "map50-95": "metrics/mAP50-95",
+        "map50": "metrics/mAP50",
+        "map75": "metrics/mAP75",
+        "f1": "metrics/best_conf_f1",
+    },
+    "classify": {
+        "top1": "metrics/accuracy_top1",
+        "top5": "metrics/accuracy_top5",
+        "f1": "metrics/f1",
+        "precision": "metrics/precision",
+        "recall": "metrics/recall",
+    },
+}
+
+SUPPORTED_BEST_METRIC_TASKS: tuple[str, ...] = tuple(sorted(BEST_METRIC_ALIASES))
+
+
+def normalize_best_metric(value: object) -> str | None:
+    """Return the canonical alias spelling, or ``None`` when unset/empty."""
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    return text or None
+
+
+def resolve_best_metric(alias: str, task: str) -> str:
+    """Resolve a ``best_metric`` alias for ``task`` into a full metric key.
+
+    Raises:
+        ValueError: if ``task`` has no selectable metrics, or ``alias`` is not
+            one of the task's aliases. The message lists the valid values.
+    """
+    task_name = str(task).strip().lower()
+    table = BEST_METRIC_ALIASES.get(task_name)
+    if table is None:
+        supported = ", ".join(SUPPORTED_BEST_METRIC_TASKS)
+        raise ValueError(
+            f"best_metric is not supported for task '{task}'. "
+            f"Supported tasks: {supported}."
+        )
+    key = normalize_best_metric(alias)
+    if key is None or key not in table:
+        valid = ", ".join(sorted(table))
+        raise ValueError(
+            f"Unknown best_metric '{alias}' for task '{task_name}'. "
+            f"Valid values: {valid}."
+        )
+    return table[key]

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -11,6 +11,7 @@ import yaml
 
 from libreyolo.utils.amp import normalize_amp_dtype
 from libreyolo.utils.image_size import normalize_imgsz
+from libreyolo.training.best_metric import normalize_best_metric
 
 logger = logging.getLogger(__name__)
 
@@ -266,6 +267,11 @@ class TrainConfig:
     # LayerNorm-only families.
     precise_bn: int = 0
     patience: int = 50
+    # Which validation metric picks best.pt and feeds early stopping. A short
+    # alias resolved against the model task at trainer construction (detect:
+    # map50-95, map50, map75, f1; classify: top1, top5, f1, precision, recall).
+    # None (default) keeps each trainer's built-in metric.
+    best_metric: Optional[str] = None
     resume: bool = False
     log_interval: int = 10
     seed: int = 0
@@ -311,6 +317,7 @@ class TrainConfig:
         self.class_balanced = bool(self.class_balanced)
         self.cls_pw = validate_class_weighting(self.cls_pw, self.class_weights)
         self.export_check = bool(self.export_check)
+        self.best_metric = normalize_best_metric(self.best_metric)
 
     @classmethod
     def from_kwargs(cls, **kwargs):

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -256,6 +256,7 @@ class BaseTrainer(ABC):
         self.best_mAP50_95 = 0.0
         self.best_mAP50 = 0.0
         self.best_epoch = 0
+        self.best_metric_name: Optional[str] = None
         self.final_loss = 0.0
         self.epoch_losses: List[float] = []
         self.epoch_events: List[TrainEpochEvent] = []
@@ -2112,7 +2113,8 @@ class BaseTrainer(ABC):
             "epoch_metrics": epoch_metrics,
             "best_mAP50": self.best_mAP50,
             "best_mAP50_95": self.best_mAP50_95,
-            "best_metric_key": getattr(self, "best_metric_key", "metrics/mAP50-95"),
+            "best_metric_key": self.best_metric_name
+            or getattr(self, "best_metric_key", "metrics/mAP50-95"),
             "best_epoch": self.best_epoch,
             "save_dir": str(self.save_dir),
             "best_checkpoint": (
@@ -2343,6 +2345,7 @@ class BaseTrainer(ABC):
             mAP50 = self._as_float(val_metrics.get("mAP50", 0.0))
             self.best_mAP50 = mAP50 if mAP50 is not None else 0.0
             self.best_epoch = epoch + 1
+            self.best_metric_name = self._best_metric_name(val_metrics)
             self.patience_counter = 0
         else:
             self.patience_counter += 1
@@ -3942,6 +3945,7 @@ class BaseTrainer(ABC):
                 self.best_mAP50_95 = 0.0
                 self.best_mAP50 = 0.0
                 self.best_epoch = 0
+                self.best_metric_name = None
             else:
                 self.best_mAP50_95 = checkpoint.get(
                     "best_metric_value",
@@ -3949,6 +3953,7 @@ class BaseTrainer(ABC):
                 )
                 self.best_mAP50 = checkpoint.get("best_mAP50", 0.0)
                 self.best_epoch = checkpoint.get("best_epoch", 0)
+                self.best_metric_name = checkpoint_metric_key
                 logger.info(
                     f"Restored best metrics: mAP50={self.best_mAP50:.4f}, "
                     f"mAP50-95={self.best_mAP50_95:.4f} (epoch {self.best_epoch})"

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -34,6 +34,7 @@ from .callbacks import (
     TrainExceptionEvent,
     TrainStartEvent,
 )
+from .best_metric import resolve_best_metric
 from .config import TrainConfig
 from .loggers import resolve_loggers
 from .distributed import (
@@ -188,6 +189,19 @@ class BaseTrainer(ABC):
                 )
         self.model = model
         self.wrapper_model = wrapper_model
+        # User-selected best.pt / early-stopping metric. Resolved here, before
+        # any data is loaded, so a bad alias fails fast with the valid list.
+        self._best_metric_explicit = False
+        if self.config.best_metric is not None:
+            task = getattr(wrapper_model, "task", "detect")
+            self.best_metric_key = resolve_best_metric(self.config.best_metric, task)
+            self._best_metric_explicit = True
+            if is_main_process():
+                logger.info(
+                    "best_metric=%s selects %s for best.pt and early stopping",
+                    self.config.best_metric,
+                    self.best_metric_key,
+                )
         self.class_weights = None
         if (self.config.class_weights or self.config.cls_pw > 0) and (
             getattr(wrapper_model, "task", None) != "classify"
@@ -2098,6 +2112,7 @@ class BaseTrainer(ABC):
             "epoch_metrics": epoch_metrics,
             "best_mAP50": self.best_mAP50,
             "best_mAP50_95": self.best_mAP50_95,
+            "best_metric_key": getattr(self, "best_metric_key", "metrics/mAP50-95"),
             "best_epoch": self.best_epoch,
             "save_dir": str(self.save_dir),
             "best_checkpoint": (
@@ -2234,6 +2249,12 @@ class BaseTrainer(ABC):
 
         return float(epoch_loss), val_metrics, dict(loss_items), dict(lr)
 
+    def _branch_best_key(self, default: str) -> str:
+        """Metric key a task branch should track: the user's choice, else its default."""
+        if getattr(self, "_best_metric_explicit", False):
+            return self.best_metric_key
+        return default
+
     def _best_metric_value(self, val_metrics: Optional[Dict[str, Any]]) -> float:
         if not val_metrics:
             return 0.0
@@ -2311,6 +2332,11 @@ class BaseTrainer(ABC):
             return False
 
         best_metric = self._best_metric_value(val_metrics)
+        if math.isnan(best_metric):
+            # A NaN metric (e.g. best_conf_f1 when no threshold reaches F1 > 0)
+            # is never an improvement, and must not seed best state either.
+            self.patience_counter += 1
+            return False
         is_best = self.best_epoch == 0 or best_metric > self.best_mAP50_95
         if is_best:
             self.best_mAP50_95 = best_metric
@@ -3008,11 +3034,13 @@ class BaseTrainer(ABC):
             top1 = raw_metrics.get("metrics/accuracy_top1", 0.0)
             top5 = raw_metrics.get("metrics/accuracy_top5", 0.0)
             logger.info("Validation - top1: %.4f, top5: %.4f", top1, top5)
+            best_key = self._branch_best_key("metrics/accuracy_top1")
+            best_metric = raw_metrics.get(best_key, top1)
             return {
                 "mAP50": top1,
-                "mAP50_95": top1,
-                "best_metric": top1,
-                "best_metric_key": "metrics/accuracy_top1",
+                "mAP50_95": best_metric,
+                "best_metric": best_metric,
+                "best_metric_key": best_key,
                 "metrics": raw_metrics,
             }
         except Exception as e:
@@ -3072,11 +3100,14 @@ class BaseTrainer(ABC):
             miou = raw_metrics.get("metrics/mIoU", 0.0)
             accuracy = raw_metrics.get("metrics/pixel_accuracy", 0.0)
             logger.info("Validation - mIoU: %.4f, pixel accuracy: %.4f", miou, accuracy)
+            # best_metric aliases exist only for detect and classify today; the helper keeps this branch ready for future aliases.
+            best_key = self._branch_best_key("metrics/mIoU")
+            best_metric = raw_metrics.get(best_key, miou)
             return {
                 "mAP50": miou,
-                "mAP50_95": miou,
-                "best_metric": miou,
-                "best_metric_key": "metrics/mIoU",
+                "mAP50_95": best_metric,
+                "best_metric": best_metric,
+                "best_metric_key": best_key,
                 "metrics": raw_metrics,
             }
         except Exception as e:
@@ -3126,11 +3157,14 @@ class BaseTrainer(ABC):
             delta1 = raw_metrics.get("metrics/delta1", 0.0)
             abs_rel = raw_metrics.get("metrics/abs_rel", 0.0)
             logger.info("Validation - delta1: %.4f, AbsRel: %.4f", delta1, abs_rel)
+            # best_metric aliases exist only for detect and classify today; the helper keeps this branch ready for future aliases.
+            best_key = self._branch_best_key("metrics/delta1")
+            best_metric = raw_metrics.get(best_key, delta1)
             return {
                 "mAP50": delta1,
-                "mAP50_95": delta1,
-                "best_metric": delta1,
-                "best_metric_key": "metrics/delta1",
+                "mAP50_95": best_metric,
+                "best_metric": best_metric,
+                "best_metric_key": best_key,
                 "metrics": raw_metrics,
             }
         except Exception as e:
@@ -3184,11 +3218,14 @@ class BaseTrainer(ABC):
             psnr = raw_metrics.get("metrics/PSNR", 0.0)
             ssim = raw_metrics.get("metrics/SSIM", 0.0)
             logger.info("Validation - PSNR: %.4f, SSIM: %.4f", psnr, ssim)
+            # best_metric aliases exist only for detect and classify today; the helper keeps this branch ready for future aliases.
+            best_key = self._branch_best_key("metrics/PSNR")
+            best_metric = raw_metrics.get(best_key, psnr)
             return {
                 "mAP50": psnr,
-                "mAP50_95": psnr,
-                "best_metric": psnr,
-                "best_metric_key": "metrics/PSNR",
+                "mAP50_95": best_metric,
+                "best_metric": best_metric,
+                "best_metric_key": best_key,
                 "metrics": raw_metrics,
             }
         except Exception as e:

--- a/libreyolo/validation/classify_validator.py
+++ b/libreyolo/validation/classify_validator.py
@@ -34,6 +34,11 @@ class ClassifyValidator(ValidationLossMixin, BaseValidator):
     """Top-1/top-5 accuracy validator for the classification task."""
 
     task = "classify"
+    # Confusion matrix, rows = targets, cols = top-1 predictions. Sized
+    # lazily from the first batch's logits width. Declared as a class-level
+    # default so validators built via ``object.__new__`` without a call to
+    # ``_init_metrics`` still see ``None`` instead of raising AttributeError.
+    _confusion: Optional[torch.Tensor] = None
 
     def __init__(
         self,
@@ -154,6 +159,9 @@ class ClassifyValidator(ValidationLossMixin, BaseValidator):
         self._top1_correct = 0
         self._top5_correct = 0
         self._total = 0
+        # Confusion matrix, rows = targets, cols = top-1 predictions. Sized
+        # lazily from the first batch's logits width.
+        self._confusion: Optional[torch.Tensor] = None
         self._reset_validation_loss()
 
     def _preprocess_batch(self, batch: Any) -> tuple:
@@ -192,16 +200,65 @@ class ClassifyValidator(ValidationLossMixin, BaseValidator):
         self._top5_correct += int(correct.any(dim=1).sum().item())
         self._total += int(targets.numel())
 
+        pred = topk[:, 0]
+        if self._confusion is None:
+            self._confusion = torch.zeros(num_classes, num_classes, dtype=torch.long)
+        valid = (targets >= 0) & (targets < num_classes)
+        flat = targets[valid].long() * num_classes + pred[valid].long()
+        self._confusion += torch.bincount(
+            flat, minlength=num_classes * num_classes
+        ).view(num_classes, num_classes)
+
     def _compute_metrics(self) -> Dict[str, float]:
         total = max(self._total, 1)
         top1 = self._top1_correct / total
         top5 = self._top5_correct / total
+        precision, recall, f1 = self._macro_precision_recall_f1()
         return {
             "metrics/accuracy_top1": top1,
             "metrics/accuracy_top5": top5,
+            "metrics/precision": precision,
+            "metrics/recall": recall,
+            "metrics/f1": f1,
             "fitness": top1,
             **self._validation_loss_metrics(),
         }
+
+    def _macro_precision_recall_f1(self) -> tuple[float, float, float]:
+        """Macro-averaged P/R/F1 over classes present in the targets.
+
+        Per class: precision = tp / (tp + fp) (0 when the class was never
+        predicted), recall = tp / (tp + fn), f1 = 2PR / (P + R) (0 when both
+        are 0). Classes with no ground-truth samples are excluded from the
+        mean. Returns zeros when nothing was accumulated.
+        """
+        if self._confusion is None:
+            return 0.0, 0.0, 0.0
+        confusion = self._confusion.double()
+        tp = confusion.diag()
+        fp = confusion.sum(dim=0) - tp
+        fn = confusion.sum(dim=1) - tp
+        support = confusion.sum(dim=1)
+        present = support > 0
+        if not bool(present.any()):
+            return 0.0, 0.0, 0.0
+        precision = torch.where(
+            tp + fp > 0, tp / (tp + fp).clamp(min=1), torch.zeros_like(tp)
+        )
+        recall = torch.where(
+            tp + fn > 0, tp / (tp + fn).clamp(min=1), torch.zeros_like(tp)
+        )
+        denom = precision + recall
+        f1 = torch.where(
+            denom > 0,
+            2 * precision * recall / denom.clamp(min=1e-12),
+            torch.zeros_like(tp),
+        )
+        return (
+            float(precision[present].mean()),
+            float(recall[present].mean()),
+            float(f1[present].mean()),
+        )
 
     def _print_results(self, metrics: Dict[str, float]) -> None:
         logger.info("=" * 50)

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -1003,3 +1003,116 @@ def test_cls_pw_help_json_exposes_numeric_default():
 
     parameter = next(p for p in schema["parameters"] if p["name"] == "cls_pw")
     assert parameter["default"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "family,model",
+    [
+        ("yolo9", "LibreYOLO9s.pt"),
+        ("rfdetr", "LibreRFDETRs.pt"),
+        ("resnet", "LibreResNet18-cls.pt"),
+    ],
+)
+@pytest.mark.parametrize("option", [["best_metric=f1"], ["--best-metric", "f1"]])
+def test_best_metric_cli_forwards_alias(monkeypatch, tmp_path, family, model, option):
+    captured = {}
+
+    class Stub:
+        FAMILY = family
+        device = "cpu"
+        task = "classify" if family == "resnet" else "detect"
+
+        def train(self, data, **kwargs):
+            captured.update(kwargs)
+            return {"output_dir": str(tmp_path)}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda *args, **kwargs: Stub(),
+    )
+    result = runner.invoke(
+        _make_app(),
+        [
+            f"model={model}",
+            "data=unused",
+            *option,
+            f"project={tmp_path}",
+            "--json",
+            "--quiet",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["best_metric"] == "f1"
+
+
+def test_best_metric_cli_default_is_none(monkeypatch, tmp_path):
+    captured = {}
+
+    class Stub:
+        FAMILY = "yolo9"
+        device = "cpu"
+        task = "detect"
+
+        def train(self, data, **kwargs):
+            captured.update(kwargs)
+            return {"output_dir": str(tmp_path)}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda *args, **kwargs: Stub(),
+    )
+    result = runner.invoke(
+        _make_app(),
+        [
+            "model=LibreYOLO9s.pt",
+            "data=unused",
+            f"project={tmp_path}",
+            "--json",
+            "--quiet",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured.get("best_metric") is None
+
+
+def test_best_metric_help_json_exposes_option():
+    result = runner.invoke(_make_app(), ["--help-json"])
+    assert result.exit_code == 0, result.output
+    schema = json.loads(result.stdout)
+    parameter = next(p for p in schema["parameters"] if p["name"] == "best_metric")
+    assert parameter.get("default") is None
+
+
+def test_train_json_output_reports_best_metric_key(monkeypatch, tmp_path):
+    """The JSON payload must say which metric key drove best.pt selection."""
+
+    class Stub:
+        FAMILY = "resnet"
+        device = "cpu"
+        task = "classify"
+
+        def train(self, data, **kwargs):
+            return {
+                "output_dir": str(tmp_path),
+                "best_mAP50": 0.1,
+                "best_mAP50_95": 0.2,
+                "best_metric_key": "metrics/best_conf_f1",
+            }
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda *args, **kwargs: Stub(),
+    )
+    result = runner.invoke(
+        _make_app(),
+        [
+            "model=LibreResNet18-cls.pt",
+            "data=unused",
+            f"project={tmp_path}",
+            "--json",
+            "--quiet",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["best_metrics"]["best_metric_key"] == "metrics/best_conf_f1"

--- a/tests/unit/test_best_metric.py
+++ b/tests/unit/test_best_metric.py
@@ -1,0 +1,234 @@
+"""Tests for the user-selectable best-checkpoint / early-stopping metric."""
+
+from __future__ import annotations
+
+import pytest
+
+from libreyolo.training.best_metric import (
+    BEST_METRIC_ALIASES,
+    SUPPORTED_BEST_METRIC_TASKS,
+    resolve_best_metric,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# resolve_best_metric
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "task,alias,expected",
+    [
+        ("detect", "map50-95", "metrics/mAP50-95"),
+        ("detect", "map50", "metrics/mAP50"),
+        ("detect", "map75", "metrics/mAP75"),
+        ("detect", "f1", "metrics/best_conf_f1"),
+        ("classify", "top1", "metrics/accuracy_top1"),
+        ("classify", "top5", "metrics/accuracy_top5"),
+        ("classify", "f1", "metrics/f1"),
+        ("classify", "precision", "metrics/precision"),
+        ("classify", "recall", "metrics/recall"),
+    ],
+)
+def test_resolve_best_metric_table(task, alias, expected):
+    assert resolve_best_metric(alias, task) == expected
+
+
+def test_resolve_best_metric_is_case_and_whitespace_insensitive():
+    assert resolve_best_metric("  F1 ", "detect") == "metrics/best_conf_f1"
+    assert resolve_best_metric("MAP50-95", "Detect") == "metrics/mAP50-95"
+
+
+def test_resolve_best_metric_unknown_alias_lists_valid_values():
+    with pytest.raises(ValueError) as excinfo:
+        resolve_best_metric("map95", "detect")
+    message = str(excinfo.value)
+    assert "map95" in message
+    assert "detect" in message
+    assert "f1, map50, map50-95, map75" in message
+
+
+def test_resolve_best_metric_unsupported_task_lists_supported_tasks():
+    with pytest.raises(ValueError) as excinfo:
+        resolve_best_metric("f1", "pose")
+    message = str(excinfo.value)
+    assert "pose" in message
+    assert "classify, detect" in message
+
+
+def test_alias_table_matches_supported_tasks():
+    assert tuple(sorted(BEST_METRIC_ALIASES)) == SUPPORTED_BEST_METRIC_TASKS
+    assert SUPPORTED_BEST_METRIC_TASKS == ("classify", "detect")
+
+
+# ---------------------------------------------------------------------------
+# TrainConfig.best_metric
+# ---------------------------------------------------------------------------
+
+
+def test_train_config_best_metric_defaults_to_none():
+    from libreyolo.training.config import TrainConfig
+
+    assert TrainConfig().best_metric is None
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [(" F1 ", "f1"), ("MAP50", "map50"), ("", None), ("   ", None), (None, None)],
+)
+def test_train_config_best_metric_is_normalized(raw, expected):
+    from libreyolo.training.config import TrainConfig
+
+    assert TrainConfig(best_metric=raw).best_metric == expected
+
+
+def test_train_config_from_kwargs_accepts_best_metric_without_warning(recwarn):
+    from libreyolo.training.config import TrainConfig
+
+    config = TrainConfig.from_kwargs(best_metric="f1")
+    assert config.best_metric == "f1"
+    assert not [w for w in recwarn if "Unknown training config keys" in str(w.message)]
+
+
+# ---------------------------------------------------------------------------
+# BaseTrainer resolution
+# ---------------------------------------------------------------------------
+
+
+def _dummy_trainer(**kwargs):
+    from types import SimpleNamespace
+
+    from torch import nn
+
+    from libreyolo.training.trainer import BaseTrainer
+
+    class DummyTrainer(BaseTrainer):
+        def get_model_family(self) -> str:
+            return "dummy"
+
+        def get_model_tag(self) -> str:
+            return "dummy"
+
+        def create_transforms(self):
+            raise NotImplementedError
+
+        def create_scheduler(self, iters_per_epoch: int):
+            raise NotImplementedError
+
+        def get_loss_components(self, outputs):
+            return {}
+
+    task = kwargs.pop("task", "detect")
+    return DummyTrainer(
+        model=nn.Linear(1, 1),
+        wrapper_model=SimpleNamespace(task=task),
+        data=None,
+        device="cpu",
+        ema=False,
+        **kwargs,
+    )
+
+
+def test_trainer_without_best_metric_keeps_class_default():
+    trainer = _dummy_trainer()
+    assert trainer.best_metric_key == "metrics/mAP50-95"
+    assert trainer._best_metric_explicit is False
+    assert trainer._branch_best_key("metrics/accuracy_top1") == "metrics/accuracy_top1"
+
+
+def test_trainer_resolves_detect_alias_into_best_metric_key():
+    trainer = _dummy_trainer(best_metric="f1", task="detect")
+    assert trainer.best_metric_key == "metrics/best_conf_f1"
+    assert trainer._best_metric_explicit is True
+    assert trainer._branch_best_key("metrics/mAP50-95") == "metrics/best_conf_f1"
+
+
+def test_trainer_resolves_classify_alias_into_best_metric_key():
+    trainer = _dummy_trainer(best_metric="F1", task="classify")
+    assert trainer.best_metric_key == "metrics/f1"
+    assert trainer._branch_best_key("metrics/accuracy_top1") == "metrics/f1"
+
+
+def test_trainer_rejects_best_metric_for_unsupported_task():
+    with pytest.raises(ValueError, match="not supported for task 'pose'"):
+        _dummy_trainer(best_metric="f1", task="pose")
+
+
+def test_trainer_rejects_unknown_best_metric_alias():
+    with pytest.raises(ValueError, match="Unknown best_metric 'map95'"):
+        _dummy_trainer(best_metric="map95", task="detect")
+
+
+# ---------------------------------------------------------------------------
+# FOMO always tracks grid F1
+# ---------------------------------------------------------------------------
+
+
+def test_fomo_trainer_rejects_best_metric():
+    from types import SimpleNamespace
+
+    from torch import nn
+
+    from libreyolo.models.fomo.trainer import FOMOTrainer
+
+    with pytest.raises(NotImplementedError, match="grid_F1"):
+        FOMOTrainer(
+            model=nn.Linear(1, 1),
+            wrapper_model=SimpleNamespace(task="detect"),
+            data=None,
+            device="cpu",
+            ema=False,
+            best_metric="f1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# V-JEPA2 has no working per-epoch validation path, so it cannot honor a
+# selected metric.
+# ---------------------------------------------------------------------------
+
+
+def test_vjepa2_trainer_rejects_best_metric():
+    from types import SimpleNamespace
+
+    from torch import nn
+
+    from libreyolo.models.vjepa2.trainer import VJEPA2Trainer
+
+    with pytest.raises(NotImplementedError, match="V-JEPA2"):
+        VJEPA2Trainer(
+            model=nn.Linear(1, 1),
+            wrapper_model=SimpleNamespace(task="classify"),
+            data=None,
+            device="cpu",
+            ema=False,
+            best_metric="f1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Python API: covered families expose best_metric explicitly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module,cls",
+    [
+        ("libreyolo.models.yolo9.model", "LibreYOLO9"),
+        ("libreyolo.models.rfdetr.model", "LibreRFDETR"),
+        ("libreyolo.models.resnet.model", "LibreResNet"),
+        ("libreyolo.models.convnext.model", "LibreConvNeXt"),
+        ("libreyolo.models.mobilenetv4.model", "LibreMobileNetV4"),
+        ("libreyolo.models.efficientnetv2.model", "LibreEfficientNetV2"),
+    ],
+)
+def test_train_signature_exposes_best_metric(module, cls):
+    import importlib
+    import inspect
+
+    train = getattr(importlib.import_module(module), cls).train
+    parameters = inspect.signature(train).parameters
+    assert "best_metric" in parameters
+    assert parameters["best_metric"].default is None

--- a/tests/unit/test_classification.py
+++ b/tests/unit/test_classification.py
@@ -317,6 +317,169 @@ def test_classify_family_train_end_to_end(tmp_path):
     assert result.probs.data.shape[0] == 2
 
 
+def test_classify_validator_macro_precision_recall_f1():
+    """Macro P/R/F1 from the confusion matrix, over classes present in targets."""
+    from contextlib import nullcontext
+
+    from libreyolo.validation.classify_validator import ClassifyValidator
+
+    validator = object.__new__(ClassifyValidator)
+    validator.loss_adapter = None
+    validator._autocast_context = nullcontext
+    validator._init_metrics()
+
+    def logits_for(preds, nc=4):
+        out = torch.full((len(preds), nc), -5.0)
+        for row, cls in enumerate(preds):
+            out[row, cls] = 5.0
+        return out
+
+    # Batch 1: targets [0, 0, 1, 1], preds [0, 1, 1, 1]
+    validator._update_metrics(
+        logits_for([0, 1, 1, 1]), torch.tensor([0, 0, 1, 1]), None
+    )
+    # Batch 2: targets [2, 2], preds [2, 0]
+    validator._update_metrics(logits_for([2, 0]), torch.tensor([2, 2]), None)
+
+    metrics = validator._compute_metrics()
+
+    # Confusion (rows=target, cols=pred):
+    #   c0: tp=1 fp=1 fn=1 -> P=0.5  R=0.5  F1=0.5
+    #   c1: tp=2 fp=1 fn=0 -> P=2/3  R=1.0  F1=0.8
+    #   c2: tp=1 fp=0 fn=1 -> P=1.0  R=0.5  F1=2/3
+    #   c3: absent from targets -> excluded from the macro mean
+    assert metrics["metrics/accuracy_top1"] == pytest.approx(4 / 6)
+    assert metrics["metrics/precision"] == pytest.approx((0.5 + 2 / 3 + 1.0) / 3)
+    assert metrics["metrics/recall"] == pytest.approx((0.5 + 1.0 + 0.5) / 3)
+    assert metrics["metrics/f1"] == pytest.approx((0.5 + 0.8 + 2 / 3) / 3)
+    assert metrics["fitness"] == pytest.approx(metrics["metrics/accuracy_top1"])
+
+
+def test_classify_validator_macro_metrics_are_zero_without_samples():
+    from contextlib import nullcontext
+
+    from libreyolo.validation.classify_validator import ClassifyValidator
+
+    validator = object.__new__(ClassifyValidator)
+    validator.loss_adapter = None
+    validator._autocast_context = nullcontext
+    validator._init_metrics()
+
+    metrics = validator._compute_metrics()
+
+    assert metrics["metrics/precision"] == 0.0
+    assert metrics["metrics/recall"] == 0.0
+    assert metrics["metrics/f1"] == 0.0
+
+
+def test_classify_validator_precision_is_zero_for_never_predicted_class():
+    """A class present in the targets but never predicted gets precision 0, not NaN."""
+    from contextlib import nullcontext
+
+    from libreyolo.validation.classify_validator import ClassifyValidator
+
+    validator = object.__new__(ClassifyValidator)
+    validator.loss_adapter = None
+    validator._autocast_context = nullcontext
+    validator._init_metrics()
+
+    def logits_for(preds, nc=3):
+        out = torch.full((len(preds), nc), -5.0)
+        for row, cls in enumerate(preds):
+            out[row, cls] = 5.0
+        return out
+
+    # targets [0, 0, 1, 2], preds [0, 0, 0, 0]: class 1 and class 2 have
+    # support 1 each but are never predicted (tp + fp == 0 for both).
+    validator._update_metrics(
+        logits_for([0, 0, 0, 0]), torch.tensor([0, 0, 1, 2]), None
+    )
+
+    metrics = validator._compute_metrics()
+
+    # Confusion (rows=target, cols=pred):
+    #   c0: tp=2 fp=2 fn=0 -> P=0.5    R=1.0  F1=2/3
+    #   c1: tp=0 fp=0 fn=1 -> P=0      R=0    F1=0
+    #   c2: tp=0 fp=0 fn=1 -> P=0      R=0    F1=0
+    assert metrics["metrics/precision"] == pytest.approx((0.5 + 0 + 0) / 3)
+    assert metrics["metrics/recall"] == pytest.approx((1.0 + 0 + 0) / 3)
+    assert metrics["metrics/f1"] == pytest.approx((2 / 3 + 0 + 0) / 3)
+    for key in ("metrics/precision", "metrics/recall", "metrics/f1"):
+        assert metrics[key] == metrics[key]  # NaN check: NaN != NaN.
+
+
+def test_classify_validator_ignores_out_of_range_targets_in_confusion():
+    """A target >= nc (dataset/head class-count mismatch) must not crash.
+
+    Before this feature such a sample simply counted as wrong; it must keep
+    doing so rather than raising out of ``torch.bincount``.
+    """
+    from contextlib import nullcontext
+
+    from libreyolo.validation.classify_validator import ClassifyValidator
+
+    validator = object.__new__(ClassifyValidator)
+    validator.loss_adapter = None
+    validator._autocast_context = nullcontext
+    validator._init_metrics()
+
+    def logits_for(preds, nc=2):
+        out = torch.full((len(preds), nc), -5.0)
+        for row, cls in enumerate(preds):
+            out[row, cls] = 5.0
+        return out
+
+    # preds [0, 0], targets [2, 0]: target 2 is out of range for nc=2.
+    validator._update_metrics(logits_for([0, 0]), torch.tensor([2, 0]), None)
+
+    metrics = validator._compute_metrics()
+
+    # The out-of-range sample counts as wrong (unchanged semantics): 1/2 correct.
+    assert metrics["metrics/accuracy_top1"] == pytest.approx(0.5)
+    assert validator._confusion.tolist() == [[1, 0], [0, 0]]
+    # Only class 0 has support; it is predicted perfectly.
+    assert metrics["metrics/precision"] == pytest.approx(1.0)
+    assert metrics["metrics/recall"] == pytest.approx(1.0)
+    assert metrics["metrics/f1"] == pytest.approx(1.0)
+
+
+def test_classify_train_with_best_metric_f1_records_key(tmp_path):
+    """best_metric=f1 drives best.pt selection and lands in checkpoint metadata."""
+    from libreyolo import LibreMobileNetV4
+
+    _make_imagefolder(tmp_path / "data", n_classes=2, n_per=6, size=64)
+
+    model = LibreMobileNetV4(size="s", device="cpu")
+    metrics = model.train(
+        data=str(tmp_path / "data"),
+        epochs=1,
+        batch=4,
+        imgsz=32,
+        workers=0,
+        device="cpu",
+        project=str(tmp_path / "runs"),
+        name="cls_f1",
+        exist_ok=True,
+        best_metric="f1",
+    )
+
+    epoch_metrics = metrics.get("epoch_metrics", [])
+    assert epoch_metrics and epoch_metrics[-1].get("validated") is True
+    # epoch_metrics' val_metrics is the flattened scalar dict the validator
+    # reports (see BaseTrainer._validation_metrics_for_event), not the
+    # internal dict the trainer builds around it -- it does not carry
+    # best_metric_key. The checkpoint's top-level best_metric_key is the
+    # contract for that, asserted below.
+    val = epoch_metrics[-1].get("val_metrics") or {}
+    scalars = val.get("metrics", val)
+    assert "metrics/f1" in scalars
+
+    best = tmp_path / "runs" / "cls_f1" / "weights" / "best.pt"
+    assert best.exists()
+    checkpoint = torch.load(best, map_location="cpu", weights_only=False)
+    assert checkpoint["best_metric_key"] == "metrics/f1"
+
+
 # ---------------------------------------------------------------------------
 # Classification augmentation pack: auto_augment / erasing / mixup / cutmix.
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_train_callbacks.py
+++ b/tests/unit/test_train_callbacks.py
@@ -500,6 +500,35 @@ def test_build_train_results_reports_best_metric_key(tmp_path):
     assert results["best_metric_key"] == "metrics/best_conf_f1"
 
 
+def test_build_train_results_reports_effective_key_from_validation(tmp_path):
+    """The reported key is the one the validation branch used, not the class attribute."""
+    trainer = DummyTrainer(model=nn.Linear(1, 1), data=None, device="cpu", ema=False)
+    trainer.save_dir = tmp_path
+
+    assert trainer.best_metric_key == "metrics/mAP50-95"
+
+    trainer._update_best_state(
+        0,
+        {
+            "mAP50": 0.5,
+            "mAP50_95": 0.4,
+            "best_metric": 0.4,
+            "best_metric_key": "fitness",
+        },
+    )
+
+    results = trainer._build_train_results()
+    assert results["best_metric_key"] == "fitness"
+    assert results["best_mAP50_95"] == pytest.approx(0.4)
+
+
+def test_build_train_results_falls_back_to_class_key_without_validation(tmp_path):
+    trainer = DummyTrainer(model=nn.Linear(1, 1), data=None, device="cpu", ema=False)
+    trainer.save_dir = tmp_path
+
+    assert trainer._build_train_results()["best_metric_key"] == "metrics/mAP50-95"
+
+
 def test_yolo9_loss_components_match_epoch_event_names():
     from libreyolo.models.yolo9.trainer import YOLO9Trainer
 

--- a/tests/unit/test_train_callbacks.py
+++ b/tests/unit/test_train_callbacks.py
@@ -452,6 +452,54 @@ def test_first_zero_validation_metric_counts_as_best():
     assert trainer.best_epoch == 1
 
 
+def test_nan_validation_metric_is_never_best():
+    trainer = DummyTrainer(
+        model=nn.Linear(1, 1),
+        data=None,
+        device="cpu",
+        ema=False,
+    )
+    nan_metrics = {
+        "mAP50": float("nan"),
+        "mAP50_95": float("nan"),
+        "best_metric": float("nan"),
+        "best_metric_key": "metrics/best_conf_f1",
+    }
+
+    # First validated epoch is NaN: nothing becomes best, so patience cannot
+    # start counting (best_epoch stays 0).
+    assert trainer._update_best_state(0, nan_metrics) is False
+    assert trainer.best_epoch == 0
+    assert trainer.best_mAP50_95 == pytest.approx(0.0)
+
+    # A finite value afterwards is accepted as best.
+    finite = dict(nan_metrics, mAP50=0.4, mAP50_95=0.3, best_metric=0.3)
+    assert trainer._update_best_state(1, finite) is True
+    assert trainer.best_epoch == 2
+    assert trainer.best_mAP50_95 == pytest.approx(0.3)
+
+    # NaN after a finite best counts as no improvement.
+    assert trainer._update_best_state(2, nan_metrics) is False
+    assert trainer.best_epoch == 2
+    assert trainer.patience_counter == 1
+
+
+def test_build_train_results_reports_best_metric_key(tmp_path):
+    """The results dict must say which metric key drove best.pt selection."""
+    trainer = DummyTrainer(
+        model=nn.Linear(1, 1),
+        data=None,
+        device="cpu",
+        ema=False,
+        best_metric="f1",
+    )
+    trainer.save_dir = tmp_path
+
+    results = trainer._build_train_results()
+
+    assert results["best_metric_key"] == "metrics/best_conf_f1"
+
+
 def test_yolo9_loss_components_match_epoch_event_names():
     from libreyolo.models.yolo9.trainer import YOLO9Trainer
 


### PR DESCRIPTION
What: `best_metric` train kwarg and `--best-metric` CLI flag select the validation metric that picks best.pt and drives `patience`.
Why: the monitored metric was fixed per trainer (mAP50-95 for detect, top-1 for classify) with no user control. Closes #852.

- `libreyolo/training/best_metric.py`: per-task alias table and `resolve_best_metric()`; detect: `map50-95` (default), `map50`, `map75`, `f1` (= existing `metrics/best_conf_f1`); classify: `top1` (default), `top5`, `f1`, `precision`, `recall`.
- `TrainConfig.best_metric` (default `None`, normalized); `BaseTrainer.__init__` resolves it against the model task into the existing `best_metric_key`; classify, semantic, depth and restore branches read that key through one helper instead of hard-coding it. Default path is value-for-value unchanged.
- `_update_best_state`: NaN is never an improvement. This changes the default path for every family: previously a NaN first validation latched as best and nothing could beat it, freezing best.pt at epoch one.
- `ClassifyValidator`: confusion matrix; new keys `metrics/precision`, `metrics/recall`, `metrics/f1` (macro over classes present in targets). Out-of-range targets are skipped by the matrix and still count as wrong for top-1. Existing keys unchanged.
- Unknown alias or unsupported task raises at trainer construction with the valid list; FOMO and V-JEPA2 raise explicitly (FOMO emits only grid F1; V-JEPA2 has no working per-epoch validation path). Narrower than the issue text: tasks other than detect and classify reject the kwarg instead of accepting their default name.
- CLI option plus RF-DETR direct mapping (its kwargs builder is hand-written). Explicit kwarg and docstring on YOLO9, RF-DETR, ResNet, ConvNeXt, MobileNetV4 and EfficientNetV2 `train()`; other families reach the config through `**kwargs`.
- `train()` results and the CLI `--json` payload gain `best_metric_key` so the reported best value is self-describing.
- Docs: section in `docs/classification_training.md`. No checkpoint schema change: `best_metric_key` was already written.

Shared code touched: `BaseTrainer` (init, best-state update, four validation branches) and `ClassifyValidator`. Every family inherits the NaN guard and the new classify keys; with `best_metric=None` nothing else changes.

Check: `_branch_best_key` defaults in the four branches; the NaN guard against `precise_bn` re-validation; RF-DETR `direct_mappings`; macro definition and target masking in `_macro_precision_recall_f1` / `_update_metrics`.
Not verified: no GPU run; detect-path `f1` exercised by unit tests only, not a real training run. Full PR gate locally (macOS, CPU, `-n auto`): one run fully clean (7028 passed, 249 skipped); two other runs had 5 subprocess/socket/file-lock timing tests fail (test_ddp_coordinator, download lock, paddle install lock) that pass in isolation every time. ty error count unchanged (56). Website docs not updated (separate repo).

## Code provenance
Original code written for this PR against LibreYOLO's own first-party code; no third-party code ported, adapted, or introduced; no GPL/AGPL/LGPL/non-commercial/unknown-license material involved.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63390309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no outstanding actionable findings.

<details><summary><h3>Summary</h3></summary>

- Supports detection and classification metric aliases through Python and CLI entry points.
- Adds macro precision, recall, and F1 classification metrics.
- Keeps checkpoint selection, resume behavior, and result reporting aligned with the effective metric key.
- Prevents NaN validation metrics from becoming the best state.
- The changes since the previous review correctly report the effective validation key used for point-task selection.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Python API or CLI] --> B[Normalize best_metric alias]
    B --> C[Resolve alias by model task]
    C --> D[Run task validator]
    D --> E[Read selected metric value]
    E --> F{Finite improvement?}
    F -->|Yes| G[Update best state and save best.pt]
    F -->|No| H[Increment patience]
    G --> I[Report effective best_metric_key]
    H --> I
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["Report the effective best\_metric\_key in ..."](https://github.com/libreyolo/libreyolo/commit/01729e382ef87ae34e23131f5d05f1939d42d2ee)</sub>

<!-- /greptile_comment -->