### PR TITLE
Add LibreVLA tier, act task and SmolVLA family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- **LibreVLA** sibling factory and the `act` task: camera frames + robot
+  state + instruction → `Results.actions`, a `(T, D)` action chunk with
+  per-dimension names, control rate and instruction. First family is
+  SmolVLA base (Apache-2.0) loaded through `lerobot` at a pinned revision.
+  `train(data=<LeRobot dataset>)` fine-tunes with held-out episodes and the
+  standard callbacks/loggers; `val()` reports offline action error (L1,
+  MSE, per dimension); checkpoints are directories with
+  `libreyolo_vla.json`. Install `libreyolo[vla]` (Python 3.12+). Export,
+  tracking and a CLI verb are out of scope. See ADR 0028 and
+  `docs/librevla.md`.
+
 - **LeVJEPA** (`levjepa`) inference-only video encoder with normalized clip
   embeddings and spatiotemporal patch embeddings. The native implementation
   loads the released 16-frame ViT-L/16 checkpoint; redistributed weights remain

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Point detection** | FOMO, LocateAnything |
 | **Gaze** | L2CS |
 | **Open vocabulary and VLMs** | Grounding DINO, OWLv2, OmDet-Turbo, OV-DEIM, Florence-2, Kosmos-2, Qwen3-VL, InternVL3, LFM2-VL, North Micro Vision, SmolVLM2, Gemma 4, Moondream, MODUS |
+| **Robot actions (VLA)** | SmolVLA |
 
 Per-family sizes, checkpoints and parity evidence live in the
 [model reference](https://www.libreyolo.com/docs/models).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,6 +125,7 @@ libreyolo predict --model yolo9-t --source screen            # 屏幕捕获
 | **点检测** | FOMO、LocateAnything |
 | **视线估计** | L2CS |
 | **开放词汇与 VLM** | Grounding DINO、OWLv2、OmDet-Turbo、OV-DEIM、Florence-2、Kosmos-2、Qwen3-VL、InternVL3、LFM2-VL、North Micro Vision、SmolVLM2、MODUS |
+| **机器人动作 (VLA)** | SmolVLA |
 
 各模型系列的尺寸、权重与一致性验证证据见[模型参考](https://www.libreyolo.com/docs/models)。
 

--- a/docs/adr/0028-librevla-contract.md
+++ b/docs/adr/0028-librevla-contract.md
@@ -1,0 +1,205 @@
+# ADR 0028: LibreVLA Contract For Vision-Language-Action Policies
+
+- Status: Accepted
+- Date: 2026-09-12
+- Scope: New sibling tier (`LibreVLA`), new canonical task (`act`), new
+  result payload (`Results.actions`)
+
+## Context
+
+A vision-language-action (VLA) model takes camera frames, the robot's
+proprioceptive state and a language instruction, and returns the actions the
+robot should execute next. It is the perception-to-control layer of a robot
+stack, and every current open family (SmolVLA, pi0, pi0.5, MolmoAct2, X-VLA,
+GR00T) is published as a Hugging Face policy through the `lerobot` package
+(Apache-2.0).
+
+None of LibreYOLO's existing contracts fit it:
+
+- `LibreYOLO(...)` sniffs a `.pt` state dict and runs one forward pass to
+  calibrated boxes. A VLA is a multi-file policy directory with a sampling
+  loop and no boxes.
+- `LibreVLM(...)` is image plus text in, text out, parsed into boxes. A VLA
+  emits a continuous action chunk, not text.
+- `LibreLLM(...)` is a hosted chat client with no local weights.
+
+The output primitive is also new. Every task in `libreyolo/tasks.py` names an
+image-space or per-object primitive. An action chunk is a `(T, D)` sequence
+of robot commands. Following ADR 0003 and ADR 0021, the task names the output
+primitive, not the domain, so `act` is a canonical task and not a `robot` or
+`vla` task.
+
+## Decision
+
+Add `LibreVLA` as a sibling factory, the task `act`, and `Results.actions`.
+The library owns the observation contract, the result payload, the offline
+training loop, the offline evaluation metric, the checkpoint directory
+contract and the user-facing API. The policy network, its processors and
+the dataset reader come from `lerobot` through its public API. No upstream
+source is ported, adapted or vendored.
+
+The line is the same as ADR 0002 drew: the contract, not the architecture.
+
+- `LibreYOLO(...)`: closed-set detector, real scores, `.pt` checkpoints.
+- `LibreVLM(...)`: generative detector, sticky vocabulary, `Results.boxes`.
+- `LibreGround(...)`: instruction, click, `Results.points`.
+- `LibreVLA(...)`: frames plus state plus instruction, `Results.actions`.
+
+The default model is SmolVLA base (`lerobot/smolvla_base`, Apache-2.0,
+about 450M parameters), pinned to a commit and downloaded on first use.
+
+## Task contract: `act`
+
+`act` is the canonical task for models whose public prediction primitive is
+an action chunk. Filename suffix `-act`. Aliases `action`, `actions`, `vla`,
+`policy`, `robot-policy` resolve to `act` at the API boundary.
+
+`Results.actions` holds an `Actions` payload:
+
+- `data` is `(T, D)` float32: `T` timesteps of a `D`-dimensional action.
+  Row 0 is the action to execute now, later rows are the model's plan.
+- Values are in the units the model was trained on. LibreYOLO does not
+  reinterpret them: for the shipped SmolVLA checkpoints they are absolute
+  joint targets in the dataset's own unit. `Actions.names` carries the
+  per-dimension names when the checkpoint knows them, `Actions.fps` the
+  control rate the chunk was planned at, `Actions.instruction` the text
+  that produced it. All three may be `None`.
+- `Results.boxes` is `None`. `Results.orig_shape` is the primary camera
+  frame's `(H, W)`. `len(result)` is `T`. Slicing a result slices
+  timesteps. `summary()` returns one row with the chunk and its metadata.
+- `result.plot(image)` renders the frame with a per-dimension trajectory
+  strip under it. `save=True` writes that under `runs/act/predict`.
+
+Box-specific paths (tracking, tiling, export backends, mAP validation)
+reject `act` results.
+
+## Observation contract
+
+`predict(source, *, state=None, instruction=None, cameras=None, ...)`.
+
+- `source` is one frame in any `ImageInput` form for a single camera, a
+  `dict[str, ImageInput]` naming several cameras, a list or directory of
+  frames, a video, a webcam index or a stream URL. Frames are original
+  camera pixels; the family's processor owns resize and normalization.
+- Camera naming: a dict key that matches one of the family's camera slots
+  (`camera1`, `camera2`, ... for SmolVLA) is used as such; other keys are
+  assigned to free slots in order. Set `cameras=["front", "wrist"]` on the
+  model or the call to fix the mapping once. A single frame goes to the
+  first slot. Missing slots are legal for families that tolerate them.
+- `state` is the proprioceptive vector `(D_state,)`. A callable is called
+  once per frame and must return that vector; this is how a live source
+  becomes a closed loop without LibreYOLO owning a robot driver. `None`
+  substitutes zeros and logs one warning: the call runs, the actions are
+  not meaningful.
+- `instruction` is the task text. `set_instruction(text)` makes it sticky,
+  the way `set_classes` and `set_query` work on the other tiers. A call
+  with neither raises.
+- `reset()` clears any family-side action queue between episodes.
+
+Depth, tactile, audio and multi-step observation histories are not part of
+this version. They enter as additional named observation entries without
+changing the call shape.
+
+## Training, validation, checkpoints
+
+`train(data=..., epochs=..., batch=..., lr0=..., ...)` fine-tunes on a
+LeRobot dataset (a Hub repo id or a local directory in the LeRobot v3
+layout). There is no LibreYOLO dataset YAML for `act`: the LeRobot format
+already is the interchange format of the field, and inventing a second one
+would only lose users. The trainer:
+
+- splits held-out episodes off the end for validation (`val_split`, default
+  10 percent of episodes, or explicit `val_episodes`),
+- builds the policy from the pinned base with the dataset's feature shapes
+  and statistics through the upstream factory,
+- runs a compact epoch loop with the family's optimizer and schedule
+  presets, gradient clipping and best/last checkpoints,
+- emits the standard training callbacks and loggers,
+- returns the standard results dict with `save_dir`, `best`, `last`.
+
+`val(data=..., split=...)` reports offline action error on held-out
+episodes: mean L1 and MSE between predicted and recorded action chunks,
+overall and per dimension, in the dataset's units. This is the metric the
+VLA papers report for offline evaluation, it needs no robot, and it is what
+CI can run. It is not a success rate. Simulator success (LIBERO through
+`lerobot[libero]`) and real-robot evaluation are the next rungs and land
+behind the same `val()` surface with a `sim=` argument; they are out of
+scope here.
+
+A VLA checkpoint is a directory, not a `.pt`: the upstream policy files,
+the saved pre and post processors, and `libreyolo_vla.json` recording
+family, size, base repo and revision, the dataset, action names and the
+control rate. `LibreVLA(path)` loads it and restores the instruction-free
+default. Schema-v1 `.pt` metadata does not apply.
+
+`export()` raises. The flow-matching action expert has no exportable
+graph contract yet; adding one is a later ADR.
+
+## Public API
+
+```python
+from libreyolo import LibreVLA
+
+model = LibreVLA()                                   # smolvla-base, autodownloads
+model.set_instruction("pick up the red cube")
+result = model.predict(frame, state=q)               # one chunk
+result.actions.data                                  # (50, 6)
+result.actions.first                                 # (6,) the next action
+result.actions.names                                 # per-dimension names
+
+result = model.predict({"front": a, "wrist": b}, state=q)   # several cameras
+
+for result in model.predict(0, state=robot.read, stream=True):   # closed loop
+    robot.send(result.actions.first)
+
+results = model.train(data="lerobot/svla_so101_pickplace", epochs=5)
+model = LibreVLA(results["best"])
+model.val(data="lerobot/svla_so101_pickplace")       # offline action error
+```
+
+Install: `pip install "libreyolo[vla]"`. The extra requires Python 3.12 or
+newer because `lerobot` does; on older interpreters the extra installs
+nothing and the tier raises an `ImportError` that says so. The extra stays
+out of `all` for the same reason.
+
+## Families
+
+| Alias | Upstream | License | Status |
+| --- | --- | --- | --- |
+| `smolvla-base` (default) | `lerobot/smolvla_base` | Apache-2.0 | shipped |
+| `pi0`, `pi05` | `lerobot/pi0_base`, `lerobot/pi05_base` | Gemma terms on the PaliGemma base | reserved, not an alias yet |
+| `molmoact2` | `allenai/MolmoAct2-*-LeRobot` | Apache-2.0 | reserved, not an alias yet |
+| `xvla`, `groot` | lerobot policies | see upstream | reserved, not an alias yet |
+
+Reserved names raise with a message rather than resolving, the way
+LibreGround handles unverified families. A family becomes an alias when its
+adapter is load-tested against a real checkpoint.
+
+## Licensing
+
+LibreYOLO ships only its own adapter, trainer, metric and payload code. The
+policy loads through the Apache-2.0 `lerobot` API. Weights are downloaded
+from the upstream Hub repo at a pinned revision; LibreYOLO does not
+redistribute them. The SmolVLA base backbone (SmolVLM2-500M) is Apache-2.0.
+
+## Out of scope
+
+- Robot drivers, motor buses, cameras: the library returns actions.
+- Simulators and real-robot rollouts in CI.
+- Export, tracking, tiling, TTA.
+- A CLI verb. The tier is a Python-API surface in this version, as the
+  VLM tier was in its first version.
+- A reinforcement-learning loop. The trainer is imitation only.
+
+## Consequences
+
+Positive: robot policies get the same three-line experience as every other
+task, with training and offline evaluation included; the tier is fully
+isolated from the detector factory; a new family is a small adapter over a
+lerobot policy class; the observation and action contracts are fixed before
+the first simulator or robot integration lands, so those can be added
+without changing what users already wrote.
+
+Negative: a second optional heavyweight dependency with its own Python
+floor; offline action error is a proxy metric; CPU inference is seconds per
+chunk, so live control needs a GPU.

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -33,7 +33,9 @@ Required field meanings:
 - `size`: model variant within the family, such as `t`, `s`, `r18`, or `atto`.
 - `task`: canonical task, one of `detect`, `segment`, `semantic`, `panoptic`,
   `pose`, `classify`, `gaze`, `obb`, `point`, `depth`, `edge`, `normal`, `albedo`, `restore`,
-  `matte`, `ocr`, `embed`, `mesh`, `detect3d`, or `act`.
+  `matte`, `ocr`, `embed`, `mesh`, or `detect3d`. The `act` task has no
+  schema-v1 `.pt` form; its checkpoints are directories (see "Optional
+  LibreVLA runtime").
 - `nc`: positive integer class count.
 - `names`: `dict[int, str]` with keys in `0..nc-1`. Official checkpoints
   should write every key. Readers may pad missing keys with `class_i` labels for

--- a/docs/checkpoint_schema.md
+++ b/docs/checkpoint_schema.md
@@ -33,7 +33,7 @@ Required field meanings:
 - `size`: model variant within the family, such as `t`, `s`, `r18`, or `atto`.
 - `task`: canonical task, one of `detect`, `segment`, `semantic`, `panoptic`,
   `pose`, `classify`, `gaze`, `obb`, `point`, `depth`, `edge`, `normal`, `albedo`, `restore`,
-  `matte`, `ocr`, `embed`, `mesh`, or `detect3d`.
+  `matte`, `ocr`, `embed`, `mesh`, `detect3d`, or `act`.
 - `nc`: positive integer class count.
 - `names`: `dict[int, str]` with keys in `0..nc-1`. Official checkpoints
   should write every key. Readers may pad missing keys with `class_i` labels for
@@ -416,6 +416,16 @@ wrap_libreyolo_checkpoint(...)
 unwrap_libreyolo_checkpoint(...)
 validate_checkpoint_metadata(...)
 ```
+
+### Optional LibreVLA runtime
+
+The `act` task reserves the suffix `-act`. `LibreVLA` checkpoints are
+directories, not schema-v1 `.pt` files: the upstream policy files, the saved
+pre and post processor pipelines, and `libreyolo_vla.json` (schema 1) with
+`family`, `size`, `base_repo`, `base_revision`, `data`, `fps`, `cameras`,
+`action_names`, `state_names`, `chunk_size` and `libreyolo_version`. The
+base snapshot is pinned to a Hub commit and never converted. See
+`docs/librevla.md` and ADR 0028.
 
 ### Optional WildDet3D runtime
 

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -115,6 +115,7 @@ in preflight.
 | showui | point |  |  |  |  |  |  |  |  |  |  |  |  |
 | siglip2 | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  | ✓ |
 | siglip2 | embed | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
+| smolvla | act |  |  |  |  |  |  |  |  |  |  |  |  |
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | ssd | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
 | swin | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
@@ -141,7 +142,6 @@ in preflight.
 | yolonas | obb | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | yolox | detect | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ | ✓ | available | ✓ |
 | zipdepth | depth | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ |  |  | ✓ |
-| smolvla | act |  |  |  |  |  |  |  |  |  |  |  |  |
 
 ## Parity thresholds
 
@@ -1520,6 +1520,18 @@ These converter paths are callable with the recorded validation context.
 - `siglip2` / `embed` / `ncnn`: PNNX 20260526 leaves unsupported pnnx.Expression nodes in the SigLIP2 attention graph, so the generated NCNN network has no runnable input.
 - `siglip2` / `embed` / `coreml`: No parity-valid embedding artifact is available for this runtime.
 - `siglip2` / `embed` / `coreai`: No parity-valid embedding artifact is available for this runtime.
+- `smolvla` / `act` / `onnx`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `torchscript`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `executorch`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `tensorrt`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `openvino`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `paddle`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `mnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `rknn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `ncnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `tflite`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `coreml`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `coreai`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
 - `smolvlm2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
@@ -1682,15 +1694,3 @@ These converter paths are callable with the recorded validation context.
 - `zipdepth` / `depth` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `zipdepth` / `depth` / `tflite`: onnx2tf 2.6.7 flatbuffer-direct conversion does not support the edge-mode Pad operation in ZipDepth's convex upsampler.
 - `zipdepth` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
-- `smolvla` / `act` / `onnx`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `torchscript`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `executorch`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `tensorrt`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `openvino`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `paddle`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `mnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `rknn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `ncnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `tflite`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `coreml`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `coreai`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -115,7 +115,6 @@ in preflight.
 | showui | point |  |  |  |  |  |  |  |  |  |  |  |  |
 | siglip2 | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  | ✓ |
 | siglip2 | embed | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
-| smolvla | act |  |  |  |  |  |  |  |  |  |  |  |  |
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | ssd | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
 | swin | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
@@ -142,6 +141,7 @@ in preflight.
 | yolonas | obb | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | yolox | detect | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ | ✓ | available | ✓ |
 | zipdepth | depth | ✓ | ✓ | ✓ | available | ✓ |  |  |  | ✓ |  |  | ✓ |
+| smolvla | act |  |  |  |  |  |  |  |  |  |  |  |  |
 
 ## Parity thresholds
 
@@ -1520,18 +1520,6 @@ These converter paths are callable with the recorded validation context.
 - `siglip2` / `embed` / `ncnn`: PNNX 20260526 leaves unsupported pnnx.Expression nodes in the SigLIP2 attention graph, so the generated NCNN network has no runnable input.
 - `siglip2` / `embed` / `coreml`: No parity-valid embedding artifact is available for this runtime.
 - `siglip2` / `embed` / `coreai`: No parity-valid embedding artifact is available for this runtime.
-- `smolvla` / `act` / `onnx`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `torchscript`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `executorch`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `tensorrt`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `openvino`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `paddle`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `mnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `rknn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `ncnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `tflite`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `coreml`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
-- `smolvla` / `act` / `coreai`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
 - `smolvlm2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `executorch`: Generative VLM export is out of scope for v1.
@@ -1694,3 +1682,15 @@ These converter paths are callable with the recorded validation context.
 - `zipdepth` / `depth` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
 - `zipdepth` / `depth` / `tflite`: onnx2tf 2.6.7 flatbuffer-direct conversion does not support the edge-mode Pad operation in ZipDepth's convex upsampler.
 - `zipdepth` / `depth` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
+- `smolvla` / `act` / `onnx`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `torchscript`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `executorch`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `tensorrt`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `openvino`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `paddle`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `mnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `rknn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `ncnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `tflite`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `coreml`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `coreai`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -115,6 +115,7 @@ in preflight.
 | showui | point |  |  |  |  |  |  |  |  |  |  |  |  |
 | siglip2 | classify | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  | ✓ |
 | siglip2 | embed | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
+| smolvla | act |  |  |  |  |  |  |  |  |  |  |  |  |
 | smolvlm2 | detect |  |  |  |  |  |  |  |  |  |  |  |  |
 | ssd | detect | ✓ |  |  |  |  |  |  |  |  |  |  |  |
 | swin | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
@@ -1519,6 +1520,18 @@ These converter paths are callable with the recorded validation context.
 - `siglip2` / `embed` / `ncnn`: PNNX 20260526 leaves unsupported pnnx.Expression nodes in the SigLIP2 attention graph, so the generated NCNN network has no runnable input.
 - `siglip2` / `embed` / `coreml`: No parity-valid embedding artifact is available for this runtime.
 - `siglip2` / `embed` / `coreai`: No parity-valid embedding artifact is available for this runtime.
+- `smolvla` / `act` / `onnx`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `torchscript`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `executorch`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `tensorrt`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `openvino`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `paddle`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `mnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `rknn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `ncnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `tflite`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `coreml`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `smolvla` / `act` / `coreai`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
 - `smolvlm2` / `detect` / `onnx`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `torchscript`: Generative VLM export is out of scope for v1.
 - `smolvlm2` / `detect` / `executorch`: Generative VLM export is out of scope for v1.

--- a/docs/librevla.md
+++ b/docs/librevla.md
@@ -1,0 +1,149 @@
+# LibreVLA
+
+`LibreVLA` runs vision-language-action (VLA) policies: camera frames plus the
+robot's state plus an instruction in, an action chunk out. It is the
+perception-to-control layer of a robot stack, behind the same three lines as
+every other LibreYOLO task. The contract lives in
+`docs/adr/0028-librevla-contract.md`.
+
+The library returns actions. It does not drive motors, own cameras or run a
+simulator. Those sit on either side of the call.
+
+## Install
+
+```bash
+pip install "libreyolo[vla]"
+```
+
+The extra pulls the Apache-2.0 `lerobot` package, which needs Python 3.12 or
+newer. On an older interpreter the extra installs nothing and the tier
+raises an `ImportError` that says so. Importing `LibreVLA` never imports
+`lerobot`; it loads on first use.
+
+## Predict
+
+```python
+from libreyolo import LibreVLA
+
+model = LibreVLA()                                   # smolvla-base, autodownloads
+model.set_instruction("pick up the red cube")        # sticky, like set_classes
+result = model.predict(frame, state=q)               # one observation
+
+result.actions.data                                  # (50, 6) float32
+result.actions.first                                 # (6,) the action to send now
+result.actions.names                                 # per-dimension names, if known
+result.actions.fps                                   # control rate, if known
+result.plot(frame).save("chunk.png")                 # frame + trajectory strip
+```
+
+- `frame` is any LibreYOLO image input (path, PIL, NumPy BGR, tensor). It is
+  the original camera pixels; the policy's processor owns resize and
+  normalization.
+- `state` is the proprioceptive vector the policy was trained with (six
+  joint positions for the SmolVLA base). Pass a callable and it is read
+  once per frame. `None` runs with zeros and logs one warning: the call
+  works, the actions are not meaningful.
+- `instruction` can also be passed per call: `predict(frame, state=q,
+  instruction="open the drawer")`.
+
+Several cameras:
+
+```python
+result = model.predict({"front": a, "wrist": b}, state=q)
+model = LibreVLA(cameras=["front", "wrist"])          # fix the slot order once
+```
+
+A dict key equal to a policy slot (`camera1`, `camera2`, `camera3` on the
+base) takes that slot; other keys fill the free slots in order. `cameras=`
+pins the mapping by position. Fewer frames than slots is fine on SmolVLA.
+
+Folders, videos and streams replay open loop, one chunk per frame:
+
+```python
+results = model.predict("episode_frames/", state=q)             # list
+for r in model.predict("episode.mp4", state=q, stream=True):    # generator
+    ...
+for r in model.predict(0, state=robot.read, stream=True):       # webcam, closed loop
+    robot.send(r.actions.first)
+```
+
+`save=True` writes the rendered chunk under `runs/act/predict`. Call
+`model.reset()` between episodes to clear the policy's action queue.
+
+## Train
+
+```python
+results = model.train(data="lerobot/svla_so101_pickplace", epochs=5, batch=8)
+model = LibreVLA(results["best"])
+```
+
+- `data` is a LeRobot dataset: a Hub repo id or a local directory in the
+  LeRobot v3 layout. There is no LibreYOLO YAML for `act`; the LeRobot
+  format already is the interchange format of the field.
+- The last ten percent of episodes are held out for validation
+  (`val_split`), or pass `val_episodes=[...]` / `train_episodes=[...]`.
+- Dataset cameras map onto the policy's slots in order (`up` becomes
+  `camera1`, and so on). The checkpoint remembers the dataset's camera
+  names, so `predict({"up": frame})` works on the fine-tune.
+- `lr0` overrides the family's optimizer preset; `accumulate` scales the
+  effective batch; `max_steps` caps steps per epoch for smoke runs;
+  `callbacks=` and `loggers=` are the standard training layers.
+- Best and last checkpoints are directories under `runs/act/train/weights`,
+  selected on validation loss.
+
+The SmolVLA recipe trains the action expert with the vision backbone
+frozen, as upstream does. LoRA and full backbone training are not exposed
+yet.
+
+## Validate
+
+```python
+model.val(data="lerobot/svla_so101_pickplace")
+# {'val/action_l1': ..., 'val/action_mse': ..., 'val/action_l1_first': ...,
+#  'val/action_l1_dims': {'shoulder_pan.pos': ..., ...}, 'val/steps': ..., 'episodes': [...]}
+```
+
+Offline action error on held-out episodes, in the dataset's units: mean L1
+and MSE between predicted and recorded chunks, the first-step L1, and a
+per-dimension table. `split="train"` or `split="all"` change the episodes;
+`max_batches=` bounds the run. A fine-tune defaults to its own dataset.
+
+This is the proxy metric VLA papers report offline. It is not a success
+rate. Simulator and real-robot evaluation are the next rungs and will land
+behind the same `val()` surface.
+
+## Checkpoints
+
+A VLA checkpoint is a directory, not a `.pt`:
+
+```
+runs/act/train/weights/best/
+  config.json                       # upstream policy config
+  model.safetensors                 # policy weights
+  policy_preprocessor.json          # saved processor pipelines (+ stats)
+  policy_postprocessor.json
+  libreyolo_vla.json                # the contract file
+```
+
+`libreyolo_vla.json` records the family, size, base repo and pinned
+revision, the dataset, its control rate, the camera names in slot order,
+the action and state names, and the chunk size. `LibreVLA(path)` reads it
+and rebuilds the right family.
+
+## Families
+
+| Alias | Upstream | Weights | Notes |
+| --- | --- | --- | --- |
+| `smolvla-base` (default) | SmolVLA 450M (`lerobot/smolvla_base`) | Apache-2.0 | 3 camera slots, state 6, action 6, 50-step chunk |
+
+`pi0`, `pi05`, `molmoact2`, `xvla`, `groot` and `openvla` are reserved names
+that raise with a message until an adapter is load-tested. Adding a family
+is a small class over its lerobot policy: see `libreyolo/models/vla/smolvla.py`.
+
+## Limits
+
+- CPU inference is seconds per chunk; live control needs a GPU. The base
+  checkpoint takes a couple of minutes to load the first time.
+- `export()`, `track()`, tiling and TTA raise.
+- No CLI verb in this version; the tier is a Python-API surface.
+- The trainer is imitation learning only.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -342,6 +342,7 @@ From `libreyolo/tasks.py`:
 | `embed`       | `-embed` |
 | `mesh`        | `-mesh` |
 | `detect3d`    | `-detect3d` |
+| `act`         | `-act` |
 
 The factory accepts selected upstream-style aliases (`detection`, `det`,
 `segmentation`, `keypoints`, `cls`, …) at the API boundary; only the canonical
@@ -995,6 +996,22 @@ Example: `yolo9_p2` declares `("visdrone",)`, so `LibreYOLO9P2s-visdrone.pt`
 resolves the Hugging Face repo `LibreYOLO/LibreYOLO9P2s-visdrone` (a research
 preview under VisDrone's CC BY-NC-SA license, announced by a download notice).
 Plain COCO-default weights never carry a variant suffix.
+
+## Vision-language-action policies
+
+`LibreSmolVLA` (`smolvla`, coverage group `s`) is a sibling API wrapping the
+SmolVLA policy through the optional `lerobot` runtime (`libreyolo[vla]`,
+Python 3.12+). It uses `act`, with aliases `action`, `actions`, `vla`,
+`policy` and `robot-policy`. Its base checkpoint is size `base`, pinned to a
+`lerobot/smolvla_base` commit and downloaded into `weights/LibreSmolVLAbase/`
+as a snapshot directory; it is not a `.pt` and is not registered in the
+`LibreYOLO(...)` state-dict factory.
+
+`Results.actions` stores the `(T, D)` action chunk with its per-dimension
+names, control rate and instruction. Fine-tunes written by `train()` are
+directories carrying `libreyolo_vla.json`; `LibreVLA(path)` reloads them.
+There is no CLI verb in this version. See ADR 0028 for the observation and
+action contracts and the explicit scope.
 
 ## Promptable 3D detection
 

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -101,6 +101,7 @@ _RESULTS_EXPORTS = (
     "Results",
     "Boxes",
     "Boxes3D",
+    "Actions",
     "Masks",
     "Keypoints",
     "Points",
@@ -198,6 +199,8 @@ def __getattr__(name):
         "OCSortTracker": (".tracking", "OCSortTracker"),
         "OCSortConfig": (".tracking", "OCSortConfig"),
         "LibreLLM": (".models.llm", "LibreLLM"),
+        "LibreVLA": (".models.vla", "LibreVLA"),
+        "LibreSmolVLA": (".models.vla", "LibreSmolVLA"),
         "LibreVLM": (".models.vlm", "LibreVLM"),
         "LibreLFM2VL": (".models.vlm", "LibreLFM2VL"),
         "LibreQwen3VL": (".models.vlm", "LibreQwen3VL"),
@@ -366,6 +369,9 @@ __all__ = [
     "LibreModus",
     # OpenAI-compatible LLM client (optional, requires libreyolo[llm])
     "LibreLLM",
+    # Vision-language-action tier (optional, requires libreyolo[vla])
+    "LibreVLA",
+    "LibreSmolVLA",
     # Calibrated native monocular 3D detection
     "LibreFCOS3D",
     # Promptable 3D detection (separately installed upstream runtime)
@@ -389,6 +395,7 @@ __all__ = [
     "Results",
     "Boxes",
     "Boxes3D",
+    "Actions",
     "Masks",
     "Keypoints",
     "Points",

--- a/libreyolo/export/support.py
+++ b/libreyolo/export/support.py
@@ -3676,6 +3676,10 @@ _add(
 
 _TASK_BLOCKS = {
     "albedo": "Albedo export does not yet have a linear-RGB backend runtime contract.",
+    "act": (
+        "Action-chunk export is blocked until the policy sampling loop has an "
+        "exportable graph and backend runtime contract (ADR 0028)."
+    ),
     "detect3d": (
         "3D detection export is blocked until its graph outputs, camera metadata, "
         "and backend runtime contract are defined."

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -48,6 +48,7 @@ OPTIONAL_MODELS = (
     ("libreyolo.models.vlm.qwen3vl", "LibreQwen3VL", "vlm", "transformers"),
     ("libreyolo.models.vlm.smolvlm", "LibreSmolVLM2", "vlm", "transformers"),
     ("libreyolo.models.ground.showui", "LibreShowUI", "vlm", "transformers"),
+    ("libreyolo.models.vla.smolvla", "LibreSmolVLA", "vla", "lerobot"),
     (
         "libreyolo.models.ground.florence",
         "LibreGroundFlorence2",

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -135,6 +135,7 @@ MODEL_GROUPS: dict[str, str] = {
     "ground_qwen3vl": "s",
     "showui": "s",
     "smolvlm2": "s",
+    "smolvla": "s",
     "clip": "s",
     "siglip2": "s",
     "libremodus": "s",

--- a/libreyolo/models/vla/__init__.py
+++ b/libreyolo/models/vla/__init__.py
@@ -1,0 +1,102 @@
+"""LibreVLA: vision-language-action policies behind the LibreYOLO surface.
+
+User-facing entry point is the ``LibreVLA(...)`` factory, a sibling to
+``LibreYOLO(...)`` and ``LibreVLM(...)``. Frames plus the robot state plus an
+instruction go in; an action chunk comes out as ``Results.actions``.
+
+    from libreyolo import LibreVLA
+
+    model = LibreVLA()                                   # smolvla-base, autodownloads
+    model.set_instruction("pick up the red cube")
+    result = model.predict(frame, state=q)               # Results.actions is (T, D)
+    result.actions.first                                 # the next action
+
+    results = model.train(data="lerobot/svla_so101_pickplace", epochs=5)
+    model = LibreVLA(results["best"])
+
+See ``docs/librevla.md`` and ``docs/adr/0028-librevla-contract.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple, Type
+
+from .base import LibreVLAModel
+from .checkpoint import CONTRACT_FILENAME, is_vla_checkpoint, read_contract
+from .smolvla import LibreSmolVLA
+
+# alias -> (family class, size)
+_ALIASES: Dict[str, Tuple[Type[LibreVLAModel], str]] = {
+    "smolvla": (LibreSmolVLA, "base"),
+    "smolvla-base": (LibreSmolVLA, "base"),
+}
+
+# Families lerobot ships that are not factory aliases until an adapter is
+# load-tested against the real checkpoint (ADR 0028 "Families").
+_RESERVED_ALIASES: Dict[str, str] = {
+    "pi0": "pi0 is reserved: the adapter lands once it is load-tested. Its PaliGemma base is under Gemma terms.",
+    "pi0-base": "pi0 is reserved: the adapter lands once it is load-tested. Its PaliGemma base is under Gemma terms.",
+    "pi05": "pi0.5 is reserved: the adapter lands once it is load-tested.",
+    "pi0.5": "pi0.5 is reserved: the adapter lands once it is load-tested.",
+    "molmoact2": "MolmoAct2 is reserved: the adapter lands once it is load-tested.",
+    "molmoact": "MolmoAct is reserved: the adapter lands once it is load-tested.",
+    "xvla": "X-VLA is reserved: the adapter lands once it is load-tested.",
+    "groot": "GR00T is reserved: the adapter lands once it is load-tested.",
+    "groot-n1.5": "GR00T is reserved: the adapter lands once it is load-tested.",
+    "openvla": "OpenVLA is reserved: it loads through transformers remote code, not lerobot; adapter later.",
+}
+
+_DEFAULT_MODEL = "smolvla-base"
+
+
+def _load_checkpoint(path, **kwargs) -> LibreVLAModel:
+    """Load a fine-tune checkpoint directory produced by ``train()``."""
+    contract = read_contract(path)
+    family_classes = {cls.FAMILY: cls for cls, _size in _ALIASES.values()}
+    family_cls = family_classes.get(contract["family"])
+    if family_cls is None:
+        raise ValueError(
+            f"VLA checkpoint {path} was trained on unknown family "
+            f"{contract['family']!r}; this libreyolo build knows "
+            f"{sorted(family_classes)}."
+        )
+    return family_cls(size=contract["size"], checkpoint_dir=str(path), **kwargs)
+
+
+def LibreVLA(model: str = _DEFAULT_MODEL, **kwargs) -> LibreVLAModel:
+    """Load a vision-language-action policy by alias or checkpoint path.
+
+    Args:
+        model: Alias (``"smolvla-base"``) or a path to a checkpoint directory
+            produced by ``train()`` (it carries ``libreyolo_vla.json``).
+        **kwargs: Forwarded to the family constructor: ``device``,
+            ``instruction`` (sticky task text), ``cameras`` (user camera
+            names in slot order).
+
+    Returns:
+        A ``LibreVLAModel`` with ``predict`` / ``train`` / ``val``.
+    """
+    if is_vla_checkpoint(model):
+        return _load_checkpoint(model, **kwargs)
+    key = str(model).strip().lower().replace("_", "-")
+    reserved = _RESERVED_ALIASES.get(key)
+    if reserved is not None:
+        raise ValueError(reserved)
+    match = _ALIASES.get(key)
+    if match is None:
+        raise ValueError(
+            f"Unknown VLA model {model!r}. Known aliases: "
+            f"{', '.join(sorted(set(_ALIASES)))}."
+        )
+    family_cls, size = match
+    return family_cls(size=size, **kwargs)
+
+
+__all__ = [
+    "CONTRACT_FILENAME",
+    "LibreVLA",
+    "LibreVLAModel",
+    "LibreSmolVLA",
+    "is_vla_checkpoint",
+    "read_contract",
+]

--- a/libreyolo/models/vla/base.py
+++ b/libreyolo/models/vla/base.py
@@ -1,0 +1,668 @@
+"""Base class for the ``LibreVLA`` tier: vision-language-action policies.
+
+A VLA policy takes camera frames, the robot's proprioceptive state and an
+instruction, and returns an action chunk: the next ``T`` actions of ``D``
+dimensions each. This base owns everything LibreYOLO promises about that
+(ADR 0028): the observation contract (``observation.py``), the ``Results``
+with an ``Actions`` payload, source handling for frames, folders, videos and
+live streams, the checkpoint directory contract, and the ``train`` / ``val``
+surface. Families implement four small hooks over their upstream policy
+API. The tier is a sibling of ``LibreVLM``: it is not a ``BaseModel`` and
+never enters the state-dict factory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from PIL import Image
+
+from ...utils.image_loader import SUPPORTED_EXTENSIONS, ImageInput
+from ...utils.results import Actions, Results
+from ...utils.source import SourceKind, build_stream_source, classify_source
+from .checkpoint import read_contract
+from .observation import Observation, coerce_state, load_frames, map_cameras
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "LibreVLA models require the 'vla' extra and Python 3.12 or newer "
+    "(the lerobot package's floor). Install with:\n"
+    "    pip install 'libreyolo[vla]'"
+)
+_SNAPSHOT_COMPLETE_MARKER = ".libreyolo_snapshot_complete"
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_UNSUPPORTED_TASK = "LibreVLA models solve the 'act' task only."
+
+
+class LibreVLAModel:
+    """Vision-language-action policy behind the LibreYOLO predict surface."""
+
+    FAMILY: ClassVar[str] = ""
+    FILENAME_PREFIX: ClassVar[str] = ""
+    HF_REPOS: ClassVar[Dict[str, str]] = {}
+    HF_REVISIONS: ClassVar[Dict[str, str]] = {}
+    # Nominal per-size resize the family applies; the processor owns resize.
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {}
+    TASK_INPUT_SIZES: ClassVar[Dict[str, Dict[str, int]]] = {}
+    SUPPORTED_TASKS: ClassVar[Tuple[str, ...]] = ("act",)
+    DEFAULT_TASK: ClassVar[str] = "act"
+    SNAPSHOT_ALLOW_PATTERNS: ClassVar[Tuple[str, ...]] = (
+        "*.json",
+        "*.safetensors",
+        "README.md",
+    )
+    TRAINABLE: ClassVar[bool] = True
+    TRAIN_UNSUPPORTED_REASON: ClassVar[str] = ""
+    _LICENSE_NOTICE: ClassVar[str] = ""
+    _LICENSE_NOTICE_SHOWN: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        size: str,
+        *,
+        device: str = "auto",
+        task: str | None = None,
+        instruction: Optional[str] = None,
+        cameras: Optional[Sequence[str]] = None,
+        checkpoint_dir: Optional[str] = None,
+        **kwargs,
+    ):
+        if size not in self.HF_REPOS:
+            raise ValueError(
+                f"Invalid size {size!r} for {type(self).__name__}. "
+                f"Must be one of: {', '.join(self.HF_REPOS)}"
+            )
+        from ...tasks import normalize_task
+
+        resolved_task = normalize_task(task, default=self.DEFAULT_TASK)
+        if resolved_task not in self.SUPPORTED_TASKS:
+            raise ValueError(f"{_UNSUPPORTED_TASK} Got task={task!r}.")
+        self.task = resolved_task
+        self.family = self.FAMILY
+        self.size = size
+        self.device = self._resolve_device(device)
+        self.input_size = self.INPUT_SIZES.get(size)
+        self.names: Dict[int, str] = {}
+        self.instruction: Optional[str] = None
+        if instruction is not None:
+            self.set_instruction(instruction)
+        self.cameras: Optional[List[str]] = (
+            [str(c) for c in cameras] if cameras is not None else None
+        )
+        self._checkpoint_dir: Optional[Path] = (
+            Path(checkpoint_dir) if checkpoint_dir else None
+        )
+        self.contract: Dict[str, Any] = {}
+        if self._checkpoint_dir is not None:
+            self.contract = read_contract(self._checkpoint_dir)
+            if self.contract.get("family") != self.FAMILY:
+                raise ValueError(
+                    f"{self._checkpoint_dir} was trained on family "
+                    f"{self.contract.get('family')!r}, not {self.FAMILY!r}."
+                )
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self._policy = None
+        self._preprocessor = None
+        self._postprocessor = None
+        self._state_warned = False
+        self.model_path: Optional[str] = (
+            str(self._checkpoint_dir) if self._checkpoint_dir else self.HF_REPOS[size]
+        )
+
+    # ------------------------------------------------------------------
+    # Family hooks
+    # ------------------------------------------------------------------
+
+    def _load_policy(self, snapshot_dir: str) -> None:
+        """Load the upstream policy and processors from ``snapshot_dir``.
+
+        Must set ``self._policy`` (an ``nn.Module`` in eval mode on
+        ``self.device``) and may set ``self._preprocessor`` /
+        ``self._postprocessor``.
+        """
+        raise NotImplementedError
+
+    def _predict_chunk(self, observation: Observation) -> Any:
+        """Return the ``(T, D)`` action chunk for one observation."""
+        raise NotImplementedError
+
+    def _pretrained_config(self, snapshot_dir: str) -> Any:
+        """Return the upstream policy config stored in ``snapshot_dir``."""
+        raise NotImplementedError
+
+    @property
+    def camera_slots(self) -> List[str]:
+        """Ordered camera slot names the loaded policy expects."""
+        raise NotImplementedError
+
+    @property
+    def state_dim(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def action_dim(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def chunk_size(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def action_names(self) -> Optional[List[str]]:
+        return self.contract.get("action_names") if self.contract else None
+
+    @property
+    def fps(self) -> Optional[float]:
+        return self.contract.get("fps") if self.contract else None
+
+    # ------------------------------------------------------------------
+    # Instruction and lifecycle
+    # ------------------------------------------------------------------
+
+    def set_instruction(self, instruction: str) -> "LibreVLAModel":
+        """Set the sticky task instruction used by later ``predict`` calls."""
+        if not isinstance(instruction, str) or not instruction.strip():
+            raise ValueError("instruction must be a non-empty string.")
+        self.instruction = instruction.strip()
+        return self
+
+    def set_classes(self, *args, **kwargs):
+        raise AttributeError(
+            f"{type(self).__name__} has no class vocabulary. Use "
+            "set_instruction(text) to tell the policy what to do."
+        )
+
+    def reset(self) -> None:
+        """Clear any family-side action queue between episodes."""
+        policy = self._policy
+        if policy is not None and hasattr(policy, "reset"):
+            policy.reset()
+
+    @property
+    def model(self):
+        """The loaded upstream policy module (loads on first access)."""
+        self._ensure_loaded()
+        return self._policy
+
+    def _ensure_loaded(self) -> None:
+        if self._policy is None:
+            self._load_policy(self._ensure_weights())
+
+    @staticmethod
+    def _resolve_device(device: Any):
+        import torch
+
+        if device == "auto":
+            return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if isinstance(device, int) or (isinstance(device, str) and device.isdigit()):
+            return torch.device(f"cuda:{device}")
+        return torch.device(device)
+
+    def to(self, device) -> "LibreVLAModel":
+        self.device = self._resolve_device(device)
+        if self._policy is not None:
+            self._policy.to(self.device)
+        return self
+
+    def info(self, verbose: bool = True) -> Dict[str, Any]:
+        data = {
+            "family": self.FAMILY,
+            "size": self.size,
+            "task": self.task,
+            "device": str(self.device),
+            "instruction": self.instruction,
+            "checkpoint": str(self._checkpoint_dir) if self._checkpoint_dir else None,
+        }
+        if verbose:
+            logger.info(json.dumps(data, indent=2))
+        return data
+
+    # ------------------------------------------------------------------
+    # Weights
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        """Hub URL of the pinned snapshot behind ``Libre<Prefix><size>``.
+
+        VLA weights are snapshot directories, not ``.pt`` files, so this
+        returns the upstream repository tree at the pinned revision.
+        """
+        stem = str(filename)
+        for ext in (".pt", ".safetensors"):
+            if stem.endswith(ext):
+                stem = stem[: -len(ext)]
+        if not cls.FILENAME_PREFIX or not stem.startswith(cls.FILENAME_PREFIX):
+            return None
+        size = stem[len(cls.FILENAME_PREFIX) :]
+        repo = cls.HF_REPOS.get(size)
+        if repo is None:
+            return None
+        revision = cls.HF_REVISIONS.get(size) or "main"
+        return f"https://huggingface.co/{repo}/tree/{revision}"
+
+    @classmethod
+    def _notify_license_once(cls) -> None:
+        if cls._LICENSE_NOTICE and not cls._LICENSE_NOTICE_SHOWN:
+            cls._LICENSE_NOTICE_SHOWN = True
+            logger.warning(cls._LICENSE_NOTICE)
+
+    @staticmethod
+    def _snapshot_complete(
+        local_dir: Path, *, repo: str, revision: Optional[str]
+    ) -> bool:
+        marker = local_dir / _SNAPSHOT_COMPLETE_MARKER
+        if not marker.is_file():
+            return False
+        try:
+            recorded = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return False
+        if recorded.get("repo") != repo or recorded.get("revision") != revision:
+            return False
+        has_config = (local_dir / "config.json").is_file()
+        has_weights = any(local_dir.glob("*.safetensors"))
+        return has_config and has_weights
+
+    def _ensure_weights(self) -> str:
+        """Return a local policy dir, downloading the pinned snapshot if needed."""
+        if self._checkpoint_dir is not None:
+            return str(self._checkpoint_dir)
+        repo = self.HF_REPOS[self.size]
+        revision = self.HF_REVISIONS.get(self.size)
+        if revision is not None and not _COMMIT_SHA_RE.fullmatch(revision):
+            raise ValueError(
+                f"{type(self).__name__}.HF_REVISIONS[{self.size!r}] must be a "
+                "40-char commit SHA."
+            )
+        local_dir = Path("weights") / f"{self.FILENAME_PREFIX}{self.size}"
+        self._notify_license_once()
+        if self._snapshot_complete(local_dir, repo=repo, revision=revision):
+            return str(local_dir)
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise ImportError(_INSTALL_HINT) from exc
+        source = f"{repo}@{revision}" if revision else repo
+        logger.info(
+            "Downloading %s weights from %s -> %s ...", self.FAMILY, source, local_dir
+        )
+        download_kwargs: Dict[str, Any] = {}
+        if revision is not None:
+            download_kwargs["revision"] = revision
+        snapshot_download(
+            repo,
+            local_dir=str(local_dir),
+            allow_patterns=list(self.SNAPSHOT_ALLOW_PATTERNS),
+            **download_kwargs,
+        )
+        (local_dir / _SNAPSHOT_COMPLETE_MARKER).write_text(
+            json.dumps({"repo": repo, "revision": revision}) + "\n", encoding="utf-8"
+        )
+        if not self._snapshot_complete(local_dir, repo=repo, revision=revision):
+            (local_dir / _SNAPSHOT_COMPLETE_MARKER).unlink(missing_ok=True)
+            raise FileNotFoundError(
+                f"Downloaded snapshot for {repo} is missing config.json or "
+                f"safetensors files in {local_dir}."
+            )
+        return str(local_dir)
+
+    # ------------------------------------------------------------------
+    # Predict
+    # ------------------------------------------------------------------
+
+    def _warn_state(self, message: str) -> None:
+        if not self._state_warned:
+            self._state_warned = True
+            logger.warning(message)
+
+    def _resolve_instruction(self, instruction: Optional[str]) -> str:
+        text = instruction if instruction is not None else self.instruction
+        if not text or not str(text).strip():
+            raise ValueError(
+                "No instruction given. Pass instruction='...' to predict() or "
+                "call set_instruction('...') once."
+            )
+        return str(text).strip()
+
+    def _build_observation(
+        self,
+        frames: Dict[str, Any],
+        state: Any,
+        instruction: str,
+        *,
+        cameras: Optional[Sequence[str]],
+        color_format: str,
+        path: Optional[str] = None,
+        frame_idx: Optional[int] = None,
+    ) -> Observation:
+        mapped = map_cameras(frames, self.camera_slots, cameras)
+        loaded = load_frames(mapped, color_format=color_format)
+        vector = coerce_state(state, self.state_dim, warn=self._warn_state)
+        return Observation(loaded, vector, instruction, path=path, frame_idx=frame_idx)
+
+    def _result(self, observation: Observation, chunk: Any) -> Results:
+        import torch
+
+        data = torch.as_tensor(chunk).detach().cpu().float()
+        if data.ndim == 3:
+            if data.shape[0] != 1:
+                raise ValueError(
+                    f"{type(self).__name__} returned a batch of {data.shape[0]} "
+                    "chunks for one observation."
+                )
+            data = data[0]
+        primary = observation.primary
+        shape = (primary.height, primary.width)
+        actions = Actions(
+            data,
+            shape,
+            names=self.action_names,
+            fps=self.fps,
+            instruction=observation.instruction,
+        )
+        return Results(
+            None,
+            shape,
+            path=observation.path,
+            names={},
+            frame_idx=observation.frame_idx,
+            actions=actions,
+        )
+
+    def _predict_one(
+        self,
+        frames: Dict[str, Any],
+        state: Any,
+        instruction: str,
+        *,
+        cameras: Optional[Sequence[str]],
+        color_format: str,
+        path: Optional[str] = None,
+        frame_idx: Optional[int] = None,
+    ) -> Results:
+        self._ensure_loaded()
+        observation = self._build_observation(
+            frames,
+            state,
+            instruction,
+            cameras=cameras,
+            color_format=color_format,
+            path=path,
+            frame_idx=frame_idx,
+        )
+        chunk = self._predict_chunk(observation)
+        result = self._result(observation, chunk)
+        result._libreyolo_frame = observation.primary  # for save=True
+        return result
+
+    def predict(
+        self,
+        source: Union[
+            ImageInput, Dict[str, ImageInput], int, Sequence[Any], None
+        ] = None,
+        *,
+        state: Any = None,
+        instruction: Optional[str] = None,
+        cameras: Optional[Sequence[str]] = None,
+        stream: bool = False,
+        save: bool = False,
+        output_path: Optional[str] = None,
+        vid_stride: int = 1,
+        stream_buffer: bool = False,
+        color_format: str = "auto",
+        **kwargs,
+    ) -> Union[Results, List[Results], Generator[Results, None, None]]:
+        """Predict an action chunk per observation.
+
+        Args:
+            source: One frame (any image input) for a single camera, a
+                ``{camera: frame}`` dict for several cameras, a list of
+                either, an image directory, a video file, a webcam index or
+                a stream URL (live sources need ``stream=True``).
+            state: The proprioceptive vector, or a callable returning it,
+                called once per frame. ``None`` uses zeros and warns.
+            instruction: The task text; else the sticky ``set_instruction``.
+            cameras: User camera names in slot order; fixes the mapping of
+                dict keys onto the family's camera slots.
+            stream: Return a generator instead of a list.
+            save: Write ``result.plot()`` renders under ``runs/act/predict``.
+            output_path: Explicit output file for a single observation.
+            vid_stride: Process every N-th frame of a video or stream.
+
+        Returns:
+            ``Results`` for one observation, a list for many, a generator
+            with ``stream=True``. Each result carries ``Results.actions``.
+        """
+        if kwargs:
+            logger.warning("Ignoring unknown predict() kwargs: %s", sorted(kwargs))
+        text = self._resolve_instruction(instruction)
+        cams = [str(c) for c in cameras] if cameras is not None else self.cameras
+        if output_path is not None and not save:
+            raise ValueError("output_path requires save=True.")
+        if source is None:
+            raise ValueError(
+                "predict() needs a source: a frame, a dict of frames, a folder, a video or a stream."
+            )
+        # One run directory per predict() call, like the shared runner.
+        self._save_dir = None
+
+        def one(frames, path=None, frame_idx=None):
+            return self._predict_one(
+                frames,
+                state,
+                text,
+                cameras=cams,
+                color_format=color_format,
+                path=path,
+                frame_idx=frame_idx,
+            )
+
+        # A single multi-camera observation.
+        if isinstance(source, dict):
+            result = one(source)
+            if save:
+                self._save_render(result, 0, output_path)
+            return result
+
+        spec = classify_source(source)
+        is_many = True
+        generator: Iterable[Results]
+
+        if spec.kind == SourceKind.IMAGE:
+            is_many = False
+            generator = iter(
+                [one({self.camera_slots[0]: source}, self._path_of(source))]
+            )
+        elif spec.kind == SourceKind.IMAGE_BATCH:
+            items = list(spec.items)
+            if not items:
+                raise ValueError("Empty source list.")
+
+            def batch_gen():
+                for idx, item in enumerate(items):
+                    frames = (
+                        item if isinstance(item, dict) else {self.camera_slots[0]: item}
+                    )
+                    yield one(frames, self._path_of(item), idx)
+
+            generator = batch_gen()
+        elif spec.kind == SourceKind.DIRECTORY:
+            paths = sorted(
+                p
+                for p in Path(source).iterdir()
+                if p.suffix.lower() in SUPPORTED_EXTENSIONS
+            )
+            if not paths:
+                raise ValueError(f"No images found in directory {source}.")
+            generator = (
+                one({self.camera_slots[0]: p}, str(p), idx)
+                for idx, p in enumerate(paths)
+            )
+        elif spec.kind == SourceKind.IMAGE_SEQUENCE:
+            generator = (
+                one(
+                    item if isinstance(item, dict) else {self.camera_slots[0]: item},
+                    None,
+                    idx,
+                )
+                for idx, item in enumerate(source)
+            )
+        elif spec.kind == SourceKind.VIDEO:
+            generator = self._video_frames(source, one, vid_stride)
+        elif spec.kind in (SourceKind.STREAM, SourceKind.STREAMS):
+            if not stream:
+                raise ValueError(
+                    "Live sources are unbounded; call predict(..., stream=True) "
+                    "and iterate the generator."
+                )
+            generator = self._stream_frames(spec, one, vid_stride, stream_buffer)
+        else:
+            raise ValueError(
+                f"Source kind {spec.kind.value!r} is not supported by LibreVLA yet."
+            )
+
+        if save:
+            generator = self._saving(generator, output_path if not is_many else None)
+        if stream:
+            return generator
+        results = list(generator)
+        return results if is_many else results[0]
+
+    __call__ = predict
+
+    @staticmethod
+    def _path_of(item: Any) -> Optional[str]:
+        return str(item) if isinstance(item, (str, Path)) else None
+
+    def _video_frames(self, source, one, vid_stride: int):
+        from ...utils.video import VideoSource
+
+        with VideoSource(source, vid_stride=vid_stride) as frames:
+            for frame_bgr, frame_idx in frames:
+                image = Image.fromarray(frame_bgr[:, :, ::-1])
+                yield one({self.camera_slots[0]: image}, str(source), frame_idx)
+
+    def _stream_frames(self, spec, one, vid_stride: int, stream_buffer: bool):
+        capture = build_stream_source(
+            spec, vid_stride=vid_stride, stream_buffer=stream_buffer
+        )
+        with capture as frames:
+            for frame in frames:
+                image = Image.fromarray(frame.frame_bgr[:, :, ::-1])
+                yield one(
+                    {self.camera_slots[0]: image}, frame.source_label, frame.frame_idx
+                )
+
+    def _saving(self, results: Iterable[Results], output_path: Optional[str]):
+        for idx, result in enumerate(results):
+            self._save_render(result, idx, output_path)
+            yield result
+
+    def _save_render(
+        self, result: Results, index: int, output_path: Optional[str]
+    ) -> None:
+        from ...utils.general import increment_path, log_saved_result
+
+        if output_path is not None:
+            destination = Path(output_path)
+        else:
+            if getattr(self, "_save_dir", None) is None:
+                self._save_dir = increment_path(Path("runs/act/predict"), mkdir=True)
+            stem = (
+                Path(result.path).stem
+                if result.path and not str(result.path).isdigit()
+                else "frame"
+            )
+            destination = self._save_dir / f"{stem}_{index}.png"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        frame = getattr(result, "_libreyolo_frame", None)
+        result.plot(frame).save(destination)
+        log_saved_result(result, destination)
+
+    # ------------------------------------------------------------------
+    # Train / val / unsupported
+    # ------------------------------------------------------------------
+
+    def train(self, data: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+        """Fine-tune on a LeRobot dataset (Hub repo id or local directory).
+
+        Args:
+            data: LeRobot dataset repo id (``"lerobot/svla_so101_pickplace"``)
+                or a local directory in the LeRobot v3 layout.
+            **kwargs: ``epochs``, ``batch``, ``lr0``, ``accumulate``,
+                ``val_split`` / ``val_episodes`` / ``train_episodes``,
+                ``output_dir`` / ``project`` / ``name`` / ``exist_ok``,
+                ``workers``, ``seed``, ``device``, ``callbacks``, ``loggers``,
+                ``max_steps`` (cap steps per epoch, for smoke runs).
+
+        Returns:
+            The standard results dict with ``save_dir``, ``best``, ``last``
+            and the final metrics. Load a checkpoint with
+            ``LibreVLA(results["best"])``.
+        """
+        if not self.TRAINABLE:
+            raise NotImplementedError(
+                self.TRAIN_UNSUPPORTED_REASON
+                or f"Training is not supported for {type(self).__name__} yet."
+            )
+        if not data:
+            raise ValueError(
+                "train() requires data=<LeRobot dataset repo id or directory>, "
+                'e.g. train(data="lerobot/svla_so101_pickplace").'
+            )
+        from .training.trainer import VLATrainer
+
+        return VLATrainer(self, data=data, **kwargs).run()
+
+    def val(self, data: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+        """Offline action error on held-out episodes of a LeRobot dataset.
+
+        Returns mean L1 / MSE between predicted and recorded action chunks
+        in the dataset's units, overall and per dimension. See
+        ``libreyolo.models.vla.metrics.action_error``.
+        """
+        if not data:
+            data = self.contract.get("data") if self.contract else None
+        if not data:
+            raise ValueError(
+                "val() requires data=<LeRobot dataset repo id or directory>."
+            )
+        from .training.trainer import VLAValidator
+
+        return VLAValidator(self, data=data, **kwargs).run()
+
+    def export(self, format: str = "onnx", **kwargs) -> str:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not export to {format!r}: the action "
+            "expert's sampling loop has no exportable graph contract yet "
+            "(ADR 0028). Run it through predict()."
+        )
+
+    def track(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self).__name__} returns action chunks, not boxes; "
+            "tracking does not apply."
+        )
+
+    def benchmark(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"{type(self).__name__} is not covered by the export benchmark."
+        )

--- a/libreyolo/models/vla/checkpoint.py
+++ b/libreyolo/models/vla/checkpoint.py
@@ -1,0 +1,107 @@
+"""Checkpoint directory contract for the LibreVLA tier.
+
+A VLA checkpoint is a directory (ADR 0028): the upstream policy files
+(``config.json`` plus ``model.safetensors``), the saved pre and post
+processor pipelines, and ``libreyolo_vla.json``, the contract file that lets
+``LibreVLA(path)`` rebuild the right family without guessing.
+
+``libreyolo_vla.json`` fields (schema 1):
+
+- ``schema``: 1
+- ``family``: LibreVLA family id (``smolvla``)
+- ``size``: family size code the fine-tune started from
+- ``base_repo`` / ``base_revision``: the pinned base the adapter was built on
+- ``data``: dataset repo id or path the fine-tune used
+- ``fps``: control rate of the dataset, or null
+- ``cameras``: dataset camera names in slot order (what ``predict`` expects)
+- ``action_names`` / ``state_names``: per-dimension names, or null
+- ``chunk_size``: action horizon of the policy
+- ``libreyolo_version``
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+CONTRACT_FILENAME = "libreyolo_vla.json"
+CONTRACT_SCHEMA = 1
+
+__all__ = [
+    "CONTRACT_FILENAME",
+    "CONTRACT_SCHEMA",
+    "is_vla_checkpoint",
+    "read_contract",
+    "write_contract",
+]
+
+
+def is_vla_checkpoint(path: Any) -> bool:
+    """True when ``path`` is a directory carrying the contract file."""
+    try:
+        p = Path(path)
+    except TypeError:
+        return False
+    return p.is_dir() and (p / CONTRACT_FILENAME).is_file()
+
+
+def read_contract(path: Any) -> Dict[str, Any]:
+    """Load and validate the contract file of a checkpoint directory."""
+    contract_path = Path(path) / CONTRACT_FILENAME
+    try:
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"{path} is not a LibreVLA checkpoint: missing {CONTRACT_FILENAME}."
+        ) from exc
+    schema = contract.get("schema")
+    if schema != CONTRACT_SCHEMA:
+        raise ValueError(
+            f"{contract_path} has schema {schema!r}; this LibreYOLO understands "
+            f"schema {CONTRACT_SCHEMA}. Upgrade libreyolo."
+        )
+    for key in ("family", "size"):
+        if not contract.get(key):
+            raise ValueError(f"{contract_path} is missing the {key!r} field.")
+    return contract
+
+
+def write_contract(
+    directory: Any,
+    *,
+    family: str,
+    size: str,
+    base_repo: Optional[str],
+    base_revision: Optional[str],
+    data: Optional[str],
+    fps: Optional[float],
+    cameras: Optional[list],
+    action_names: Optional[list],
+    state_names: Optional[list],
+    chunk_size: Optional[int],
+) -> Path:
+    """Write the contract file into ``directory`` and return its path."""
+    from ... import __version__
+
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    contract = {
+        "schema": CONTRACT_SCHEMA,
+        "family": family,
+        "size": size,
+        "base_repo": base_repo,
+        "base_revision": base_revision,
+        "data": data,
+        "fps": fps,
+        "cameras": list(cameras) if cameras is not None else None,
+        "action_names": list(action_names) if action_names is not None else None,
+        "state_names": list(state_names) if state_names is not None else None,
+        "chunk_size": int(chunk_size) if chunk_size is not None else None,
+        "libreyolo_version": __version__,
+    }
+    path = directory / CONTRACT_FILENAME
+    path.write_text(
+        json.dumps(contract, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return path

--- a/libreyolo/models/vla/metrics.py
+++ b/libreyolo/models/vla/metrics.py
@@ -1,0 +1,85 @@
+"""Offline action-error metrics for the LibreVLA tier (pure functions).
+
+These compare predicted action chunks with the chunks a dataset recorded,
+in the dataset's own units. They are the offline proxy VLA papers report;
+they are not a task success rate (ADR 0028).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+__all__ = ["action_error"]
+
+
+def _as_array(value: Any) -> np.ndarray:
+    if hasattr(value, "detach"):
+        value = value.detach().cpu().numpy()
+    return np.asarray(value, dtype=np.float32)
+
+
+def action_error(
+    predicted: Any,
+    target: Any,
+    *,
+    mask: Any = None,
+    names: Optional[List[str]] = None,
+    decimals: int = 6,
+) -> Dict[str, Any]:
+    """Mean L1 and MSE between predicted and recorded action chunks.
+
+    Args:
+        predicted: ``(N, T, D)`` or ``(T, D)`` predicted actions.
+        target: matching recorded actions.
+        mask: optional ``(N, T)`` or ``(T,)`` boolean, True where the target
+            step is valid (LeRobot's ``~action_is_pad``).
+        names: optional per-dimension names for the per-dimension table.
+
+    Returns:
+        ``{"val/action_l1", "val/action_mse", "val/action_l1_first",
+        "val/action_l1_dims": {name: value}, "val/steps": int}``.
+    """
+    pred = _as_array(predicted)
+    tgt = _as_array(target)
+    if pred.ndim == 2:
+        pred = pred[None]
+    if tgt.ndim == 2:
+        tgt = tgt[None]
+    if pred.shape != tgt.shape or pred.ndim != 3:
+        raise ValueError(
+            f"predicted {tuple(pred.shape)} and target {tuple(tgt.shape)} must "
+            "both be (N, T, D) with the same shape."
+        )
+    n, t, d = pred.shape
+    if mask is None:
+        valid = np.ones((n, t), dtype=bool)
+    else:
+        valid = np.asarray(_as_array(mask), dtype=bool)
+        if valid.ndim == 1:
+            valid = valid[None]
+        if valid.shape != (n, t):
+            raise ValueError(f"mask must have shape {(n, t)}, got {valid.shape}.")
+    steps = int(valid.sum())
+    if steps == 0:
+        raise ValueError("mask leaves no valid action steps.")
+    diff = pred - tgt
+    w = valid[..., None].astype(np.float32)
+    l1_dims = (np.abs(diff) * w).sum(axis=(0, 1)) / steps
+    mse = float(((diff**2) * w).sum() / (steps * d))
+    first_valid = valid[:, 0]
+    if first_valid.any():
+        l1_first = float(np.abs(diff[first_valid, 0, :]).mean())
+    else:
+        l1_first = float("nan")
+    labels = list(names) if names and len(names) == d else [f"a{i}" for i in range(d)]
+    return {
+        "val/action_l1": round(float(l1_dims.mean()), decimals),
+        "val/action_mse": round(mse, decimals),
+        "val/action_l1_first": round(l1_first, decimals),
+        "val/action_l1_dims": {
+            label: round(float(v), decimals) for label, v in zip(labels, l1_dims)
+        },
+        "val/steps": steps,
+    }

--- a/libreyolo/models/vla/observation.py
+++ b/libreyolo/models/vla/observation.py
@@ -1,0 +1,165 @@
+"""Observation assembly for the LibreVLA tier (pure, unit-tested offline).
+
+A VLA observation is a set of named camera frames, a proprioceptive state
+vector and an instruction. This module owns the user-facing rules from ADR
+0028: how a single frame or a ``{name: frame}`` dict maps onto a family's
+camera slots, how ``state`` is coerced (array, callable, or missing), and
+how a PIL frame becomes the ``(3, H, W)`` float tensor policies expect.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+import numpy as np
+from PIL import Image
+
+from ...utils.image_loader import ImageLoader
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Observation",
+    "coerce_state",
+    "frame_to_tensor",
+    "load_frames",
+    "map_cameras",
+]
+
+
+@dataclass
+class Observation:
+    """One policy input: frames keyed by camera slot, a state, an instruction."""
+
+    frames: Dict[str, Image.Image]
+    state: np.ndarray
+    instruction: str
+    path: Optional[str] = None
+    frame_idx: Optional[int] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def primary(self) -> Image.Image:
+        """The first camera frame; ``Results.orig_shape`` comes from it."""
+        return next(iter(self.frames.values()))
+
+
+def map_cameras(
+    frames: Mapping[str, Any],
+    slots: Sequence[str],
+    cameras: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Map user camera names onto a family's ordered camera slots.
+
+    Rules (ADR 0028):
+
+    - With ``cameras=[...]`` the i-th user name maps to the i-th slot. A key
+      outside that list raises.
+    - Without it, a key equal to a slot name takes that slot; every other
+      key is assigned to the free slots in order.
+    - More frames than slots raises; fewer is legal (families decide).
+    """
+    if not slots:
+        raise ValueError("This family declares no camera slots.")
+    if not frames:
+        raise ValueError("At least one camera frame is required.")
+    keys = [str(k) for k in frames]
+    if len(keys) > len(slots):
+        raise ValueError(
+            f"{len(keys)} camera frames given but the model has "
+            f"{len(slots)} camera slot(s): {list(slots)}."
+        )
+    mapping: Dict[str, str] = {}
+    if cameras is not None:
+        cameras = [str(c) for c in cameras]
+        if len(cameras) > len(slots):
+            raise ValueError(
+                f"cameras lists {len(cameras)} names but the model has "
+                f"{len(slots)} camera slot(s)."
+            )
+        for key in keys:
+            if key not in cameras:
+                raise ValueError(
+                    f"Camera {key!r} is not in cameras={cameras}. Name every "
+                    "camera you pass, in slot order."
+                )
+            mapping[key] = slots[cameras.index(key)]
+    else:
+        free = [s for s in slots if s not in keys]
+        for key in keys:
+            if key in slots:
+                mapping[key] = key
+            else:
+                mapping[key] = free.pop(0)
+    out: Dict[str, Any] = {}
+    for slot in slots:
+        for key, target in mapping.items():
+            if target == slot:
+                out[slot] = frames[key]
+    return out
+
+
+def load_frames(
+    frames: Mapping[str, Any], color_format: str = "auto"
+) -> Dict[str, Image.Image]:
+    """Load every value of a slot-keyed mapping into a PIL RGB image."""
+    return {
+        slot: ImageLoader.load(value, color_format=color_format)
+        for slot, value in frames.items()
+    }
+
+
+def frame_to_tensor(image: Image.Image):
+    """PIL RGB frame to a ``(3, H, W)`` float32 tensor in ``[0, 1]``."""
+    import torch
+
+    array = np.asarray(image.convert("RGB"), dtype=np.float32) / 255.0
+    return torch.from_numpy(np.ascontiguousarray(array.transpose(2, 0, 1)))
+
+
+def coerce_state(
+    state: Any,
+    dim: int,
+    *,
+    warn: Optional[Callable[[str], None]] = None,
+) -> np.ndarray:
+    """Turn the ``state=`` argument into a float32 ``(dim,)`` vector.
+
+    A callable is invoked (the live-loop hook). ``None`` becomes zeros and
+    reports through ``warn`` once per caller, because a policy fed a zero
+    state still runs but its actions are not meaningful.
+    """
+    if callable(state):
+        state = state()
+    if state is None:
+        if warn is not None:
+            warn(
+                "state=None: using a zero proprioceptive vector. The policy "
+                "runs, but its actions are not meaningful without the real "
+                "robot state."
+            )
+        return np.zeros(int(dim), dtype=np.float32)
+    array = np.asarray(state, dtype=np.float32).reshape(-1)
+    if array.shape[0] != int(dim):
+        raise ValueError(
+            f"state has {array.shape[0]} values but the model expects {int(dim)}."
+        )
+    if not np.isfinite(array).all():
+        raise ValueError("state must be finite.")
+    return array
+
+
+def action_names_from_features(features: Mapping[str, Any]) -> Optional[List[str]]:
+    """Read per-dimension action names from a LeRobot ``features`` mapping."""
+    action = features.get("action") if isinstance(features, Mapping) else None
+    names = action.get("names") if isinstance(action, Mapping) else None
+    if isinstance(names, (list, tuple)) and all(isinstance(n, str) for n in names):
+        return list(names)
+    if isinstance(names, Mapping):
+        # Some datasets nest names as {"motors": [...]}.
+        for value in names.values():
+            if isinstance(value, (list, tuple)):
+                return [str(v) for v in value]
+    return None

--- a/libreyolo/models/vla/smolvla.py
+++ b/libreyolo/models/vla/smolvla.py
@@ -1,0 +1,162 @@
+"""LibreYOLO adapter for SmolVLA (Hugging Face / lerobot).
+
+SmolVLA is a 450M-parameter vision-language-action policy: a SmolVLM2
+backbone with a flow-matching action expert that emits a 50-step chunk.
+The upstream policy, its pre/post processor pipelines and its weights load
+through the Apache-2.0 ``lerobot`` package at a pinned Hub revision. This
+module is LibreYOLO's own adapter code and calls only the upstream public
+API; no upstream source is ported.
+
+Base checkpoint (``lerobot/smolvla_base``): three camera slots (``camera1``,
+``camera2``, ``camera3``), a 6-dimensional state, a 6-dimensional action,
+50-step chunks. Fine-tunes recorded by ``train()`` carry the dataset's own
+camera names, action names and control rate in the checkpoint contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar, Dict, List, Optional
+
+from .base import _INSTALL_HINT, LibreVLAModel
+from .observation import Observation, frame_to_tensor
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_PREFIX = "observation.images."
+
+
+def _require_lerobot():
+    """Import the upstream pieces, registering the SmolVLA config choice."""
+    try:
+        # Importing the configuration module registers the "smolvla" policy
+        # type with the upstream config registry; PreTrainedConfig.from_pretrained
+        # refuses unknown types otherwise.
+        from lerobot.configs.policies import PreTrainedConfig
+        from lerobot.policies.factory import make_pre_post_processors
+        from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig
+        from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    return PreTrainedConfig, SmolVLAConfig, SmolVLAPolicy, make_pre_post_processors
+
+
+class LibreSmolVLA(LibreVLAModel):
+    """SmolVLA behind the LibreVLA predict / train / val surface."""
+
+    FAMILY = "smolvla"
+    FILENAME_PREFIX = "LibreSmolVLA"
+    HF_REPOS: ClassVar[Dict[str, str]] = {
+        "base": "lerobot/smolvla_base",
+    }
+    HF_REVISIONS: ClassVar[Dict[str, str]] = {
+        "base": "c83c3163b8ca9b7e67c509fffd9121e66cb96205",
+    }
+    # SmolVLA resizes with padding to a 512 square; nominal, for inventory.
+    INPUT_SIZES: ClassVar[Dict[str, int]] = {"base": 512}
+    UPSTREAM_TYPE: ClassVar[str] = "smolvla"
+
+    def __init__(self, size: str = "base", **kwargs):
+        super().__init__(size, **kwargs)
+        self._config = None
+
+    @classmethod
+    def get_download_url(cls, filename: str) -> Optional[str]:
+        """Pinned ``lerobot/smolvla_base`` snapshot tree for ``LibreSmolVLAbase``."""
+        return super().get_download_url(filename)
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    def _load_policy(self, snapshot_dir: str) -> None:
+        _PreTrainedConfig, _SmolVLAConfig, SmolVLAPolicy, make_pre_post_processors = (
+            _require_lerobot()
+        )
+        config = self._pretrained_config(snapshot_dir)
+        config.device = str(self.device)
+        policy = SmolVLAPolicy.from_pretrained(snapshot_dir, config=config)
+        policy.eval()
+        policy.to(self.device)
+        preprocessor, postprocessor = make_pre_post_processors(
+            config,
+            pretrained_path=snapshot_dir,
+            preprocessor_overrides={"device_processor": {"device": str(self.device)}},
+        )
+        self._config = config
+        self._policy = policy
+        self._preprocessor = preprocessor
+        self._postprocessor = postprocessor
+        self.reset()
+
+    # ------------------------------------------------------------------
+    # Contract properties
+    # ------------------------------------------------------------------
+
+    def _pretrained_config(self, snapshot_dir: str):
+        PreTrainedConfig, *_rest = _require_lerobot()
+        config = PreTrainedConfig.from_pretrained(snapshot_dir)
+        if getattr(config, "type", None) != self.UPSTREAM_TYPE:
+            raise ValueError(
+                f"{snapshot_dir} holds a {getattr(config, 'type', None)!r} policy, "
+                f"not {self.UPSTREAM_TYPE!r}."
+            )
+        return config
+
+    @property
+    def config(self):
+        """The upstream policy config (loads the policy on first access)."""
+        if self._config is None:
+            self._ensure_loaded()
+        return self._config
+
+    @property
+    def camera_slots(self) -> List[str]:
+        cameras = self.contract.get("cameras") if self.contract else None
+        if cameras:
+            return [str(c) for c in cameras]
+        keys = list(self.config.image_features)
+        return [
+            k[len(_IMAGE_PREFIX) :] if k.startswith(_IMAGE_PREFIX) else k for k in keys
+        ]
+
+    @property
+    def state_dim(self) -> int:
+        feature = self.config.robot_state_feature
+        return int(feature.shape[0]) if feature is not None else 0
+
+    @property
+    def action_dim(self) -> int:
+        return int(self.config.action_feature.shape[0])
+
+    @property
+    def chunk_size(self) -> int:
+        return int(self.config.chunk_size)
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def _raw_observation(self, observation: Observation) -> Dict[str, Any]:
+        """The upstream observation dict before the preprocessor pipeline."""
+        import torch
+
+        raw: Dict[str, Any] = {
+            "observation.state": torch.as_tensor(
+                observation.state, dtype=torch.float32
+            ),
+            "task": observation.instruction,
+        }
+        for slot, image in observation.frames.items():
+            raw[f"{_IMAGE_PREFIX}{slot}"] = frame_to_tensor(image)
+        raw.update(observation.extras)
+        return raw
+
+    def _predict_chunk(self, observation: Observation) -> Any:
+        import torch
+
+        batch = self._preprocessor(self._raw_observation(observation))
+        with torch.inference_mode():
+            chunk = self._policy.predict_action_chunk(batch)
+        chunk = self._postprocessor(chunk)
+        return chunk[:, :, : self.action_dim]

--- a/libreyolo/models/vla/training/__init__.py
+++ b/libreyolo/models/vla/training/__init__.py
@@ -1,0 +1,13 @@
+"""LibreVLA imitation fine-tuning and offline validation.
+
+The public entry points are ``LibreVLA(...).train(data=...)`` and
+``LibreVLA(...).val(data=...)``; this package is their implementation. See
+``docs/adr/0028-librevla-contract.md`` and ``docs/librevla.md``.
+
+Heavy imports (torch, lerobot) stay inside the modules so importing the
+``vla`` package without the ``vla`` extra keeps working.
+"""
+
+from .data import resolve_data_source, split_episodes
+
+__all__ = ["resolve_data_source", "split_episodes"]

--- a/libreyolo/models/vla/training/data.py
+++ b/libreyolo/models/vla/training/data.py
@@ -1,0 +1,130 @@
+"""LeRobot dataset access for the LibreVLA trainer and validator.
+
+The LeRobot v3 layout is the interchange format of the field, so ``act`` has
+no LibreYOLO dataset YAML (ADR 0028). This module resolves a ``data``
+argument (Hub repo id or local directory), splits episodes into train and
+validation, and builds the upstream datasets. The split logic is pure and
+unit-tested offline; the dataset builders need the ``vla`` extra.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["DataSource", "resolve_data_source", "split_episodes", "camera_rename_map"]
+
+
+@dataclass(frozen=True)
+class DataSource:
+    """A resolved ``data=`` argument."""
+
+    repo_id: str
+    root: Optional[Path]
+
+    @property
+    def label(self) -> str:
+        return str(self.root) if self.root is not None else self.repo_id
+
+
+def resolve_data_source(data: Any) -> DataSource:
+    """Hub repo id, or a local directory in the LeRobot layout."""
+    if data is None or not str(data).strip():
+        raise ValueError("data must be a LeRobot dataset repo id or directory.")
+    text = str(data).strip()
+    path = Path(text).expanduser()
+    if path.is_dir():
+        if not (path / "meta" / "info.json").is_file():
+            raise ValueError(
+                f"{path} is a directory but not a LeRobot dataset (no meta/info.json)."
+            )
+        return DataSource(repo_id=path.name, root=path.resolve())
+    if "/" not in text:
+        raise ValueError(
+            f"data={text!r} is neither an existing directory nor a Hub repo id "
+            "of the form owner/name."
+        )
+    return DataSource(repo_id=text, root=None)
+
+
+def split_episodes(
+    total_episodes: int,
+    *,
+    val_split: float = 0.1,
+    val_episodes: Optional[Sequence[int]] = None,
+    train_episodes: Optional[Sequence[int]] = None,
+) -> Tuple[List[int], List[int]]:
+    """Return ``(train, val)`` episode index lists.
+
+    Explicit lists win. Otherwise the last ``val_split`` fraction of episodes
+    (at least one when the dataset has two or more) is held out, so
+    validation never sees frames adjacent to training frames of the same
+    episode.
+    """
+    total = int(total_episodes)
+    if total < 1:
+        raise ValueError("The dataset has no episodes.")
+    every = list(range(total))
+    if val_episodes is not None or train_episodes is not None:
+        val = sorted({int(e) for e in (val_episodes or [])})
+        if train_episodes is not None:
+            train = sorted({int(e) for e in train_episodes})
+        else:
+            train = [e for e in every if e not in set(val)]
+        for name, subset in (("train_episodes", train), ("val_episodes", val)):
+            bad = [e for e in subset if e < 0 or e >= total]
+            if bad:
+                raise ValueError(f"{name} has indices outside 0..{total - 1}: {bad}")
+        overlap = sorted(set(train) & set(val))
+        if overlap:
+            raise ValueError(f"train_episodes and val_episodes overlap: {overlap}")
+        if not train:
+            raise ValueError("train_episodes is empty.")
+        return train, val
+    if not 0.0 <= float(val_split) < 1.0:
+        raise ValueError("val_split must be in [0, 1).")
+    n_val = int(round(total * float(val_split)))
+    if total >= 2 and float(val_split) > 0:
+        n_val = max(1, min(n_val, total - 1))
+    else:
+        n_val = 0
+    train = every[: total - n_val]
+    val = every[total - n_val :]
+    return train, val
+
+
+def camera_rename_map(
+    dataset_camera_keys: Sequence[str], slots: Sequence[str]
+) -> Dict[str, str]:
+    """Map dataset camera keys onto the policy's camera slots, in order.
+
+    Returns ``{"observation.images.up": "observation.images.camera1", ...}``.
+    Dataset cameras beyond the policy's slot count are dropped with a warning.
+    """
+    prefix = "observation.images."
+    keys = [str(k) for k in dataset_camera_keys]
+    if len(keys) > len(slots):
+        logger.warning(
+            "Dataset has %d cameras but the policy has %d slots; using %s.",
+            len(keys),
+            len(slots),
+            keys[: len(slots)],
+        )
+        keys = keys[: len(slots)]
+    mapping: Dict[str, str] = {}
+    for key, slot in zip(keys, slots):
+        target = slot if slot.startswith(prefix) else f"{prefix}{slot}"
+        if key != target:
+            mapping[key] = target
+    return mapping
+
+
+def camera_names(dataset_camera_keys: Sequence[str], slots: Sequence[str]) -> List[str]:
+    """Dataset camera names (without the prefix) in slot order."""
+    prefix = "observation.images."
+    keys = [str(k) for k in dataset_camera_keys][: len(slots)]
+    return [k[len(prefix) :] if k.startswith(prefix) else k for k in keys]

--- a/libreyolo/models/vla/training/data.py
+++ b/libreyolo/models/vla/training/data.py
@@ -57,13 +57,15 @@ def split_episodes(
     val_split: float = 0.1,
     val_episodes: Optional[Sequence[int]] = None,
     train_episodes: Optional[Sequence[int]] = None,
+    allow_empty_train: bool = False,
 ) -> Tuple[List[int], List[int]]:
     """Return ``(train, val)`` episode index lists.
 
     Explicit lists win. Otherwise the last ``val_split`` fraction of episodes
     (at least one when the dataset has two or more) is held out, so
     validation never sees frames adjacent to training frames of the same
-    episode.
+    episode. ``allow_empty_train`` lets a validation-only caller hold out
+    every episode.
     """
     total = int(total_episodes)
     if total < 1:
@@ -82,7 +84,7 @@ def split_episodes(
         overlap = sorted(set(train) & set(val))
         if overlap:
             raise ValueError(f"train_episodes and val_episodes overlap: {overlap}")
-        if not train:
+        if not train and not allow_empty_train:
             raise ValueError("train_episodes is empty.")
         return train, val
     if not 0.0 <= float(val_split) < 1.0:

--- a/libreyolo/models/vla/training/trainer.py
+++ b/libreyolo/models/vla/training/trainer.py
@@ -120,7 +120,15 @@ class _DatasetBundle:
 
 
 def _build_datasets(
-    wrapper, config, data, *, val_split, val_episodes, train_episodes, need_train=True
+    wrapper,
+    config,
+    data,
+    *,
+    val_split,
+    val_episodes,
+    train_episodes,
+    need_train=True,
+    allow_empty_train=False,
 ):
     (
         LeRobotDataset,
@@ -137,6 +145,7 @@ def _build_datasets(
         val_split=val_split,
         val_episodes=val_episodes,
         train_episodes=train_episodes,
+        allow_empty_train=allow_empty_train,
     )
     slots = wrapper.camera_slots
     rename_map = camera_rename_map(meta.camera_keys, slots)
@@ -367,7 +376,11 @@ class VLATrainer:
                         break
                     batch = preprocessor(batch)
                     loss, _out = policy.forward(batch)
-                    (loss / cfg.accumulate).backward()
+                    # Scale by the real window so a partial tail window is not
+                    # underweighted when steps_per_epoch % accumulate != 0.
+                    window_start = (step // cfg.accumulate) * cfg.accumulate
+                    window = min(cfg.accumulate, steps_per_epoch - window_start)
+                    (loss / window).backward()
                     running += float(loss.detach()) * 1
                     seen += 1
                     if (step + 1) % cfg.accumulate == 0 or step + 1 == steps_per_epoch:
@@ -542,6 +555,7 @@ class VLAValidator:
             val_episodes=self.val_episodes,
             train_episodes=None,
             need_train=self.split != "val",
+            allow_empty_train=self.split == "val",
         )
         if self.split == "val":
             dataset = bundle.val

--- a/libreyolo/models/vla/training/trainer.py
+++ b/libreyolo/models/vla/training/trainer.py
@@ -1,0 +1,602 @@
+"""Imitation-learning trainer and offline validator for the LibreVLA tier.
+
+Deliberately not a ``BaseTrainer`` subclass: that chassis assumes stacked
+image tensors, detection losses and mAP validation. This trainer keeps the
+repo's user-facing surface (run directories, callbacks, loggers, results
+dict) and owns a compact epoch loop over a LeRobot dataset: the upstream
+policy's own loss, the family's optimizer and schedule presets, gradient
+clipping, best/last checkpoints and the checkpoint contract in
+:mod:`..checkpoint`.
+
+The validator computes offline action error (:mod:`..metrics`) on held-out
+episodes, which is what CI can run without a robot (ADR 0028).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ....training.callbacks import (
+    TrainCallbackList,
+    TrainCallbacks,
+    TrainEndEvent,
+    TrainEpochEvent,
+    TrainExceptionEvent,
+    TrainStartEvent,
+)
+from ....training.loggers import resolve_loggers
+from ..base import _INSTALL_HINT
+from ..checkpoint import write_contract
+from ..metrics import action_error
+from ..observation import action_names_from_features
+from .data import (
+    camera_names,
+    camera_rename_map,
+    resolve_data_source,
+    split_episodes,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["VLATrainConfig", "VLATrainer", "VLAValidator"]
+
+
+@dataclass
+class VLATrainConfig:
+    """Resolved VLA training configuration (user kwargs over preset defaults)."""
+
+    data: str = ""
+    epochs: int = 5
+    batch: int = 8
+    accumulate: int = 1
+    lr0: Optional[float] = None
+    val_split: float = 0.1
+    val_episodes: Optional[List[int]] = None
+    train_episodes: Optional[List[int]] = None
+    output_dir: str = "runs/act/train"
+    project: Optional[str] = None
+    name: Optional[str] = None
+    exist_ok: bool = False
+    workers: int = 0
+    seed: int = 0
+    device: Optional[str] = None
+    max_steps: Optional[int] = None
+    val_batches: Optional[int] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+def _lerobot():
+    try:
+        from lerobot.datasets.factory import resolve_delta_timestamps
+        from lerobot.datasets.lerobot_dataset import (
+            LeRobotDataset,
+            LeRobotDatasetMetadata,
+        )
+        from lerobot.policies.factory import make_policy, make_pre_post_processors
+        from lerobot.processor import rename_stats
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    return (
+        LeRobotDataset,
+        LeRobotDatasetMetadata,
+        resolve_delta_timestamps,
+        make_policy,
+        make_pre_post_processors,
+        rename_stats,
+    )
+
+
+class _DatasetBundle:
+    """Metadata, episode split and the train/val LeRobot datasets."""
+
+    def __init__(
+        self, source, meta, train_ds, val_ds, train_eps, val_eps, rename_map, cameras
+    ):
+        self.source = source
+        self.meta = meta
+        self.train = train_ds
+        self.val = val_ds
+        self.train_episodes = train_eps
+        self.val_episodes = val_eps
+        self.rename_map = rename_map
+        self.cameras = cameras
+
+    @property
+    def action_names(self) -> Optional[List[str]]:
+        return action_names_from_features(self.meta.features)
+
+    @property
+    def state_names(self) -> Optional[List[str]]:
+        state = self.meta.features.get("observation.state", {})
+        names = state.get("names") if isinstance(state, dict) else None
+        if isinstance(names, (list, tuple)):
+            return [str(n) for n in names]
+        return None
+
+
+def _build_datasets(
+    wrapper, config, data, *, val_split, val_episodes, train_episodes, need_train=True
+):
+    (
+        LeRobotDataset,
+        LeRobotDatasetMetadata,
+        resolve_delta_timestamps,
+        _mp,
+        _mpp,
+        _rs,
+    ) = _lerobot()
+    source = resolve_data_source(data)
+    meta = LeRobotDatasetMetadata(source.repo_id, root=source.root)
+    train_eps, val_eps = split_episodes(
+        meta.total_episodes,
+        val_split=val_split,
+        val_episodes=val_episodes,
+        train_episodes=train_episodes,
+    )
+    slots = wrapper.camera_slots
+    rename_map = camera_rename_map(meta.camera_keys, slots)
+    cameras = camera_names(meta.camera_keys, slots)
+    delta = resolve_delta_timestamps(config, meta)
+    train_ds = (
+        LeRobotDataset(
+            source.repo_id, root=source.root, episodes=train_eps, delta_timestamps=delta
+        )
+        if need_train and train_eps
+        else None
+    )
+    val_ds = (
+        LeRobotDataset(
+            source.repo_id, root=source.root, episodes=val_eps, delta_timestamps=delta
+        )
+        if val_eps
+        else None
+    )
+    return _DatasetBundle(
+        source, meta, train_ds, val_ds, train_eps, val_eps, rename_map, cameras
+    )
+
+
+def _make_loader(dataset, batch, shuffle, workers, seed):
+    import torch
+    from torch.utils.data import DataLoader
+
+    generator = torch.Generator()
+    generator.manual_seed(int(seed))
+    return DataLoader(
+        dataset,
+        batch_size=int(batch),
+        shuffle=shuffle,
+        num_workers=int(workers),
+        drop_last=False,
+        generator=generator,
+    )
+
+
+class VLATrainer:
+    """Epoch-based imitation fine-tuning of a LibreVLA family."""
+
+    def __init__(
+        self,
+        wrapper,
+        *,
+        data: str,
+        callbacks: TrainCallbacks = None,
+        loggers: Any = None,
+        **kwargs,
+    ):
+        known = set(VLATrainConfig.__dataclass_fields__) - {"data", "extra"}
+        config_kwargs = {k: v for k, v in kwargs.items() if k in known}
+        extra = {k: v for k, v in kwargs.items() if k not in known}
+        if extra:
+            logger.warning("Ignoring unknown train() kwargs: %s", sorted(extra))
+        self.config = VLATrainConfig(data=str(data), extra=extra, **config_kwargs)
+        if self.config.epochs < 1:
+            raise ValueError(f"epochs must be >= 1, got {self.config.epochs}")
+        if self.config.batch < 1 or self.config.accumulate < 1:
+            raise ValueError("batch and accumulate must both be >= 1.")
+        self.wrapper = wrapper
+        self.callbacks = TrainCallbackList(callbacks)
+        for logger_cb in resolve_loggers(loggers):
+            self.callbacks.append(logger_cb)
+        self.save_dir = self._resolve_save_dir()
+
+    def _resolve_save_dir(self) -> Path:
+        from ....utils.general import increment_path
+
+        cfg = self.config
+        output = Path(cfg.output_dir)
+        project = Path(cfg.project) if cfg.project else output.parent
+        name = cfg.name if cfg.name else output.name
+        return increment_path(
+            Path(project) / str(name), exist_ok=cfg.exist_ok, mkdir=True
+        )
+
+    def _resolve_device(self):
+        import torch
+
+        if self.config.device is not None:
+            return self.wrapper._resolve_device(self.config.device)
+        return torch.device(self.wrapper.device)
+
+    # ------------------------------------------------------------------
+
+    def run(self) -> Dict[str, Any]:
+        import torch
+
+        cfg = self.config
+        wrapper = self.wrapper
+        start_time = time.time()
+        torch.manual_seed(cfg.seed)
+        device = self._resolve_device()
+
+        (_LD, _LM, _rdt, make_policy, make_pre_post_processors, rename_stats) = (
+            _lerobot()
+        )
+        base_dir = wrapper._ensure_weights()
+        config = wrapper._pretrained_config(base_dir)
+        config.pretrained_path = base_dir
+        config.device = str(device)
+
+        # Datasets need the config for delta timestamps; the config needs the
+        # wrapper's camera slots, which come from the same base config.
+        wrapper._config = config
+        bundle = _build_datasets(
+            wrapper,
+            config,
+            cfg.data,
+            val_split=cfg.val_split,
+            val_episodes=cfg.val_episodes,
+            train_episodes=cfg.train_episodes,
+        )
+        if bundle.train is None:
+            raise ValueError("No training episodes after the split.")
+
+        policy = make_policy(config, ds_meta=bundle.meta, rename_map=bundle.rename_map)
+        policy.to(device)
+        stats = rename_stats(bundle.meta.stats, bundle.rename_map)
+        features = {**config.input_features, **config.output_features}
+        preprocessor, postprocessor = make_pre_post_processors(
+            config,
+            pretrained_path=base_dir,
+            dataset_stats=stats,
+            preprocessor_overrides={
+                "device_processor": {"device": device.type},
+                "normalizer_processor": {
+                    "features": features,
+                    "norm_map": config.normalization_mapping,
+                    "stats": stats,
+                },
+                "rename_observations_processor": {"rename_map": bundle.rename_map},
+            },
+            postprocessor_overrides={
+                "unnormalizer_processor": {
+                    "features": config.output_features,
+                    "norm_map": config.normalization_mapping,
+                    "stats": stats,
+                },
+            },
+        )
+
+        train_loader = _make_loader(
+            bundle.train, cfg.batch, True, cfg.workers, cfg.seed
+        )
+        val_loader = (
+            _make_loader(bundle.val, cfg.batch, False, cfg.workers, cfg.seed)
+            if bundle.val is not None
+            else None
+        )
+        steps_per_epoch = len(train_loader)
+        if cfg.max_steps is not None:
+            steps_per_epoch = min(steps_per_epoch, int(cfg.max_steps))
+        total_updates = max(1, math.ceil(steps_per_epoch / cfg.accumulate) * cfg.epochs)
+
+        optimizer_cfg = config.get_optimizer_preset()
+        if cfg.lr0 is not None:
+            optimizer_cfg.lr = float(cfg.lr0)
+        optimizer = optimizer_cfg.build(policy.get_optim_params())
+        grad_clip = float(getattr(optimizer_cfg, "grad_clip_norm", 0.0) or 0.0)
+        scheduler_cfg = config.get_scheduler_preset()
+        scheduler = None
+        if scheduler_cfg is not None:
+            if hasattr(scheduler_cfg, "num_warmup_steps"):
+                scheduler_cfg.num_warmup_steps = min(
+                    int(scheduler_cfg.num_warmup_steps), max(1, total_updates // 10)
+                )
+            if hasattr(scheduler_cfg, "num_decay_steps"):
+                scheduler_cfg.num_decay_steps = max(1, total_updates)
+            if hasattr(scheduler_cfg, "peak_lr") and cfg.lr0 is not None:
+                scheduler_cfg.peak_lr = float(cfg.lr0)
+            scheduler = scheduler_cfg.build(optimizer, total_updates)
+
+        weights_dir = self.save_dir / "weights"
+        best_metric: Optional[float] = None
+        best_epoch: Optional[int] = None
+        final_loss = float("nan")
+        completed_epochs = 0
+        metric_name = "val/loss" if val_loader is not None else "train/loss"
+        config_dump = {**asdict(cfg), "family": wrapper.FAMILY, "lr0": optimizer_cfg.lr}
+        config_dump.pop("extra", None)
+
+        self.callbacks.on_train_start(
+            TrainStartEvent(
+                start_epoch=1,
+                total_epochs=cfg.epochs,
+                model_family=wrapper.FAMILY,
+                model_size=wrapper.size,
+                task="act",
+                save_dir=str(self.save_dir),
+                config=config_dump,
+            )
+        )
+
+        def save(directory: Path) -> None:
+            directory.mkdir(parents=True, exist_ok=True)
+            policy.save_pretrained(directory)
+            if hasattr(config, "save_pretrained"):
+                config.save_pretrained(directory)
+            preprocessor.save_pretrained(directory)
+            postprocessor.save_pretrained(directory)
+            write_contract(
+                directory,
+                family=wrapper.FAMILY,
+                size=wrapper.size,
+                base_repo=wrapper.HF_REPOS.get(wrapper.size),
+                base_revision=wrapper.HF_REVISIONS.get(wrapper.size),
+                data=bundle.source.label,
+                fps=float(bundle.meta.fps) if bundle.meta.fps else None,
+                cameras=bundle.cameras,
+                action_names=bundle.action_names,
+                state_names=bundle.state_names,
+                chunk_size=int(getattr(config, "chunk_size", 0)) or None,
+            )
+
+        epoch = 0
+        try:
+            for epoch in range(1, cfg.epochs + 1):
+                epoch_start = time.time()
+                policy.train()
+                running, seen = 0.0, 0
+                optimizer.zero_grad(set_to_none=True)
+                for step, batch in enumerate(train_loader):
+                    if step >= steps_per_epoch:
+                        break
+                    batch = preprocessor(batch)
+                    loss, _out = policy.forward(batch)
+                    (loss / cfg.accumulate).backward()
+                    running += float(loss.detach()) * 1
+                    seen += 1
+                    if (step + 1) % cfg.accumulate == 0 or step + 1 == steps_per_epoch:
+                        if grad_clip > 0:
+                            torch.nn.utils.clip_grad_norm_(
+                                policy.parameters(), grad_clip
+                            )
+                        optimizer.step()
+                        optimizer.zero_grad(set_to_none=True)
+                        if scheduler is not None:
+                            scheduler.step()
+                train_loss = running / max(seen, 1)
+                final_loss = train_loss
+
+                val_metrics: Dict[str, float] = {}
+                validated = False
+                if val_loader is not None:
+                    val_metrics = self._validate_loss(
+                        policy, preprocessor, val_loader, cfg.val_batches
+                    )
+                    validated = True
+                current = val_metrics.get("val/loss", train_loss)
+                is_best = best_metric is None or current < best_metric
+                if is_best:
+                    best_metric, best_epoch = current, epoch
+                    save(weights_dir / "best")
+                save(weights_dir / "last")
+                completed_epochs = epoch
+                lr_now = {
+                    f"lr/{i}": float(g["lr"])
+                    for i, g in enumerate(optimizer.param_groups)
+                }
+                logger.info(
+                    "epoch %d/%d  train/loss %.5f  %s %.5f%s",
+                    epoch,
+                    cfg.epochs,
+                    train_loss,
+                    metric_name,
+                    current,
+                    "  (best)" if is_best else "",
+                )
+                self.callbacks.on_train_epoch_end(
+                    TrainEpochEvent(
+                        epoch=epoch,
+                        total_epochs=cfg.epochs,
+                        model_family=wrapper.FAMILY,
+                        model_size=wrapper.size,
+                        task="act",
+                        save_dir=str(self.save_dir),
+                        train_loss=train_loss,
+                        train_loss_items={"loss": train_loss},
+                        lr=lr_now,
+                        val_metrics=val_metrics,
+                        validated=validated,
+                        is_best=is_best,
+                        current_metric=current,
+                        current_metric_name=metric_name,
+                        best_metric=best_metric,
+                        best_metric_name=metric_name,
+                        best_epoch=best_epoch,
+                        epoch_seconds=time.time() - epoch_start,
+                    )
+                )
+        except BaseException as exc:
+            self.callbacks.on_train_exception(
+                TrainExceptionEvent(
+                    epoch=epoch or None,
+                    total_epochs=cfg.epochs,
+                    model_family=wrapper.FAMILY,
+                    model_size=wrapper.size,
+                    task="act",
+                    save_dir=str(self.save_dir),
+                    exception=exc,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                    elapsed_seconds=time.time() - start_time,
+                )
+            )
+            raise
+
+        results: Dict[str, Any] = {
+            "save_dir": str(self.save_dir),
+            "best": str(weights_dir / "best"),
+            "last": str(weights_dir / "last"),
+            "epochs": completed_epochs,
+            "final_loss": final_loss,
+            "best_metric": best_metric,
+            "best_epoch": best_epoch,
+            "metric_name": metric_name,
+            "train_episodes": bundle.train_episodes,
+            "val_episodes": bundle.val_episodes,
+        }
+        self.callbacks.on_train_end(
+            TrainEndEvent(
+                total_epochs=cfg.epochs,
+                completed_epochs=completed_epochs,
+                model_family=wrapper.FAMILY,
+                model_size=wrapper.size,
+                task="act",
+                save_dir=str(self.save_dir),
+                final_loss=final_loss,
+                best_metric=best_metric,
+                best_epoch=best_epoch,
+                total_seconds=time.time() - start_time,
+                results=results,
+            )
+        )
+        return results
+
+    @staticmethod
+    def _validate_loss(policy, preprocessor, loader, max_batches) -> Dict[str, float]:
+        import torch
+
+        policy.eval()
+        total, count = 0.0, 0
+        with torch.no_grad():
+            for idx, batch in enumerate(loader):
+                if max_batches is not None and idx >= int(max_batches):
+                    break
+                batch = preprocessor(batch)
+                loss, _out = policy.forward(batch)
+                total += float(loss)
+                count += 1
+        policy.train()
+        return {"val/loss": total / max(count, 1)}
+
+
+class VLAValidator:
+    """Offline action error of a loaded policy on held-out episodes."""
+
+    def __init__(
+        self,
+        wrapper,
+        *,
+        data: str,
+        batch: int = 8,
+        workers: int = 0,
+        val_split: float = 0.1,
+        val_episodes: Optional[List[int]] = None,
+        split: str = "val",
+        max_batches: Optional[int] = None,
+        verbose: bool = True,
+        **kwargs,
+    ):
+        if kwargs:
+            logger.warning("Ignoring unknown val() kwargs: %s", sorted(kwargs))
+        if split not in ("val", "train", "all"):
+            raise ValueError("split must be 'val', 'train' or 'all'.")
+        self.wrapper = wrapper
+        self.data = str(data)
+        self.batch = int(batch)
+        self.workers = int(workers)
+        self.val_split = float(val_split)
+        self.val_episodes = val_episodes
+        self.split = split
+        self.max_batches = max_batches
+        self.verbose = verbose
+
+    def run(self) -> Dict[str, Any]:
+        import torch
+
+        wrapper = self.wrapper
+        wrapper._ensure_loaded()
+        config = wrapper.config
+        (LeRobotDataset, _LM, resolve_delta_timestamps, *_rest) = _lerobot()
+        source = resolve_data_source(self.data)
+        bundle = _build_datasets(
+            wrapper,
+            config,
+            self.data,
+            val_split=0.0 if self.split == "all" else self.val_split,
+            val_episodes=self.val_episodes,
+            train_episodes=None,
+            need_train=self.split != "val",
+        )
+        if self.split == "val":
+            dataset = bundle.val
+        elif self.split == "train":
+            dataset = bundle.train
+        else:
+            delta = resolve_delta_timestamps(config, bundle.meta)
+            dataset = LeRobotDataset(
+                source.repo_id, root=source.root, delta_timestamps=delta
+            )
+        if dataset is None:
+            raise ValueError(f"The {self.split!r} split has no episodes.")
+        loader = _make_loader(dataset, self.batch, False, self.workers, 0)
+        preds, targets, masks = [], [], []
+        wrapper.reset()
+        policy = wrapper._policy
+        policy.eval()
+        with torch.inference_mode():
+            for idx, batch in enumerate(loader):
+                if self.max_batches is not None and idx >= int(self.max_batches):
+                    break
+                target = batch["action"].detach().clone()
+                pad = batch.get("action_is_pad")
+                processed = wrapper._preprocessor(batch)
+                chunk = policy.predict_action_chunk(processed)
+                chunk = wrapper._postprocessor(chunk)
+                dim = target.shape[-1]
+                preds.append(chunk[:, : target.shape[1], :dim].detach().cpu())
+                targets.append(target.cpu())
+                masks.append(
+                    (~pad).cpu()
+                    if pad is not None
+                    else torch.ones(target.shape[:2], dtype=torch.bool)
+                )
+        if not preds:
+            raise ValueError("No batches evaluated.")
+        metrics = action_error(
+            torch.cat(preds),
+            torch.cat(targets),
+            mask=torch.cat(masks),
+            names=bundle.action_names or wrapper.action_names,
+        )
+        metrics["episodes"] = (
+            bundle.val_episodes
+            if self.split == "val"
+            else bundle.train_episodes
+            if self.split == "train"
+            else list(range(bundle.meta.total_episodes))
+        )
+        if self.verbose:
+            logger.info(
+                "val/action_l1 %.5f  val/action_mse %.5f  val/action_l1_first %.5f  steps %d",
+                metrics["val/action_l1"],
+                metrics["val/action_mse"],
+                metrics["val/action_l1_first"],
+                metrics["val/steps"],
+            )
+        return metrics

--- a/libreyolo/tasks.py
+++ b/libreyolo/tasks.py
@@ -27,6 +27,7 @@ TaskType = Literal[
     "embed",
     "mesh",
     "detect3d",
+    "act",
 ]
 TASKS = (
     "detect",
@@ -48,6 +49,7 @@ TASKS = (
     "embed",
     "mesh",
     "detect3d",
+    "act",
 )
 
 TASK_ALIASES = {
@@ -140,6 +142,14 @@ TASK_ALIASES = {
     "hmr": "mesh",
     "human-mesh-recovery": "mesh",
     "human_mesh_recovery": "mesh",
+    # Vision-language-action policies: an action chunk is the primitive.
+    "act": "act",
+    "action": "act",
+    "actions": "act",
+    "vla": "act",
+    "policy": "act",
+    "robot-policy": "act",
+    "robot_policy": "act",
 }
 
 TASK_TO_SUFFIX = {
@@ -161,6 +171,7 @@ TASK_TO_SUFFIX = {
     "ocr": "ocr",
     "embed": "embed",
     "mesh": "mesh",
+    "act": "act",
 }
 
 SUFFIX_TO_TASK = {v: k for k, v in TASK_TO_SUFFIX.items()}

--- a/libreyolo/utils/drawing.py
+++ b/libreyolo/utils/drawing.py
@@ -1238,3 +1238,66 @@ def draw_boxes3d(image, boxes3d, near_clip=0.01):
             xy = np.clip(xy, -1e6, 1e6)
             draw.line([tuple(xy[0]), tuple(xy[1])], fill=(0, 220, 120), width=2)
     return canvas
+
+
+def draw_actions(
+    image: Image.Image,
+    actions,
+    panel_height: int | None = None,
+) -> Image.Image:
+    """Render an ``Actions`` chunk as a trajectory strip under the frame.
+
+    One polyline per action dimension, each scaled to its own range so a
+    gripper and a shoulder joint stay readable side by side. The instruction
+    is written as the panel title, the per-dimension names (or indices) as
+    the legend. Pure PIL so it needs no plotting dependency.
+    """
+    frame = image.convert("RGB")
+    w, h = frame.size
+    panel_h = int(panel_height) if panel_height else max(140, int(h * 0.35))
+    canvas = Image.new("RGB", (w, h + panel_h), (24, 24, 24))
+    canvas.paste(frame, (0, 0))
+    draw = ImageDraw.Draw(canvas)
+    font = _get_font(max(11, min(16, w // 50)))
+
+    data = actions.data
+    if hasattr(data, "detach"):
+        data = data.detach().cpu().numpy()
+    data = np.asarray(data, dtype=np.float32)
+    horizon, dim = data.shape
+    names = actions.names or [f"a{i}" for i in range(dim)]
+
+    title = actions.instruction or "action chunk"
+    title = f"{title}  ({horizon} steps x {dim} dims"
+    title += f", {actions.fps:g} Hz)" if actions.fps else ")"
+    draw.text((8, h + 6), title, fill=(235, 235, 235), font=font)
+
+    legend_w = min(w // 3, 12 + max(draw.textlength(n, font=font) for n in names))
+    top = h + 30
+    bottom = h + panel_h - 8
+    left = 8 + int(legend_w)
+    right = w - 8
+    if bottom - top < 10 or right - left < 10:
+        return canvas
+    draw.line([(left, top), (left, bottom), (right, bottom)], fill=(90, 90, 90))
+    xs = (
+        [left + (right - left) * t / max(horizon - 1, 1) for t in range(horizon)]
+        if horizon > 1
+        else [left]
+    )
+    for d in range(dim):
+        color = _get_class_color_rgb(d)
+        col = data[:, d]
+        lo, hi = float(col.min()), float(col.max())
+        span = hi - lo if hi > lo else 1.0
+        ys = [bottom - (bottom - top) * (v - lo) / span for v in col]
+        pts = list(zip(xs, ys))
+        if len(pts) > 1:
+            draw.line(pts, fill=color, width=2)
+        else:
+            x, y = pts[0]
+            draw.ellipse([x - 3, y - 3, x + 3, y + 3], fill=color)
+        label_y = top + d * (font.size + 2)
+        if label_y + font.size < bottom:
+            draw.text((8, label_y), names[d], fill=color, font=font)
+    return canvas

--- a/libreyolo/utils/results.py
+++ b/libreyolo/utils/results.py
@@ -545,6 +545,117 @@ class Points(_TensorPayload):
         )
 
 
+class Actions(_TensorPayload):
+    """An action chunk from a vision-language-action policy (ADR 0028).
+
+    ``data`` is ``(T, D)`` float32: ``T`` timesteps of a ``D``-dimensional
+    action. Row 0 is the action to execute now; later rows are the policy's
+    plan at the control rate ``fps``. Values are in the units the policy was
+    trained on; LibreYOLO does not reinterpret them. ``names`` carries the
+    per-dimension names when the checkpoint knows them, ``instruction`` the
+    text that produced the chunk. Slicing selects timesteps.
+    """
+
+    def __init__(
+        self,
+        data: TensorLike,
+        orig_shape: Tuple[int, int] | None = None,
+        *,
+        names: Optional[List[str]] = None,
+        fps: Optional[float] = None,
+        instruction: Optional[str] = None,
+    ):
+        if not isinstance(data, (torch.Tensor, np.ndarray)):
+            data = torch.as_tensor(np.asarray(data, dtype=np.float32))
+        if data.ndim == 1:
+            data = data.unsqueeze(0) if isinstance(data, torch.Tensor) else data[None, :]
+        if data.ndim != 2:
+            raise ValueError(
+                f"Actions data must have shape (T, D), got {tuple(data.shape)}."
+            )
+        finite = (
+            bool(torch.isfinite(data).all())
+            if isinstance(data, torch.Tensor)
+            else bool(np.isfinite(data).all())
+        )
+        if not finite:
+            raise ValueError("Actions data must be finite.")
+        if names is not None:
+            names = [str(n) for n in names]
+            if len(names) != int(data.shape[1]):
+                raise ValueError(
+                    f"Actions names has {len(names)} entries for {int(data.shape[1])} "
+                    "action dimensions."
+                )
+        if fps is not None:
+            fps = float(fps)
+            if not fps > 0:
+                raise ValueError("Actions fps must be positive.")
+        super().__init__(data, orig_shape)
+        self.names = names
+        self.fps = fps
+        self.instruction = str(instruction) if instruction is not None else None
+
+    def _clone(self, data: TensorLike) -> "Actions":
+        return Actions(
+            data,
+            self.orig_shape,
+            names=self.names,
+            fps=self.fps,
+            instruction=self.instruction,
+        )
+
+    @property
+    def horizon(self) -> int:
+        """Number of timesteps in the chunk."""
+        return int(self.data.shape[0])
+
+    @property
+    def dim(self) -> int:
+        """Action dimensionality."""
+        return int(self.data.shape[1])
+
+    @property
+    def first(self) -> TensorLike:
+        """The action to execute now, shape ``(D,)``."""
+        return self.data[0]
+
+    def to(self, *args, **kwargs):
+        return self._clone(_move(self.data, *args, **kwargs))
+
+    def cpu(self):
+        return self._clone(_cpu(self.data))
+
+    def cuda(self):
+        return self._clone(_cuda(self.data))
+
+    def numpy(self):
+        return self._clone(_numpy(self.data))
+
+    def __getitem__(self, idx):
+        return self._clone(_slice_first(self.data, idx))
+
+    def to_dict(self, decimals: int = 5) -> Dict[str, Any]:
+        """One JSON-ready record for the whole chunk."""
+        rows = _numpy(self.data) if isinstance(self.data, torch.Tensor) else self.data
+        return {
+            "instruction": self.instruction,
+            "horizon": self.horizon,
+            "dim": self.dim,
+            "fps": self.fps,
+            "names": list(self.names) if self.names is not None else None,
+            "actions": [
+                [round(float(v), decimals) for v in row] for row in np.asarray(rows)
+            ],
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"Actions(horizon={self.horizon}, dim={self.dim}, "
+            f"instruction={self.instruction!r})"
+        )
+
+
 class Probs(_TensorPayload):
     @property
     def top1(self) -> int:
@@ -1752,6 +1863,7 @@ class Results:
         "identities",
         "meshes",
         "boxes3d",
+        "actions",
     )
 
     def __init__(
@@ -1785,6 +1897,7 @@ class Results:
         edges: Optional[EdgeMap] = None,
         boxes3d: Optional[Boxes3D] = None,
         albedo: Optional[AlbedoMap] = None,
+        actions: Optional[Actions] = None,
     ):
         if boxes is not None and boxes.orig_shape is None:
             boxes = boxes.with_orig_shape(orig_shape)
@@ -1827,6 +1940,7 @@ class Results:
         self.ocr = ocr
         self.meshes = meshes
         self.boxes3d = boxes3d
+        self.actions = actions
         # Integer upscale factor of a restore/super-resolution result: the
         # restored canvas is ``restore_scale`` times the input. 1 for
         # deblur/denoise and every non-restore task.
@@ -1865,6 +1979,7 @@ class Results:
             "ocr": self.ocr,
             "meshes": self.meshes,
             "boxes3d": self.boxes3d,
+            "actions": self.actions,
             "restore_scale": self.restore_scale,
             "embeddings": self.embeddings,
             "identities": self.identities,
@@ -1938,6 +2053,7 @@ class Results:
         edges: Optional[EdgeMap] = None,
         boxes3d: Optional[Boxes3D] = None,
         albedo: Optional[AlbedoMap] = None,
+        actions: Optional[Actions] = None,
     ) -> "Results":
         aligned_cuboids = boxes3d if boxes3d is not None else self.boxes3d
         if aligned_cuboids is not None:
@@ -1988,6 +2104,8 @@ class Results:
             self.restored = restored
         if boxes3d is not None:
             self.boxes3d = boxes3d
+        if actions is not None:
+            self.actions = actions
         if meshes is not None:
             self.meshes = meshes
         if matte is not None:
@@ -2026,7 +2144,13 @@ class Results:
         self.normal_map = value
 
     def plot(self, image=None):
-        """Render dense outputs or calibrated 3D cuboids."""
+        """Render dense outputs, calibrated 3D cuboids, or an action chunk."""
+        if self.actions is not None:
+            from PIL import Image
+            from .drawing import draw_actions
+
+            canvas = Image.fromarray(self._source_rgb(image, self.orig_shape))
+            return draw_actions(canvas, self.actions)
         if self.albedo is not None:
             from PIL import Image
 
@@ -2134,6 +2258,8 @@ class Results:
         embeddings: bool = False,
     ) -> List[Dict[str, Any]]:
         if self.boxes is None:
+            if self.actions is not None:
+                return [self.actions.to_dict(decimals)]
             if self.embeddings is not None:
                 emb = (
                     self.embeddings.numpy()
@@ -2439,6 +2565,8 @@ class Results:
             return len(self.boxes)
         if self.points is not None:
             return len(self.points)
+        if self.actions is not None:
+            return len(self.actions)
         if self.embeddings is not None:
             return len(self.embeddings)
         if self.probs is not None:
@@ -2499,6 +2627,8 @@ class Results:
             parts.append(f"meshes={self.meshes}")
         if self.boxes3d is not None:
             parts.append(f"boxes3d={self.boxes3d}")
+        if self.actions is not None:
+            parts.append(f"actions={self.actions}")
         if self.track_id is not None:
             parts.append(f"track_ids={len(self.track_id)}")
         if self.frame_idx is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,14 @@ fast-eval = [
     # platform without one must not be able to break a plain `pip install`.
     "faster-coco-eval>=1.7.0",
 ]
+vla = [
+    # LibreVLA loads vision-language-action policies through the Apache-2.0
+    # lerobot package (policy classes, processor pipelines, LeRobot datasets).
+    # lerobot requires Python >= 3.12, so the extra installs nothing on older
+    # interpreters and the tier raises an ImportError that says so. Kept out
+    # of `all` for the same reason.
+    "lerobot[smolvla,dataset]>=0.6.1; python_version >= '3.12'",
+]
 llm = [
     # LibreLLM talks to OpenAI-compatible Responses / Chat Completions
     # endpoints through the official Apache-2.0 OpenAI Python SDK.
@@ -543,6 +551,7 @@ markers = [
     "vgg: tests covering the LibreVGG classification family",
     "vlm: tests covering the LibreVLM (VLM-as-detector) tier",
     "llm: tests covering the LibreLLM OpenAI-compatible client",
+    "vla: tests covering the LibreVLA (vision-language-action) tier",
     "sam: tests covering the LibreSAM (promptable-segmentation) tier",
     "openvocab: tests covering the LibreOpenVocab detector tier",
     "sensenova: tests covering the LibreSenseNovaVision unified multimodal family",

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1060,7 +1060,7 @@
     "task_sizes": {},
     "export_override": "blocked",
     "optional_extra": "onnx",
-    "available": true,
+    "available": false,
     "group": "g3"
   },
   "levjepa": {
@@ -2051,6 +2051,24 @@
     "export_override": "custom",
     "optional_extra": null,
     "available": true,
+    "group": "s"
+  },
+  "smolvla": {
+    "class": "libreyolo.models.vla.smolvla.LibreSmolVLA",
+    "tasks": [
+      "act"
+    ],
+    "default_task": "act",
+    "sizes": {
+      "base": 512
+    },
+    "default_imgsz": {
+      "base": 512
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "vla",
+    "available": false,
     "group": "s"
   },
   "smolvlm2": {

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -1060,7 +1060,7 @@
     "task_sizes": {},
     "export_override": "blocked",
     "optional_extra": "onnx",
-    "available": false,
+    "available": true,
     "group": "g3"
   },
   "levjepa": {
@@ -2053,24 +2053,6 @@
     "available": true,
     "group": "s"
   },
-  "smolvla": {
-    "class": "libreyolo.models.vla.smolvla.LibreSmolVLA",
-    "tasks": [
-      "act"
-    ],
-    "default_task": "act",
-    "sizes": {
-      "base": 512
-    },
-    "default_imgsz": {
-      "base": 512
-    },
-    "task_sizes": {},
-    "export_override": "blocked",
-    "optional_extra": "vla",
-    "available": false,
-    "group": "s"
-  },
   "smolvlm2": {
     "class": "libreyolo.models.vlm.smolvlm.LibreSmolVLM2",
     "tasks": [
@@ -2609,5 +2591,23 @@
     "optional_extra": null,
     "available": true,
     "group": "g3"
+  },
+  "smolvla": {
+    "class": "libreyolo.models.vla.smolvla.LibreSmolVLA",
+    "tasks": [
+      "act"
+    ],
+    "default_task": "act",
+    "sizes": {
+      "base": 512
+    },
+    "default_imgsz": {
+      "base": 512
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "vla",
+    "available": false,
+    "group": "s"
   }
 }

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -2053,6 +2053,24 @@
     "available": true,
     "group": "s"
   },
+  "smolvla": {
+    "class": "libreyolo.models.vla.smolvla.LibreSmolVLA",
+    "tasks": [
+      "act"
+    ],
+    "default_task": "act",
+    "sizes": {
+      "base": 512
+    },
+    "default_imgsz": {
+      "base": 512
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "vla",
+    "available": false,
+    "group": "s"
+  },
   "smolvlm2": {
     "class": "libreyolo.models.vlm.smolvlm.LibreSmolVLM2",
     "tasks": [
@@ -2591,23 +2609,5 @@
     "optional_extra": null,
     "available": true,
     "group": "g3"
-  },
-  "smolvla": {
-    "class": "libreyolo.models.vla.smolvla.LibreSmolVLA",
-    "tasks": [
-      "act"
-    ],
-    "default_task": "act",
-    "sizes": {
-      "base": 512
-    },
-    "default_imgsz": {
-      "base": 512
-    },
-    "task_sizes": {},
-    "export_override": "blocked",
-    "optional_extra": "vla",
-    "available": false,
-    "group": "s"
   }
 }

--- a/tests/smoke/install_surface.py
+++ b/tests/smoke/install_surface.py
@@ -139,6 +139,13 @@ def _check_import_surface(expect_source: str, source_root: Path | None) -> None:
 
     if not callable(LibreVLM):
         raise AssertionError("LibreVLM import did not resolve to a callable")
+    # The LibreVLA tier is importable without the vla extra (lerobot loads lazily).
+    from libreyolo import Actions, LibreSmolVLA, LibreVLA
+
+    if not callable(LibreVLA):
+        raise AssertionError("LibreVLA import did not resolve to a callable")
+    if not isinstance(LibreSmolVLA, type) or not isinstance(Actions, type):
+        raise AssertionError("LibreVLA family/payload exports did not resolve to classes")
     for family in (
         LibreQwen3VL,
         LibreLFM2VL,

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -109,6 +109,7 @@ def test_task_type_literal_is_public():
         "embed",
         "mesh",
         "detect3d",
+        "act",
     }
 
 

--- a/tests/unit/test_vla_api.py
+++ b/tests/unit/test_vla_api.py
@@ -1,0 +1,488 @@
+"""Offline unit tests for the LibreVLA tier (no lerobot, no weights, no network).
+
+Covers the ``act`` task registration, the ``Actions`` payload and its
+``Results`` integration, the observation contract (camera mapping, state
+coercion, instruction), the factory, the checkpoint contract, the offline
+metric, and the predict surface end to end through a fake family.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo import Actions, LibreSmolVLA, LibreVLA, Results
+from libreyolo.models.vla import _load_checkpoint
+from libreyolo.models.vla.base import LibreVLAModel
+from libreyolo.models.vla.checkpoint import (
+    CONTRACT_FILENAME,
+    is_vla_checkpoint,
+    read_contract,
+    write_contract,
+)
+from libreyolo.models.vla.metrics import action_error
+from libreyolo.models.vla.observation import (
+    Observation,
+    action_names_from_features,
+    coerce_state,
+    frame_to_tensor,
+    map_cameras,
+)
+from libreyolo.tasks import TASKS, normalize_task, suffix_to_task, task_to_suffix
+from libreyolo.utils.drawing import draw_actions
+
+pytestmark = [pytest.mark.unit, pytest.mark.vla]
+
+
+# ---------------------------------------------------------------------------
+# Task registration
+# ---------------------------------------------------------------------------
+
+
+def test_act_task_is_canonical():
+    assert "act" in TASKS
+    for alias in ("act", "action", "actions", "vla", "policy", "robot-policy"):
+        assert normalize_task(alias) == "act"
+    assert task_to_suffix("act") == "act"
+    assert suffix_to_task("-act") == "act"
+
+
+# ---------------------------------------------------------------------------
+# Actions payload
+# ---------------------------------------------------------------------------
+
+
+class TestActions:
+    def test_shape_and_metadata(self):
+        a = Actions(
+            torch.zeros(5, 3), (10, 20), names=["x", "y", "g"], fps=30, instruction="go"
+        )
+        assert a.horizon == 5 and a.dim == 3 and len(a) == 5
+        assert a.first.shape == (3,)
+        assert a.names == ["x", "y", "g"] and a.fps == 30.0 and a.instruction == "go"
+        assert "horizon=5" in repr(a)
+
+    def test_one_dimensional_becomes_single_step(self):
+        a = Actions(np.array([1.0, 2.0]))
+        assert a.horizon == 1 and a.dim == 2
+
+    def test_rejects_bad_input(self):
+        with pytest.raises(ValueError):
+            Actions(torch.zeros(2, 2, 2))
+        with pytest.raises(ValueError):
+            Actions(torch.tensor([[float("nan"), 0.0]]))
+        with pytest.raises(ValueError):
+            Actions(torch.zeros(2, 3), names=["a", "b"])
+        with pytest.raises(ValueError):
+            Actions(torch.zeros(2, 3), fps=0)
+
+    def test_slice_and_move_keep_metadata(self):
+        a = Actions(
+            torch.arange(12.0).reshape(4, 3),
+            names=["a", "b", "c"],
+            fps=10,
+            instruction="t",
+        )
+        s = a[1:3]
+        assert (
+            s.horizon == 2
+            and s.names == ["a", "b", "c"]
+            and s.fps == 10
+            and s.instruction == "t"
+        )
+        one = a[0]
+        assert one.horizon == 1 and float(one.first[1]) == 1.0
+        n = a.numpy()
+        assert isinstance(n.data, np.ndarray) and n.names == a.names
+        c = a.cpu().to(torch.float64)
+        assert c.data.dtype == torch.float64 and c.instruction == "t"
+
+    def test_to_dict_rounds(self):
+        a = Actions(
+            torch.tensor([[0.123456, 1.0]]), names=["p", "q"], fps=5, instruction="i"
+        )
+        d = a.to_dict(decimals=3)
+        assert d == {
+            "instruction": "i",
+            "horizon": 1,
+            "dim": 2,
+            "fps": 5.0,
+            "names": ["p", "q"],
+            "actions": [[0.123, 1.0]],
+        }
+
+
+class TestResultsWithActions:
+    def _result(self):
+        a = Actions(
+            torch.arange(6.0).reshape(3, 2), names=["a", "b"], fps=2, instruction="pick"
+        )
+        return Results(None, (8, 6), path=None, names={}, actions=a)
+
+    def test_len_summary_json_repr(self):
+        r = self._result()
+        assert len(r) == 3
+        assert r.boxes is None and r.actions.horizon == 3
+        rows = json.loads(r.to_json())
+        assert (
+            len(rows) == 1 and rows[0]["instruction"] == "pick" and rows[0]["dim"] == 2
+        )
+        assert "actions=" in repr(r)
+
+    def test_slice_moves_and_update(self):
+        r = self._result()
+        first = r[0]
+        assert first.actions.horizon == 1 and first.actions.names == ["a", "b"]
+        assert isinstance(r.numpy().actions.data, np.ndarray)
+        r2 = self._result()
+        r2.update(actions=Actions(torch.zeros(1, 2)))
+        assert r2.actions.horizon == 1
+
+    def test_plot_appends_strip(self):
+        r = self._result()
+        img = Image.new("RGB", (6, 8), (0, 0, 0))
+        out = r.plot(img)
+        assert out.size[0] == 6 and out.size[1] > 8
+        strip = draw_actions(Image.new("RGB", (300, 100)), r.actions, panel_height=120)
+        assert strip.size == (300, 220)
+
+    def test_plot_needs_source_when_path_unset(self):
+        with pytest.raises(ValueError):
+            self._result().plot()
+
+
+# ---------------------------------------------------------------------------
+# Observation contract
+# ---------------------------------------------------------------------------
+
+
+class TestMapCameras:
+    SLOTS = ["camera1", "camera2", "camera3"]
+
+    def test_slot_names_take_their_slot_and_others_fill_in_order(self):
+        out = map_cameras({"wrist": 1, "camera1": 2}, self.SLOTS)
+        assert out == {"camera1": 2, "camera2": 1}
+
+    def test_explicit_cameras_map_by_position(self):
+        out = map_cameras(
+            {"front": 1, "side": 2}, self.SLOTS, cameras=["side", "front"]
+        )
+        assert out == {"camera1": 2, "camera2": 1}
+
+    def test_unknown_name_with_explicit_cameras_raises(self):
+        with pytest.raises(ValueError, match="not in cameras"):
+            map_cameras({"top": 1}, self.SLOTS, cameras=["front"])
+
+    def test_too_many_frames_raises(self):
+        with pytest.raises(ValueError, match="camera slot"):
+            map_cameras({"a": 1, "b": 2}, ["camera1"])
+        with pytest.raises(ValueError):
+            map_cameras({}, self.SLOTS)
+
+
+class TestCoerceState:
+    def test_array_callable_and_none(self):
+        warnings = []
+        assert coerce_state([1, 2, 3], 3, warn=warnings.append).tolist() == [
+            1.0,
+            2.0,
+            3.0,
+        ]
+        assert coerce_state(lambda: np.ones(3), 3).dtype == np.float32
+        zeros = coerce_state(None, 3, warn=warnings.append)
+        assert zeros.tolist() == [0.0, 0.0, 0.0] and len(warnings) == 1
+
+    def test_wrong_length_or_nonfinite_raises(self):
+        with pytest.raises(ValueError, match="expects 3"):
+            coerce_state([1, 2], 3)
+        with pytest.raises(ValueError, match="finite"):
+            coerce_state([1, float("inf"), 2], 3)
+
+
+def test_frame_to_tensor_and_action_names():
+    t = frame_to_tensor(Image.new("RGB", (4, 2), (255, 0, 0)))
+    assert (
+        t.shape == (3, 2, 4) and float(t[0, 0, 0]) == 1.0 and float(t[1, 0, 0]) == 0.0
+    )
+    assert action_names_from_features({"action": {"names": ["j1", "j2"]}}) == [
+        "j1",
+        "j2",
+    ]
+    assert action_names_from_features({"action": {"names": {"motors": ["m1"]}}}) == [
+        "m1"
+    ]
+    assert action_names_from_features({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Factory and install gating
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_default_alias_and_lazy_load(self):
+        model = LibreVLA(device="cpu")
+        assert isinstance(model, LibreSmolVLA)
+        assert model.size == "base" and model.task == "act"
+        assert model._policy is None  # nothing downloaded or loaded yet
+        assert model.model_path == "lerobot/smolvla_base"
+
+    def test_reserved_and_unknown_aliases(self):
+        with pytest.raises(ValueError, match="reserved"):
+            LibreVLA("pi0")
+        with pytest.raises(ValueError, match="Unknown VLA model"):
+            LibreVLA("not-a-policy")
+
+    def test_pinned_revision_is_a_commit_sha(self):
+        for size, sha in LibreSmolVLA.HF_REVISIONS.items():
+            assert size in LibreSmolVLA.HF_REPOS
+            assert len(sha) == 40 and int(sha, 16) >= 0
+
+    def test_instruction_and_task_validation(self):
+        model = LibreVLA(device="cpu", instruction="  push the cube ")
+        assert model.instruction == "push the cube"
+        with pytest.raises(ValueError):
+            model.set_instruction("   ")
+        with pytest.raises(ValueError, match="act"):
+            LibreSmolVLA(task="detect", device="cpu")
+        with pytest.raises(AttributeError, match="set_instruction"):
+            model.set_classes(["cube"])
+
+    def test_missing_lerobot_raises_install_hint(self, monkeypatch, tmp_path):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("lerobot"):
+                raise ImportError("no lerobot")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        model = LibreVLA(device="cpu")
+        monkeypatch.setattr(model, "_ensure_weights", lambda: str(tmp_path))
+        with pytest.raises(ImportError, match=r"libreyolo\[vla\]"):
+            model.predict(Image.new("RGB", (8, 8)), instruction="go")
+
+    def test_unsupported_surfaces_raise(self):
+        model = LibreVLA(device="cpu")
+        with pytest.raises(NotImplementedError):
+            model.export("onnx")
+        with pytest.raises(NotImplementedError):
+            model.track("x.mp4")
+        with pytest.raises(ValueError, match="data="):
+            model.train()
+        with pytest.raises(ValueError, match="data="):
+            model.val()
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint contract
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_contract_roundtrip(tmp_path):
+    assert not is_vla_checkpoint(tmp_path)
+    assert not is_vla_checkpoint(123)
+    path = write_contract(
+        tmp_path,
+        family="smolvla",
+        size="base",
+        base_repo="lerobot/smolvla_base",
+        base_revision="c" * 40,
+        data="lerobot/svla_so101_pickplace",
+        fps=30,
+        cameras=["up", "side"],
+        action_names=["a"] * 6,
+        state_names=None,
+        chunk_size=50,
+    )
+    assert path.name == CONTRACT_FILENAME and is_vla_checkpoint(tmp_path)
+    contract = read_contract(tmp_path)
+    assert contract["cameras"] == ["up", "side"] and contract["fps"] == 30
+    assert contract["schema"] == 1 and contract["libreyolo_version"]
+
+    model = LibreVLA(str(tmp_path), device="cpu")
+    assert isinstance(model, LibreSmolVLA)
+    assert model.camera_slots == ["up", "side"]
+    assert model.action_names == ["a"] * 6 and model.fps == 30
+    assert model.model_path == str(tmp_path)
+
+    (tmp_path / CONTRACT_FILENAME).write_text(
+        json.dumps({"schema": 99, "family": "smolvla", "size": "base"})
+    )
+    with pytest.raises(ValueError, match="schema"):
+        read_contract(tmp_path)
+    (tmp_path / CONTRACT_FILENAME).write_text(
+        json.dumps({"schema": 1, "family": "other", "size": "base"})
+    )
+    with pytest.raises(ValueError, match="unknown family"):
+        _load_checkpoint(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Offline metric
+# ---------------------------------------------------------------------------
+
+
+class TestActionError:
+    def test_perfect_prediction_is_zero(self):
+        target = torch.arange(24.0).reshape(2, 4, 3)
+        m = action_error(target.clone(), target, names=["a", "b", "c"])
+        assert m["val/action_l1"] == 0.0 and m["val/action_mse"] == 0.0
+        assert m["val/action_l1_dims"] == {"a": 0.0, "b": 0.0, "c": 0.0}
+        assert m["val/steps"] == 8
+
+    def test_mask_and_values(self):
+        target = torch.zeros(1, 2, 2)
+        pred = torch.tensor([[[1.0, 3.0], [100.0, 100.0]]])
+        m = action_error(pred, target, mask=torch.tensor([[True, False]]))
+        assert m["val/action_l1"] == 2.0 and m["val/action_l1_first"] == 2.0
+        assert m["val/action_mse"] == 5.0 and m["val/steps"] == 1
+        assert m["val/action_l1_dims"] == {"a0": 1.0, "a1": 3.0}
+
+    def test_shape_errors(self):
+        with pytest.raises(ValueError):
+            action_error(torch.zeros(2, 3), torch.zeros(3, 3))
+        with pytest.raises(ValueError, match="mask"):
+            action_error(
+                torch.zeros(1, 2, 2),
+                torch.zeros(1, 2, 2),
+                mask=torch.zeros(3, dtype=torch.bool),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Predict surface through a fake family
+# ---------------------------------------------------------------------------
+
+
+class FakeVLA(LibreVLAModel):
+    FAMILY = "fakevla"
+    FILENAME_PREFIX = "LibreFakeVLA"
+    HF_REPOS = {"tiny": "fake/tiny"}
+    INPUT_SIZES = {"tiny": 8}
+
+    def __init__(self, **kwargs):
+        super().__init__("tiny", **kwargs)
+        self.seen = []
+
+    def _ensure_weights(self):
+        return "fake-dir"
+
+    def _load_policy(self, snapshot_dir):
+        self.loaded_from = snapshot_dir
+        self._policy = SimpleNamespace(reset=lambda: None, to=lambda device: None)
+
+    @property
+    def camera_slots(self):
+        return ["camera1", "camera2"]
+
+    @property
+    def state_dim(self):
+        return 2
+
+    @property
+    def action_dim(self):
+        return 3
+
+    @property
+    def chunk_size(self):
+        return 4
+
+    def _predict_chunk(self, observation: Observation):
+        self.seen.append(observation)
+        base = torch.arange(12.0).reshape(4, 3)
+        return base + float(observation.state.sum())
+
+
+@pytest.fixture
+def fake():
+    return FakeVLA(device="cpu")
+
+
+def _img(w=6, h=4):
+    return Image.new("RGB", (w, h), (10, 20, 30))
+
+
+class TestPredict:
+    def test_single_frame_goes_to_first_slot(self, fake):
+        r = fake.predict(_img(), state=[1, 2], instruction="go")
+        assert isinstance(r, Results) and r.orig_shape == (4, 6)
+        assert r.actions.horizon == 4 and r.actions.dim == 3
+        assert float(r.actions.first[0]) == 3.0  # state sum added
+        obs = fake.seen[-1]
+        assert list(obs.frames) == ["camera1"] and obs.instruction == "go"
+        assert fake.loaded_from == "fake-dir"
+
+    def test_dict_maps_cameras_and_sticky_instruction(self, fake):
+        fake.set_instruction("stack")
+        r = fake.predict({"wrist": _img(3, 3), "camera1": _img()}, state=np.zeros(2))
+        assert r.orig_shape == (4, 6)  # primary is slot camera1
+        assert list(fake.seen[-1].frames) == ["camera1", "camera2"]
+        assert r.actions.instruction == "stack"
+
+    def test_missing_instruction_raises(self, fake):
+        with pytest.raises(ValueError, match="instruction"):
+            fake.predict(_img(), state=[0, 0])
+
+    def test_state_none_warns_once_and_callable_is_called_per_frame(self, fake, caplog):
+        with caplog.at_level("WARNING"):
+            fake.predict([_img(), _img()], instruction="go")
+        assert sum("state=None" in m for m in caplog.messages) == 1
+        counter = {"n": 0}
+
+        def read_state():
+            counter["n"] += 1
+            return [counter["n"], 0]
+
+        results = fake.predict(
+            [_img(), _img(), _img()], state=read_state, instruction="go"
+        )
+        assert counter["n"] == 3 and [r.frame_idx for r in results] == [0, 1, 2]
+        assert float(results[2].actions.first[0]) == 3.0
+
+    def test_list_directory_and_stream_shapes(self, fake, tmp_path):
+        for i in range(2):
+            _img().save(tmp_path / f"f{i}.png")
+        results = fake.predict(str(tmp_path), state=[0, 0], instruction="go")
+        assert isinstance(results, list) and len(results) == 2
+        assert results[0].path.endswith("f0.png")
+        gen = fake.predict(
+            [_img(), {"camera2": _img()}], state=[0, 0], instruction="go", stream=True
+        )
+        assert hasattr(gen, "__next__")
+        assert len(list(gen)) == 2
+        with pytest.raises(ValueError, match="stream=True"):
+            fake.predict("rtsp://camera/1", state=[0, 0], instruction="go")
+
+    def test_reset_and_wrong_state(self, fake):
+        fake.reset()  # before load: no-op
+        with pytest.raises(ValueError, match="expects 2"):
+            fake.predict(_img(), state=[1, 2, 3], instruction="go")
+
+    def test_save_writes_render(self, fake, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        r = fake.predict(_img(40, 30), state=[0, 0], instruction="go", save=True)
+        saved = Path(r.saved_path)
+        assert saved.is_file()
+        assert (
+            saved.resolve().parent == (tmp_path / "runs" / "act" / "predict").resolve()
+        )
+        out = tmp_path / "explicit.png"
+        fake.predict(
+            _img(40, 30),
+            state=[0, 0],
+            instruction="go",
+            save=True,
+            output_path=str(out),
+        )
+        assert out.is_file()
+        with pytest.raises(ValueError, match="output_path"):
+            fake.predict(_img(), state=[0, 0], instruction="go", output_path="x.png")

--- a/tests/unit/test_vla_training.py
+++ b/tests/unit/test_vla_training.py
@@ -1,0 +1,460 @@
+"""Offline unit tests for LibreVLA training and validation.
+
+The upstream ``lerobot`` package is replaced by small fakes through the
+trainer's single import seam, so the loop, checkpointing, contract file,
+callbacks, split logic and the offline validator all run on CPU in seconds.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+from torch.utils.data import Dataset
+
+from libreyolo.models.vla.base import LibreVLAModel
+from libreyolo.models.vla.checkpoint import CONTRACT_FILENAME, read_contract
+from libreyolo.models.vla.training import trainer as trainer_mod
+from libreyolo.models.vla.training.data import (
+    camera_names,
+    camera_rename_map,
+    resolve_data_source,
+    split_episodes,
+)
+from libreyolo.models.vla.training.trainer import VLATrainer, VLAValidator
+from libreyolo.training.callbacks import TrainEndEvent, TrainEpochEvent, TrainStartEvent
+
+pytestmark = [pytest.mark.unit, pytest.mark.vla]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSplitEpisodes:
+    def test_default_holds_out_tail(self):
+        assert split_episodes(10) == (list(range(9)), [9])
+        assert split_episodes(20, val_split=0.25) == (
+            list(range(15)),
+            [15, 16, 17, 18, 19],
+        )
+        assert split_episodes(1) == ([0], [])
+        assert split_episodes(2) == ([0], [1])
+        assert split_episodes(5, val_split=0.0) == ([0, 1, 2, 3, 4], [])
+
+    def test_explicit_lists(self):
+        assert split_episodes(5, val_episodes=[1, 3]) == ([0, 2, 4], [1, 3])
+        assert split_episodes(5, train_episodes=[0], val_episodes=[4]) == ([0], [4])
+        with pytest.raises(ValueError, match="overlap"):
+            split_episodes(5, train_episodes=[0, 1], val_episodes=[1])
+        with pytest.raises(ValueError, match="outside"):
+            split_episodes(5, val_episodes=[7])
+        with pytest.raises(ValueError):
+            split_episodes(0)
+        with pytest.raises(ValueError):
+            split_episodes(5, val_split=1.0)
+
+
+def test_camera_rename_map_and_names():
+    keys = [
+        "observation.images.up",
+        "observation.images.side",
+        "observation.images.wrist",
+    ]
+    slots = ["camera1", "camera2"]
+    assert camera_rename_map(keys, slots) == {
+        "observation.images.up": "observation.images.camera1",
+        "observation.images.side": "observation.images.camera2",
+    }
+    assert camera_names(keys, slots) == ["up", "side"]
+    assert camera_rename_map(["observation.images.camera1"], ["camera1"]) == {}
+
+
+def test_resolve_data_source(tmp_path):
+    src = resolve_data_source("lerobot/svla_so101_pickplace")
+    assert src.repo_id == "lerobot/svla_so101_pickplace" and src.root is None
+    (tmp_path / "meta").mkdir()
+    (tmp_path / "meta" / "info.json").write_text("{}")
+    local = resolve_data_source(tmp_path)
+    assert local.root == tmp_path.resolve() and local.repo_id == tmp_path.name
+    assert local.label == str(tmp_path.resolve())
+    with pytest.raises(ValueError, match="owner/name"):
+        resolve_data_source("nodataset")
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(ValueError, match="meta/info.json"):
+        resolve_data_source(empty)
+    with pytest.raises(ValueError):
+        resolve_data_source("")
+
+
+# ---------------------------------------------------------------------------
+# Fake upstream
+# ---------------------------------------------------------------------------
+
+T, D, S = 4, 3, 2
+
+
+class FakeDataset(Dataset):
+    def __init__(self, n):
+        self.n = n
+
+    def __len__(self):
+        return self.n
+
+    def __getitem__(self, idx):
+        g = torch.Generator().manual_seed(idx)
+        return {
+            "observation.images.up": torch.rand(3, 8, 8, generator=g),
+            "observation.state": torch.rand(1, S, generator=g),
+            "action": torch.rand(T, D, generator=g),
+            "action_is_pad": torch.tensor([False, False, False, idx % 2 == 1]),
+            "task": "fake task",
+        }
+
+
+class FakeMeta:
+    total_episodes = 5
+    fps = 30
+    camera_keys = ["observation.images.up"]
+    features = {
+        "action": {"names": ["j1", "j2", "j3"]},
+        "observation.state": {"names": ["s1", "s2"]},
+    }
+    stats = {"action": {"mean": torch.zeros(D), "std": torch.ones(D)}}
+
+
+class FakePolicy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.tensor(2.0))
+        self.saved = []
+
+    def forward(self, batch):
+        loss = (self.w * batch["action"].mean()) ** 2
+        return loss, {}
+
+    def get_optim_params(self):
+        return self.parameters()
+
+    def predict_action_chunk(self, batch):
+        return batch["action"] * 0 + self.w
+
+    def reset(self):
+        pass
+
+    def save_pretrained(self, directory):
+        directory = Path(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "config.json").write_text("{}")
+        (directory / "model.safetensors").write_bytes(b"fake")
+        self.saved.append(directory)
+
+
+class FakeProcessor:
+    def __init__(self, name):
+        self.name = name
+        self.saved = []
+
+    def __call__(self, batch):
+        return batch
+
+    def save_pretrained(self, directory):
+        self.saved.append(Path(directory))
+        (Path(directory) / f"{self.name}.json").write_text("{}")
+
+
+class FakeConfig:
+    def __init__(self):
+        self.input_features = {}
+        self.output_features = {}
+        self.normalization_mapping = {}
+        self.chunk_size = T
+        self.pretrained_path = None
+        self.device = None
+        self.saved = []
+
+    def get_optimizer_preset(self):
+        return SimpleNamespace(
+            lr=1e-1,
+            grad_clip_norm=1.0,
+            build=lambda params: torch.optim.SGD(params, lr=1e-1),
+        )
+
+    def get_scheduler_preset(self):
+        return None
+
+    def save_pretrained(self, directory):
+        self.saved.append(Path(directory))
+
+
+class FakeVLA(LibreVLAModel):
+    FAMILY = "smolvla"
+    FILENAME_PREFIX = "LibreFakeVLA"
+    HF_REPOS = {"base": "fake/base"}
+    HF_REVISIONS = {"base": "a" * 40}
+
+    def __init__(self, **kwargs):
+        super().__init__("base", **kwargs)
+        self._config = None
+        self.fake_policy = FakePolicy()
+
+    def _ensure_weights(self):
+        return "fake-base-dir"
+
+    def _pretrained_config(self, snapshot_dir):
+        return FakeConfig()
+
+    def _load_policy(self, snapshot_dir):
+        self._config = FakeConfig()
+        self._policy = self.fake_policy
+        self._preprocessor = FakeProcessor("pre")
+        self._postprocessor = FakeProcessor("post")
+
+    @property
+    def config(self):
+        if self._config is None:
+            self._ensure_loaded()
+        return self._config
+
+    @property
+    def camera_slots(self):
+        return ["camera1", "camera2", "camera3"]
+
+    @property
+    def state_dim(self):
+        return S
+
+    @property
+    def action_dim(self):
+        return D
+
+    @property
+    def chunk_size(self):
+        return T
+
+    def _predict_chunk(self, observation):
+        return torch.zeros(T, D)
+
+
+@pytest.fixture
+def fake_lerobot(monkeypatch):
+    made = {}
+
+    def make_policy(config, ds_meta=None, rename_map=None):
+        made["config"] = config
+        made["rename_map"] = rename_map
+        made["policy"] = FakePolicy()
+        return made["policy"]
+
+    def make_pre_post_processors(config, pretrained_path=None, **kwargs):
+        made["processor_kwargs"] = kwargs
+        return FakeProcessor("pre"), FakeProcessor("post")
+
+    def fake_bundle():
+        return (
+            lambda repo_id, root=None, episodes=None, delta_timestamps=None: (
+                FakeDataset(
+                    3
+                    * (
+                        len(episodes)
+                        if episodes is not None
+                        else FakeMeta.total_episodes
+                    )
+                )
+            ),
+            lambda repo_id, root=None: FakeMeta(),
+            lambda config, meta: {"action": [0.0]},
+            make_policy,
+            make_pre_post_processors,
+            lambda stats, rename_map: stats,
+        )
+
+    monkeypatch.setattr(trainer_mod, "_lerobot", fake_bundle)
+    return made
+
+
+# ---------------------------------------------------------------------------
+# Trainer
+# ---------------------------------------------------------------------------
+
+
+class Recorder:
+    """Object-style callback: plain callables only receive epoch events."""
+
+    def __init__(self):
+        self.events = []
+
+    def on_train_start(self, event):
+        self.events.append(event)
+
+    def on_train_epoch_end(self, event):
+        self.events.append(event)
+
+    def on_train_end(self, event):
+        self.events.append(event)
+
+    def on_train_exception(self, event):
+        self.events.append(event)
+
+
+def test_trainer_runs_saves_contract_and_emits_callbacks(fake_lerobot, tmp_path):
+    recorder = Recorder()
+    events = recorder.events
+    model = FakeVLA(device="cpu")
+    results = model.train(
+        data="fake/dataset",
+        epochs=2,
+        batch=4,
+        output_dir=str(tmp_path / "run"),
+        callbacks=[recorder],
+        loggers=None,
+        seed=1,
+    )
+    assert results["epochs"] == 2 and results["metric_name"] == "val/loss"
+    assert results["train_episodes"] == [0, 1, 2, 3] and results["val_episodes"] == [4]
+    assert results["best_epoch"] in (1, 2)
+    best, last = Path(results["best"]), Path(results["last"])
+    for directory in (best, last):
+        assert (directory / CONTRACT_FILENAME).is_file()
+        assert (directory / "model.safetensors").is_file()
+        assert (directory / "pre.json").is_file() and (
+            directory / "post.json"
+        ).is_file()
+    contract = read_contract(best)
+    assert contract["family"] == "smolvla" and contract["size"] == "base"
+    assert (
+        contract["base_repo"] == "fake/base" and contract["base_revision"] == "a" * 40
+    )
+    assert contract["cameras"] == ["up"] and contract["fps"] == 30.0
+    assert contract["action_names"] == ["j1", "j2", "j3"] and contract[
+        "state_names"
+    ] == ["s1", "s2"]
+    assert contract["chunk_size"] == T and contract["data"] == "fake/dataset"
+
+    # The dataset camera was renamed onto the first policy slot.
+    assert fake_lerobot["rename_map"] == {
+        "observation.images.up": "observation.images.camera1"
+    }
+    assert fake_lerobot["config"].pretrained_path == "fake-base-dir"
+    overrides = fake_lerobot["processor_kwargs"]["preprocessor_overrides"]
+    assert (
+        overrides["rename_observations_processor"]["rename_map"]
+        == fake_lerobot["rename_map"]
+    )
+    assert "normalizer_processor" in overrides
+
+    # Loss decreased: SGD on (w * mean)^2 drives w towards zero.
+    assert float(fake_lerobot["policy"].w.detach()) < 2.0
+
+    kinds = [type(e).__name__ for e in events]
+    assert kinds[0] == "TrainStartEvent" and kinds[-1] == "TrainEndEvent"
+    assert kinds.count("TrainEpochEvent") == 2
+    start = next(e for e in events if isinstance(e, TrainStartEvent))
+    assert start.task == "act" and start.config["family"] == "smolvla"
+    epoch = next(e for e in events if isinstance(e, TrainEpochEvent))
+    assert epoch.validated and "val/loss" in epoch.val_metrics
+    end = next(e for e in events if isinstance(e, TrainEndEvent))
+    assert end.results["best"] == results["best"]
+
+
+def test_trainer_increments_run_dir_and_honours_max_steps(fake_lerobot, tmp_path):
+    model = FakeVLA(device="cpu")
+    first = model.train(
+        data="fake/dataset",
+        epochs=1,
+        batch=2,
+        output_dir=str(tmp_path / "exp"),
+        max_steps=1,
+    )
+    second = model.train(
+        data="fake/dataset",
+        epochs=1,
+        batch=2,
+        output_dir=str(tmp_path / "exp"),
+        max_steps=1,
+    )
+    assert (
+        Path(first["save_dir"]).name == "exp"
+        and Path(second["save_dir"]).name == "exp2"
+    )
+
+
+def test_trainer_rejects_bad_config(fake_lerobot):
+    model = FakeVLA(device="cpu")
+    with pytest.raises(ValueError, match="epochs"):
+        VLATrainer(model, data="fake/dataset", epochs=0)
+    with pytest.raises(ValueError, match="batch"):
+        VLATrainer(model, data="fake/dataset", batch=0)
+    with pytest.raises(ValueError, match="overlap"):
+        model.train(data="fake/dataset", epochs=1, train_episodes=[0], val_episodes=[0])
+
+
+def test_train_and_val_without_lerobot_raise_install_hint(monkeypatch):
+    def missing():
+        raise ImportError("LibreVLA models require the 'vla' extra")
+
+    monkeypatch.setattr(trainer_mod, "_lerobot", missing)
+    model = FakeVLA(device="cpu")
+    with pytest.raises(ImportError, match="vla"):
+        model.train(data="fake/dataset", epochs=1)
+    with pytest.raises(ImportError, match="vla"):
+        model.val(data="fake/dataset")
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+def test_validator_reports_action_error_on_held_out_episodes(fake_lerobot):
+    model = FakeVLA(device="cpu")
+    metrics = model.val(data="fake/dataset", batch=3)
+    assert set(metrics) >= {
+        "val/action_l1",
+        "val/action_mse",
+        "val/action_l1_first",
+        "val/action_l1_dims",
+        "val/steps",
+        "episodes",
+    }
+    assert metrics["episodes"] == [4]
+    assert list(metrics["val/action_l1_dims"]) == ["j1", "j2", "j3"]
+    assert metrics["val/action_l1"] > 0  # the fake policy predicts a constant
+    # Padded steps are excluded: 3 frames x 4 steps minus one pad on odd frames.
+    assert metrics["val/steps"] == 3 * T - 1
+
+    all_metrics = VLAValidator(
+        model, data="fake/dataset", split="all", max_batches=1
+    ).run()
+    assert all_metrics["episodes"] == [0, 1, 2, 3, 4]
+    with pytest.raises(ValueError, match="split"):
+        VLAValidator(model, data="fake/dataset", split="test")
+
+
+def test_val_defaults_to_contract_dataset(fake_lerobot, tmp_path):
+    from libreyolo.models.vla.checkpoint import write_contract
+
+    write_contract(
+        tmp_path,
+        family="smolvla",
+        size="base",
+        base_repo="fake/base",
+        base_revision=None,
+        data="fake/dataset",
+        fps=30,
+        cameras=["up"],
+        action_names=["j1", "j2", "j3"],
+        state_names=None,
+        chunk_size=T,
+    )
+    model = FakeVLA(device="cpu", checkpoint_dir=str(tmp_path))
+    assert model.val()["episodes"] == [4]
+    assert (
+        json.loads((tmp_path / CONTRACT_FILENAME).read_text())["data"] == "fake/dataset"
+    )

--- a/tests/unit/test_vla_training.py
+++ b/tests/unit/test_vla_training.py
@@ -59,6 +59,14 @@ class TestSplitEpisodes:
         with pytest.raises(ValueError):
             split_episodes(5, val_split=1.0)
 
+    def test_validation_only_caller_may_hold_out_every_episode(self):
+        with pytest.raises(ValueError, match="empty"):
+            split_episodes(3, val_episodes=[0, 1, 2])
+        assert split_episodes(3, val_episodes=[0, 1, 2], allow_empty_train=True) == (
+            [],
+            [0, 1, 2],
+        )
+
 
 def test_camera_rename_map_and_names():
     keys = [
@@ -385,6 +393,44 @@ def test_trainer_increments_run_dir_and_honours_max_steps(fake_lerobot, tmp_path
     )
 
 
+def test_partial_accumulation_window_is_scaled_by_its_real_size(
+    fake_lerobot, tmp_path, monkeypatch
+):
+    """With 3 steps and accumulate=2 the tail window holds one step and must divide by 1."""
+    seen = []
+    real_backward = torch.Tensor.backward
+
+    def spy(self, *args, **kwargs):
+        seen.append(float(self.detach()))
+        return real_backward(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "backward", spy)
+    losses = []
+    orig_forward = FakePolicy.forward
+
+    def forward(self, batch):
+        loss, out = orig_forward(self, batch)
+        losses.append(float(loss.detach()))
+        return loss, out
+
+    monkeypatch.setattr(FakePolicy, "forward", forward)
+    model = FakeVLA(device="cpu")
+    model.train(
+        data="fake/dataset",
+        epochs=1,
+        batch=4,
+        accumulate=2,
+        max_steps=3,
+        output_dir=str(tmp_path / "acc"),
+        val_split=0.0,
+    )
+    train_losses = losses[:3]
+    assert len(seen) >= 3
+    assert seen[0] == pytest.approx(train_losses[0] / 2)
+    assert seen[1] == pytest.approx(train_losses[1] / 2)
+    assert seen[2] == pytest.approx(train_losses[2] / 1)
+
+
 def test_trainer_rejects_bad_config(fake_lerobot):
     model = FakeVLA(device="cpu")
     with pytest.raises(ValueError, match="epochs"):
@@ -435,6 +481,10 @@ def test_validator_reports_action_error_on_held_out_episodes(fake_lerobot):
     assert all_metrics["episodes"] == [0, 1, 2, 3, 4]
     with pytest.raises(ValueError, match="split"):
         VLAValidator(model, data="fake/dataset", split="test")
+
+    # Validating on every episode is legal: there is no training complement to protect.
+    every = model.val(data="fake/dataset", batch=3, val_episodes=[0, 1, 2, 3, 4])
+    assert every["episodes"] == [0, 1, 2, 3, 4]
 
 
 def test_val_defaults_to_contract_dataset(fake_lerobot, tmp_path):


### PR DESCRIPTION
What: `LibreVLA` sibling tier, canonical `act` task, `Results.actions`, SmolVLA base family, imitation trainer and offline `val()` on LeRobot datasets.
Why: #856. VLA policies fit none of the existing contracts; this lays the observation, action, checkpoint and evaluation foundations so later families and simulators plug in without changing the user API.

- `act` task (suffix `-act`, aliases `action`, `vla`, `policy`) and `Actions` payload `(T, D)` with names, fps and instruction; `Results.plot()` renders a trajectory strip.
- `LibreVLA(...)`: `set_instruction()`, `predict(frame | {camera: frame} | folder | video | stream, state=vector|callable)`, `reset()`; export/track raise.
- `LibreSmolVLA`: `lerobot/smolvla_base` pinned to `c83c3163b8ca9b7e67c509fffd9121e66cb96205`, loaded through the lerobot public API (Apache-2.0). Reserved aliases (`pi0`, `molmoact2`, `groot`, `xvla`, `openvla`) raise until load-tested.
- `train(data=<LeRobot repo id or dir>)`: held-out episode split, family optimizer presets, standard callbacks/loggers, best/last checkpoint dirs with `libreyolo_vla.json`; `LibreVLA(path)` reloads. `val()`: action L1/MSE overall and per dimension.
- `vla` extra gated on Python 3.12 (lerobot floor), kept out of `all`. Export matrix marks `act` blocked; inventory and export table regenerated.
- Docs: ADR 0028, `docs/librevla.md`, nomenclature, checkpoint schema, changelog, one README family row.

Check: `Results` slot wiring in `libreyolo/utils/results.py`; the trainer's processor overrides mirror lerobot's train script; README row is the sanctioned single-row exception.
Verified: 44 new offline unit tests; PR gate 6883 passed (2 MNN/RKNN preflight failures reproduce on dev without this change). Real run in a Python 3.12 venv on CPU: base predict with saved render, two-camera call, 2-step fine-tune on `lerobot/svla_so101_pickplace`, reload, fine-tune predict, offline val.
Not verified: GPU/CUDA and MPS paths; multi-epoch convergence; live stream sources with a real camera.
Opened by an agent.

## Code provenance
Original code written for this PR (adapter, observation contract, payload, trainer, validator, tests, docs). It calls the public API of the Apache-2.0 `lerobot` package (0.6.1) and `huggingface_hub`; no lerobot or other third-party source was ported, adapted, or vendored. Weights are downloaded by the user from `lerobot/smolvla_base` (Apache-2.0) at a pinned revision and are not redistributed. No GPL/AGPL/LGPL/non-commercial/unknown-license material involved.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63463181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable new failures identified in the changes since the previous review.

<details><summary><h3>Summary</h3></summary>

- Adds the canonical `act` task and `Results.actions` payload with trajectory rendering.
- Adds the SmolVLA adapter, pinned checkpoint loading, observation mapping, prediction, reset, training, validation, and directory checkpoints.
- Adds the Python 3.12-gated `vla` dependency extra and marks action export unsupported.
- Documents the API, checkpoint contract, architecture decision, nomenclature, and model inventory.
- Since the previous review, generated inventory and export-support entries were reordered consistently.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    U[LibreVLA API] --> O[Observation mapping]
    O --> P[SmolVLA preprocessors]
    P --> M[SmolVLA policy]
    M --> Q[Action chunk]
    Q --> R[Results.actions]
    R --> V[Trajectory rendering]

    D[LeRobot dataset] --> T[Imitation trainer]
    T --> C[VLA checkpoint directory]
    C --> U
    D --> E[Offline validator]
    M --> E
    E --> X[L1 and MSE metrics]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["Keep the inventory snapshot alphabetical"](https://github.com/libreyolo/libreyolo/commit/d8545fc9578ffb7da7934386fd5968e665862c3d)</sub>

<!-- /greptile_comment -->