### PR TITLE
Add ACT and Diffusion action policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ before 1.4.0 are documented in the
 
 ### Added
 
+- ACT and Diffusion action policies: train from scratch, predict without a language instruction, and validate saved checkpoints through `LibreVLA`.
+
 - **LibreVLA** sibling factory and the `act` task: camera frames + robot
   state + instruction → `Results.actions`, a `(T, D)` action chunk with
   per-dimension names, control rate and instruction. First family is

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ libreyolo predict --model yolo9-t --source screen            # screen capture
 | **Point detection** | FOMO, LocateAnything |
 | **Gaze** | L2CS |
 | **Open vocabulary and VLMs** | Grounding DINO, OWLv2, OmDet-Turbo, OV-DEIM, Florence-2, Kosmos-2, Qwen3-VL, InternVL3, LFM2-VL, North Micro Vision, SmolVLM2, Gemma 4, Moondream, MODUS |
-| **Robot actions (VLA)** | SmolVLA |
+| **Robot actions (VLA)** | SmolVLA, ACT, Diffusion Policy |
 
 Per-family sizes, checkpoints and parity evidence live in the
 [model reference](https://www.libreyolo.com/docs/models).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,7 +125,7 @@ libreyolo predict --model yolo9-t --source screen            # 屏幕捕获
 | **点检测** | FOMO、LocateAnything |
 | **视线估计** | L2CS |
 | **开放词汇与 VLM** | Grounding DINO、OWLv2、OmDet-Turbo、OV-DEIM、Florence-2、Kosmos-2、Qwen3-VL、InternVL3、LFM2-VL、North Micro Vision、SmolVLM2、MODUS |
-| **机器人动作 (VLA)** | SmolVLA |
+| **机器人动作 (VLA)** | SmolVLA, ACT, Diffusion Policy |
 
 各模型系列的尺寸、权重与一致性验证证据见[模型参考](https://www.libreyolo.com/docs/models)。
 

--- a/docs/adr/0028-librevla-contract.md
+++ b/docs/adr/0028-librevla-contract.md
@@ -96,8 +96,13 @@ reject `act` results.
   with neither raises.
 - `reset()` clears any family-side action queue between episodes.
 
-Depth, tactile, audio and multi-step observation histories are not part of
-this version. They enter as additional named observation entries without
+Amendment (2026-09-12): Diffusion Policy maintains a rolling observation
+history, pads the initial history by repetition, and clears it on `reset()`.
+Its offline validator aligns targets and padding masks with the predicted
+chunk's current-step origin.
+
+Depth, tactile, audio and user-supplied multi-step observation histories are
+not part of this version. They enter as additional named observation entries without
 changing the call shape.
 
 ## Training, validation, checkpoints

--- a/docs/export_support.md
+++ b/docs/export_support.md
@@ -10,6 +10,7 @@ in preflight.
 | Family | Task | onnx | torchscript | executorch | tensorrt | openvino | paddle | mnn | rknn | ncnn | tflite | coreml | coreai |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | 3dmood | detect3d |  |  |  |  |  |  |  |  |  |  |  |  |
+| act_policy | act |  |  |  |  |  |  |  |  |  |  |  |  |
 | alexnet | classify | ✓ | ✓ | available | ✓ | ✓ |  |  |  | available |  |  |  |
 | ben2 | matte | ✓ | ✓ | available | available | available |  |  |  | available |  |  |  |
 | birefnet | matte | available | ✓ |  |  |  |  |  |  |  |  |  |  |
@@ -31,6 +32,7 @@ in preflight.
 | dexined | edge | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  | ✓ |  |  |
 | dfine | detect | ✓ | ✓ |  | available | ✓ | ✓ | ✓ |  |  |  |  | ✓ |
 | dfine | segment | ✓ | ✓ |  | available | ✓ |  |  |  |  |  |  |  |
+| diffusion_policy | act |  |  |  |  |  |  |  |  |  |  |  |  |
 | dinodetr | detect | ✓ | available | available | available | available |  |  |  |  |  |  |  |
 | dinov2 | semantic | ✓ | ✓ | ✓ | ✓ | ✓ |  |  |  |  |  |  |  |
 | dinov2 | classify | ✓ | ✓ | ✓ | available | ✓ |  |  |  |  |  |  | available |
@@ -630,6 +632,18 @@ These converter paths are callable with the recorded validation context.
 - `3dmood` / `detect3d` / `tflite`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
 - `3dmood` / `detect3d` / `coreml`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
 - `3dmood` / `detect3d` / `coreai`: 3D detection export is blocked until its graph outputs, camera metadata, and backend runtime contract are defined.
+- `act_policy` / `act` / `onnx`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `torchscript`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `executorch`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `tensorrt`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `openvino`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `paddle`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `mnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `rknn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `ncnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `tflite`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `coreml`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `act_policy` / `act` / `coreai`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
 - `alexnet` / `classify` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
 - `alexnet` / `classify` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `alexnet` / `classify` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.
@@ -778,6 +792,18 @@ These converter paths are callable with the recorded validation context.
 - `dfine` / `segment` / `tflite`: onnx2tf flatbuffer-direct lowering crashes in GatherElements shape handling with an axis IndexError.
 - `dfine` / `segment` / `coreml`: This family and task are not covered by the family-aware CoreML wrapper.
 - `dfine` / `segment` / `coreai`: This family and task have not been validated for Core AI export.
+- `diffusion_policy` / `act` / `onnx`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `torchscript`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `executorch`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `tensorrt`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `openvino`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `paddle`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `mnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `rknn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `ncnn`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `tflite`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `coreml`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
+- `diffusion_policy` / `act` / `coreai`: Action-chunk export is blocked until the policy sampling loop has an exportable graph and backend runtime contract (ADR 0028).
 - `dinodetr` / `detect` / `paddle`: This family and task have not been validated through the ONNX-to-Paddle conversion path.
 - `dinodetr` / `detect` / `mnn`: MNN v1 has no implemented runtime contract for this family and task.
 - `dinodetr` / `detect` / `rknn`: RKNN v1 is limited to the exact simulator-tested detection variants: YOLO9-t, YOLO9-E2E-t, YOLO-NAS-s, and PicoDet-s on RK3588.

--- a/docs/librevla.md
+++ b/docs/librevla.md
@@ -105,6 +105,32 @@ error. After `train()`, that instance uses the last checkpoint; load
 `results["best"]` to use the best checkpoint instead. Training a loaded
 checkpoint starts from its saved policy and processors.
 
+## Action policies without language
+
+```python
+model = LibreVLA("act")                 # or "diffusion"; initially untrained
+run = model.train(data="lerobot/svla_so101_pickplace", epochs=5)
+model = LibreVLA(run["best"])
+result = model.predict({"up": front, "wrist": wrist}, state=q)
+```
+
+Both policies learn the dataset's action representation without a language
+instruction. Supply all camera slots used during training. Training starts
+with a randomly initialized action policy and the upstream ResNet18 backbone
+weights; there is no pretrained robot-policy download.
+
+Diffusion keeps the last `n_obs_steps` observations across calls, padding the
+first observation by repetition. Call `reset()` between episodes or before
+predicting an unrelated frame. The returned chunk starts at the current
+step; validation aligns it with the corresponding part of the dataset's
+longer training horizon, including padding masks.
+
+The offline CPU smoke uses tiny configs and a synthetic in-memory dataset:
+`PYTHONPATH=. python tests/smoke/vla_action_policies.py` (Python 3.12+, VLA
+and Diffusion extras installed). It exercises the real policies, processors,
+training, checkpoint reload, prediction and validation without downloads.
+It verifies the runtime path, not robot task success.
+
 ## Validate
 
 ```python
@@ -148,6 +174,8 @@ For policies trained without a base checkpoint, `base_repo` and
 | Alias | Upstream | Weights | Notes |
 | --- | --- | --- | --- |
 | `smolvla-base` (default) | SmolVLA 450M (`lerobot/smolvla_base`) | Apache-2.0 | 3 camera slots, state 6, action 6, 50-step chunk |
+| `act`, `act-policy` | LeRobot ACT | No pretrained policy; torchvision ResNet18 backbone (BSD-3-Clause code) | No instruction; dataset camera/state/action shapes; 100-step chunk |
+| `diffusion`, `diffusion-policy` | LeRobot Diffusion Policy | No pretrained policy; torchvision ResNet18 backbone (BSD-3-Clause code) | No instruction; two observations of history; 64-step training horizon, 32 predicted steps with LeRobot 0.6.1 defaults |
 
 `pi0`, `pi05`, `molmoact2`, `xvla`, `groot` and `openvla` are reserved names
 that raise with a message until an adapter is load-tested. Adding a family

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -999,6 +999,12 @@ Plain COCO-default weights never carry a variant suffix.
 
 ## Vision-language-action policies
 
+`LibreACT` (`act_policy`, aliases `act` and `act-policy`) and
+`LibreDiffusionPolicy` (`diffusion_policy`, aliases `diffusion` and
+`diffusion-policy`) use the same `act` task and coverage group `s`. They
+start without a pretrained policy, require no instruction, and save policy
+directories with null base repo/revision. Their default size is `base`.
+
 `LibreSmolVLA` (`smolvla`, coverage group `s`) is a sibling API wrapping the
 SmolVLA policy through the optional `lerobot` runtime (`libreyolo[vla]`,
 Python 3.12+). It uses `act`, with aliases `action`, `actions`, `vla`,

--- a/libreyolo/__init__.py
+++ b/libreyolo/__init__.py
@@ -201,6 +201,8 @@ def __getattr__(name):
         "LibreLLM": (".models.llm", "LibreLLM"),
         "LibreVLA": (".models.vla", "LibreVLA"),
         "LibreSmolVLA": (".models.vla", "LibreSmolVLA"),
+        "LibreACT": (".models.vla", "LibreACT"),
+        "LibreDiffusionPolicy": (".models.vla", "LibreDiffusionPolicy"),
         "LibreVLM": (".models.vlm", "LibreVLM"),
         "LibreLFM2VL": (".models.vlm", "LibreLFM2VL"),
         "LibreQwen3VL": (".models.vlm", "LibreQwen3VL"),
@@ -372,6 +374,8 @@ __all__ = [
     # Vision-language-action tier (optional, requires libreyolo[vla])
     "LibreVLA",
     "LibreSmolVLA",
+    "LibreACT",
+    "LibreDiffusionPolicy",
     # Calibrated native monocular 3D detection
     "LibreFCOS3D",
     # Promptable 3D detection (separately installed upstream runtime)

--- a/libreyolo/models/inventory.py
+++ b/libreyolo/models/inventory.py
@@ -49,6 +49,8 @@ OPTIONAL_MODELS = (
     ("libreyolo.models.vlm.smolvlm", "LibreSmolVLM2", "vlm", "transformers"),
     ("libreyolo.models.ground.showui", "LibreShowUI", "vlm", "transformers"),
     ("libreyolo.models.vla.smolvla", "LibreSmolVLA", "vla", "lerobot"),
+    ("libreyolo.models.vla.act_policy", "LibreACT", "vla", "lerobot"),
+    ("libreyolo.models.vla.diffusion_policy", "LibreDiffusionPolicy", "vla", "lerobot"),
     (
         "libreyolo.models.ground.florence",
         "LibreGroundFlorence2",

--- a/libreyolo/models/registry.py
+++ b/libreyolo/models/registry.py
@@ -136,6 +136,8 @@ MODEL_GROUPS: dict[str, str] = {
     "showui": "s",
     "smolvlm2": "s",
     "smolvla": "s",
+    "act_policy": "s",
+    "diffusion_policy": "s",
     "clip": "s",
     "siglip2": "s",
     "libremodus": "s",

--- a/libreyolo/models/vla/__init__.py
+++ b/libreyolo/models/vla/__init__.py
@@ -21,12 +21,18 @@ from __future__ import annotations
 
 from typing import Dict, Tuple, Type
 
+from .act_policy import LibreACT
 from .base import LibreVLAModel
 from .checkpoint import CONTRACT_FILENAME, is_vla_checkpoint, read_contract
 from .smolvla import LibreSmolVLA
+from .diffusion_policy import LibreDiffusionPolicy
 
 # alias -> (family class, size)
 _ALIASES: Dict[str, Tuple[Type[LibreVLAModel], str]] = {
+    "diffusion": (LibreDiffusionPolicy, "base"),
+    "diffusion-policy": (LibreDiffusionPolicy, "base"),
+    "act": (LibreACT, "base"),
+    "act-policy": (LibreACT, "base"),
     "smolvla": (LibreSmolVLA, "base"),
     "smolvla-base": (LibreSmolVLA, "base"),
 }
@@ -97,6 +103,8 @@ __all__ = [
     "LibreVLA",
     "LibreVLAModel",
     "LibreSmolVLA",
+    "LibreACT",
+    "LibreDiffusionPolicy",
     "is_vla_checkpoint",
     "read_contract",
 ]

--- a/libreyolo/models/vla/act_policy.py
+++ b/libreyolo/models/vla/act_policy.py
@@ -1,0 +1,25 @@
+"""Original LibreYOLO adapter for ACT through LeRobot's public API.
+
+ACT is an action policy without language input. Policy weights start from
+scratch; LeRobot's default ResNet18 image backbone uses torchvision weights.
+"""
+
+from typing import ClassVar
+
+from .lerobot_family import LeRobotPolicyFamily
+
+
+class LibreACT(LeRobotPolicyFamily):
+    """Train ACT on a LeRobot dataset, then predict action chunks."""
+
+    FAMILY = "act_policy"
+    FILENAME_PREFIX = "LibreACT"
+    INPUT_SIZES: ClassVar[dict[str, int]] = {"base": 224}
+    PRETRAINED_BASE = False
+    REQUIRES_INSTRUCTION = False
+    UPSTREAM_TYPE = "act"
+    CONFIG_MODULE = "lerobot.policies.act.configuration_act"
+    CONFIG_CLASS = "ACTConfig"
+    POLICY_MODULE = "lerobot.policies.act.modeling_act"
+    POLICY_CLASS = "ACTPolicy"
+    LEROBOT_EXTRA = "dataset"

--- a/libreyolo/models/vla/base.py
+++ b/libreyolo/models/vla/base.py
@@ -156,6 +156,10 @@ class LibreVLAModel:
         """Return the family's default config for training without a base policy."""
         raise NotImplementedError
 
+    def _validation_targets(self, target, pad, steps):
+        """Align recorded actions with a family prediction's temporal origin."""
+        return target, pad
+
     @property
     def camera_slots(self) -> List[str]:
         """Ordered camera slot names the loaded policy expects."""

--- a/libreyolo/models/vla/diffusion_policy.py
+++ b/libreyolo/models/vla/diffusion_policy.py
@@ -1,0 +1,62 @@
+"""Original adapter for LeRobot's diffusion action policy public API."""
+
+from collections import deque
+from typing import ClassVar
+
+from .lerobot_family import LeRobotPolicyFamily
+
+
+class LibreDiffusionPolicy(LeRobotPolicyFamily):
+    """Diffusion Policy with a rolling history of camera/state observations."""
+
+    FAMILY = "diffusion_policy"
+    FILENAME_PREFIX = "LibreDiffusionPolicy"
+    INPUT_SIZES: ClassVar[dict[str, int]] = {"base": 224}
+    PRETRAINED_BASE = False
+    REQUIRES_INSTRUCTION = False
+    UPSTREAM_TYPE = "diffusion"
+    CONFIG_MODULE = "lerobot.policies.diffusion.configuration_diffusion"
+    CONFIG_CLASS = "DiffusionConfig"
+    POLICY_MODULE = "lerobot.policies.diffusion.modeling_diffusion"
+    POLICY_CLASS = "DiffusionPolicy"
+    LEROBOT_EXTRA = "diffusion"
+
+    @property
+    def chunk_size(self):
+        return int(self.config.n_action_steps)
+
+    def reset(self):
+        super().reset()
+        self._observation_history = None
+
+    def _raw_observation(self, observation):
+        import torch
+
+        raw = super()._raw_observation(observation)
+        count = int(self.config.n_obs_steps)
+        history = getattr(self, "_observation_history", None)
+        if history is None:
+            history = deque(maxlen=count)
+            self._observation_history = history
+        if history and set(raw) != set(history[-1]):
+            raise ValueError(
+                "Diffusion Policy camera keys changed; call reset() between episodes."
+            )
+        history.append(raw)
+        while len(history) < count:
+            history.appendleft(raw)
+        return {
+            key: torch.stack([frame[key] for frame in history]).unsqueeze(0)
+            if key.startswith("observation.")
+            else value
+            for key, value in raw.items()
+        }
+
+    def _validation_targets(self, target, pad, steps):
+        start = int(self.config.n_obs_steps) - 1
+        stop = start + steps
+        if stop > target.shape[1]:
+            raise ValueError(
+                "Recorded diffusion action horizon is shorter than the prediction."
+            )
+        return target[:, start:stop], pad[:, start:stop] if pad is not None else None

--- a/libreyolo/models/vla/training/trainer.py
+++ b/libreyolo/models/vla/training/trainer.py
@@ -385,7 +385,7 @@ class VLATrainer:
                 cameras=bundle.cameras,
                 action_names=bundle.action_names,
                 state_names=bundle.state_names,
-                chunk_size=int(getattr(config, "chunk_size", 0)) or None,
+                chunk_size=wrapper.chunk_size,
             )
 
         epoch = 0
@@ -615,6 +615,7 @@ class VLAValidator:
                 processed = wrapper._preprocessor(batch)
                 chunk = policy.predict_action_chunk(processed)
                 chunk = wrapper._postprocessor(chunk)
+                target, pad = wrapper._validation_targets(target, pad, chunk.shape[1])
                 dim = target.shape[-1]
                 preds.append(chunk[:, : target.shape[1], :dim].detach().cpu())
                 targets.append(target.cpu())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ vla = [
     # lerobot requires Python >= 3.12, so the extra installs nothing on older
     # interpreters and the tier raises an ImportError that says so. Kept out
     # of `all` for the same reason.
-    "lerobot[smolvla,dataset]>=0.6.1; python_version >= '3.12'",
+    "lerobot[smolvla,diffusion,dataset]>=0.6.1; python_version >= '3.12'",
 ]
 llm = [
     # LibreLLM talks to OpenAI-compatible Responses / Chat Completions

--- a/reports/export_inventory.json
+++ b/reports/export_inventory.json
@@ -32,6 +32,24 @@
     "group": "s",
     "cli_command": "3dmood"
   },
+  "act_policy": {
+    "class": "libreyolo.models.vla.act_policy.LibreACT",
+    "tasks": [
+      "act"
+    ],
+    "default_task": "act",
+    "sizes": {
+      "base": 224
+    },
+    "default_imgsz": {
+      "base": 224
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "vla",
+    "available": false,
+    "group": "s"
+  },
   "alexnet": {
     "class": "libreyolo.models.alexnet.model.LibreAlexNet",
     "tasks": [
@@ -463,6 +481,24 @@
     "optional_extra": null,
     "available": true,
     "group": "g1"
+  },
+  "diffusion_policy": {
+    "class": "libreyolo.models.vla.diffusion_policy.LibreDiffusionPolicy",
+    "tasks": [
+      "act"
+    ],
+    "default_task": "act",
+    "sizes": {
+      "base": 224
+    },
+    "default_imgsz": {
+      "base": 224
+    },
+    "task_sizes": {},
+    "export_override": "blocked",
+    "optional_extra": "vla",
+    "available": false,
+    "group": "s"
   },
   "dinodetr": {
     "class": "libreyolo.models.dinodetr.model.LibreDINODETR",

--- a/tests/smoke/install_surface.py
+++ b/tests/smoke/install_surface.py
@@ -140,11 +140,11 @@ def _check_import_surface(expect_source: str, source_root: Path | None) -> None:
     if not callable(LibreVLM):
         raise AssertionError("LibreVLM import did not resolve to a callable")
     # The LibreVLA tier is importable without the vla extra (lerobot loads lazily).
-    from libreyolo import Actions, LibreSmolVLA, LibreVLA
+    from libreyolo import Actions, LibreACT, LibreDiffusionPolicy, LibreSmolVLA, LibreVLA
 
     if not callable(LibreVLA):
         raise AssertionError("LibreVLA import did not resolve to a callable")
-    if not isinstance(LibreSmolVLA, type) or not isinstance(Actions, type):
+    if not all(isinstance(cls, type) for cls in (LibreSmolVLA, LibreACT, LibreDiffusionPolicy, Actions)):
         raise AssertionError("LibreVLA family/payload exports did not resolve to classes")
     for family in (
         LibreQwen3VL,

--- a/tests/smoke/vla_action_policies.py
+++ b/tests/smoke/vla_action_policies.py
@@ -1,0 +1,139 @@
+"""Offline CPU smoke for ACT and Diffusion, using the real LeRobot runtime.
+
+Run on Python 3.12+: ``python tests/smoke/vla_action_policies.py`` after
+installing ``libreyolo[vla]`` and ``lerobot[diffusion]>=0.6.1``. Only the
+dataset reader is replaced with synthetic in-memory observations. Policies,
+optimizers, processors, saved weights and checkpoint reload are real.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import ClassVar
+
+
+def run_smoke():
+    started = time.monotonic()
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    import torch
+    from lerobot.policies.act.configuration_act import ACTConfig
+    from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
+    from PIL import Image
+    from torch.utils.data import Dataset
+
+    from libreyolo import LibreVLA
+    from libreyolo.models.vla.training import trainer
+
+    torch.set_num_threads(2)
+    configs = {
+        "act": ACTConfig(
+            device="cpu",
+            pretrained_backbone_weights=None,
+            chunk_size=4,
+            n_action_steps=4,
+            dim_model=32,
+            dim_feedforward=64,
+            n_heads=4,
+            n_encoder_layers=1,
+            n_decoder_layers=1,
+            n_vae_encoder_layers=1,
+        ),
+        "diffusion": DiffusionConfig(
+            device="cpu",
+            pretrained_backbone_weights=None,
+            horizon=8,
+            n_action_steps=4,
+            n_obs_steps=2,
+            down_dims=(32, 64, 128),
+            diffusion_step_embed_dim=32,
+            num_train_timesteps=10,
+            num_inference_steps=2,
+        ),
+    }
+
+    class Meta:
+        total_episodes = 2
+        fps = 10
+        camera_keys: ClassVar[list[str]] = ["observation.images.front"]
+        features: ClassVar[dict] = {
+            "observation.images.front": {
+                "dtype": "image",
+                "shape": (3, 64, 64),
+                "names": ["channels", "height", "width"],
+            },
+            "observation.state": {
+                "dtype": "float32",
+                "shape": (2,),
+                "names": ["q0", "q1"],
+            },
+            "action": {"dtype": "float32", "shape": (2,), "names": ["a0", "a1"]},
+        }
+        stats: ClassVar[dict] = {}
+
+    for key in Meta.features:
+        shape = (3, 1, 1) if "images" in key else (2,)
+        Meta.stats[key] = {
+            "mean": torch.zeros(shape),
+            "std": torch.ones(shape),
+            "min": -torch.ones(shape),
+            "max": torch.ones(shape),
+        }
+
+    original_seam = trainer._lerobot
+    upstream = original_seam()
+    try:
+        with tempfile.TemporaryDirectory(prefix="librevla-smoke-") as root:
+            for family, config in configs.items():
+
+                class Data(Dataset):
+                    def __init__(self, *args, policy_config=config, **kwargs):
+                        self.n_obs = policy_config.n_obs_steps
+                        self.horizon = getattr(policy_config, "horizon", 4)
+
+                    def __len__(self):
+                        return 8
+
+                    def __getitem__(self, index):
+                        shape = () if self.n_obs == 1 else (self.n_obs,)
+                        return {
+                            "observation.images.front": torch.zeros(*shape, 3, 64, 64),
+                            "observation.state": torch.zeros(*shape, 2),
+                            "action": torch.ones(self.horizon, 2) * 0.5,
+                            "action_is_pad": torch.zeros(
+                                self.horizon, dtype=torch.bool
+                            ),
+                            "task": "",
+                        }
+
+                trainer._lerobot = lambda: (Data, lambda *a, **k: Meta(), *upstream[2:])
+                model = LibreVLA(family, device="cpu")
+                model._scratch_config = lambda meta, policy_config=config: policy_config
+                result = model.train(
+                    data="synthetic/offline",
+                    epochs=1,
+                    batch=2,
+                    max_steps=3,
+                    val_batches=1,
+                    output_dir=str(Path(root) / family),
+                )
+                restored = LibreVLA(result["best"], device="cpu")
+                prediction = restored.predict(Image.new("RGB", (64, 64)), state=[0, 0])
+                assert prediction.actions.data.shape == (4, 2)
+                assert torch.isfinite(prediction.actions.data).all()
+                assert prediction.actions.instruction == ""
+                metrics = restored.val(max_batches=1, batch=2)
+                assert metrics["val/steps"] == 8
+                assert restored.contract["base_repo"] is None
+                assert restored.contract["base_revision"] is None
+                print(f"{family}: train, reload, predict, val passed", flush=True)
+    finally:
+        trainer._lerobot = original_seam
+    print(f"Elapsed: {time.monotonic() - started:.2f}s", flush=True)
+
+
+if __name__ == "__main__":
+    run_smoke()

--- a/tests/unit/test_vla_action_policies.py
+++ b/tests/unit/test_vla_action_policies.py
@@ -1,0 +1,73 @@
+"""Action-policy aliases, history and offline timestamp alignment."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from libreyolo import LibreVLA
+from libreyolo.models.vla.act_policy import LibreACT
+from libreyolo.models.vla.diffusion_policy import LibreDiffusionPolicy
+from libreyolo.models.vla.observation import Observation
+
+pytestmark = [pytest.mark.unit, pytest.mark.vla]
+
+
+@pytest.mark.parametrize(
+    "alias,cls",
+    [
+        ("act", LibreACT),
+        ("act-policy", LibreACT),
+        ("act_policy", LibreACT),
+        ("diffusion", LibreDiffusionPolicy),
+        ("diffusion-policy", LibreDiffusionPolicy),
+        ("diffusion_policy", LibreDiffusionPolicy),
+    ],
+)
+def test_scratch_policy_aliases_are_lazy_and_untrained(alias, cls):
+    model = LibreVLA(alias, device="cpu")
+    assert isinstance(model, cls)
+    assert model.task == "act" and model.model_path is None
+    assert model._resolve_instruction(None) == ""
+    with pytest.raises(ValueError, match="untrained"):
+        model.predict(Image.new("RGB", (8, 8)))
+
+
+def test_diffusion_history_pads_first_observation_and_resets():
+    model = LibreDiffusionPolicy(device="cpu")
+    model._config = SimpleNamespace(n_obs_steps=2, n_action_steps=4)
+    frame = Image.new("RGB", (8, 8))
+    first = Observation({"front": frame}, np.array([1.0, 2.0]), "")
+    second = Observation({"front": frame}, np.array([3.0, 4.0]), "")
+    raw = model._raw_observation(first)
+    assert raw["observation.state"].shape == (1, 2, 2)
+    torch.testing.assert_close(
+        raw["observation.state"][0], torch.tensor([[1.0, 2.0], [1.0, 2.0]])
+    )
+    raw = model._raw_observation(second)
+    torch.testing.assert_close(
+        raw["observation.state"][0], torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    )
+    assert raw["observation.images.front"].shape == (1, 2, 3, 8, 8)
+    with pytest.raises(ValueError, match="camera keys changed"):
+        model._raw_observation(Observation({"wrist": frame}, np.zeros(2), ""))
+    model.reset()
+    raw = model._raw_observation(second)
+    torch.testing.assert_close(
+        raw["observation.state"][0], torch.tensor([[3.0, 4.0], [3.0, 4.0]])
+    )
+
+
+def test_diffusion_validation_starts_at_current_timestep():
+    model = LibreDiffusionPolicy(device="cpu")
+    model._config = SimpleNamespace(n_obs_steps=2, n_action_steps=4)
+    target = torch.arange(8.0).view(1, 8, 1)
+    pad = torch.tensor([[True, False, False, True, False, False, False, True]])
+    aligned, mask = model._validation_targets(target, pad, 4)
+    assert aligned.flatten().tolist() == [1.0, 2.0, 3.0, 4.0]
+    assert mask.tolist() == [[False, False, True, False]]
+    assert model.chunk_size == 4
+    with pytest.raises(ValueError, match="shorter"):
+        model._validation_targets(target, pad, 8)


### PR DESCRIPTION
- Add ACT and Diffusion aliases, scratch training, checkpoint reload, inventory and docs.
- Buffer Diffusion observations and align validation with the current action timestep; the shared target hook leaves other families unchanged.
- Stacked on #858; retarget to dev after dependencies land. Opened by an agent.
- Verified: 173 rebased VLA/export/coordinator checks, install surface, offline real-runtime smoke (4.82s), and 200 CPU training steps per family on `lerobot/svla_so101_pickplace` (train episode 0, val episode 1).
- ACT: train loss 15.704 to 4.433; 221.96s training; reload 2.94s; chunk 0.125s; val L1 16.257322, MSE 478.988556.
- Diffusion: train loss 1.056 to 0.132; 312.60s training; reload 1.42s; chunk 3.174s; val L1 14.999387, MSE 514.402161.
- Timings use CPU with 4 threads; val uses one batch of two observations. No simulator or robot-success claim.
- Full CPU gate passed before rebase (6,917). Three expanded ONNX parity failures reproduce on unchanged dev. No broader convergence claim; new family files pass lint.

## Code provenance
Original LibreYOLO adapter, history, validation and test code calling Hugging Face LeRobot 0.6.1 public APIs (Apache-2.0). No third-party implementation ported or vendored. Policy weights train locally; torchvision downloads the upstream ResNet18 backbone. No weights redistributed.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63471051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no outstanding correctness, security, or repository-rule findings.

<details><summary><h3>Summary</h3></summary>

- Adds aliases, lazy public exports, inventory entries, and coverage-group registration.
- Supports scratch training, checkpoint reload, inference, and validation through the existing LeRobot policy-family abstraction.
- Adds Diffusion observation-history buffering and family-specific validation target alignment.
- Extends the VLA optional dependency set and documents runtime, checkpoint, and export limitations.
- Adds CPU unit and offline real-runtime smoke coverage.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    U[LibreVLA alias or checkpoint] --> F{Resolve family}
    F -->|act| A[LibreACT]
    F -->|diffusion| D[LibreDiffusionPolicy]
    A --> L[LeRobot policy adapter]
    D --> H[Rolling observation history]
    H --> L
    L --> T[Scratch training]
    T --> C[Saved checkpoint directory]
    C --> P[Reload and predict action chunk]
    C --> V[Offline validation]
    D --> X[Current-step target alignment]
    X --> V
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["Add ACT and Diffusion action policies"](https://github.com/libreyolo/libreyolo/commit/2116fd541cf0ebef622173c445c6e23b16a9f290)</sub>

<!-- /greptile_comment -->