### PR TITLE
 [Feature] Support training on a subset of a dataset's classes

### DIFF
--- a/libreyolo/cli/commands/train.py
+++ b/libreyolo/cli/commands/train.py
@@ -308,6 +308,12 @@ def train_cmd(
         "--single-cls/--no-single-cls",
         help="Train a G0/G1 detector with every label remapped to class 0",
     ),
+    classes: Optional[str] = typer.Option(
+        None,
+        help="Train a G0/G1 detector on only these original dataset class "
+        "ids, comma-separated (e.g. '0,3,5'); every other class is dropped "
+        "as if unlabeled. Ids are kept as-is, not compacted",
+    ),
     average_best: int = typer.Option(
         0,
         help="Uniform-average the N best checkpoints by the watched metric "
@@ -504,7 +510,7 @@ def train_cmd(
     model_path = resolve_model_or_exit(out, model)
     family = detect_family_from_model_ref(model, model_path, inspect_checkpoint=dry_run)
 
-    if single_cls:
+    if single_cls or classes:
         # Gate before the model is constructed: building it can fetch weights
         # (an explicit task derives a task-suffixed checkpoint name), and a
         # rejected combination must not pay for a download first.
@@ -522,8 +528,9 @@ def train_cmd(
             exit_with_error(
                 out,
                 "config_unsupported",
-                "single_cls=True is supported only for G0/G1 detection models; "
-                f"got family={family!r} ({group}), task={selected_task!r}.",
+                "single_cls=True and classes=... are supported only for "
+                f"G0/G1 detection models; got family={family!r} ({group}), "
+                f"task={selected_task!r}.",
             )
 
     loaded_model = None
@@ -618,6 +625,7 @@ def train_cmd(
         "min_samples": min_samples,
         "class_balanced": class_balanced,
         "single_cls": single_cls,
+        "classes": classes,
         "average_best": average_best,
         "export_check": export_check,
         "precise_bn": precise_bn,
@@ -731,6 +739,7 @@ def train_cmd(
             "max_det": params["max_det"],
             "class_balanced": params["class_balanced"],
             "single_cls": params["single_cls"],
+            "classes": params["classes"],
             "average_best": params["average_best"],
             "export_check": params["export_check"],
             "precise_bn": params["precise_bn"],
@@ -767,6 +776,7 @@ def train_cmd(
                 "lora": params["lora"],
                 "class_balanced": params["class_balanced"],
                 "single_cls": params["single_cls"],
+                "classes": params["classes"],
                 "average_best": params["average_best"],
                 "export_check": params["export_check"],
                 "precise_bn": params["precise_bn"],

--- a/libreyolo/cli/config.py
+++ b/libreyolo/cli/config.py
@@ -449,6 +449,7 @@ def _build_rfdetr_train_kwargs(
         "cache": "cache",
         "class_balanced": "class_balanced",
         "single_cls": "single_cls",
+        "classes": "classes",
         "average_best": "average_best",
         "export_check": "export_check",
         "precise_bn": "precise_bn",

--- a/libreyolo/data/__init__.py
+++ b/libreyolo/data/__init__.py
@@ -69,6 +69,7 @@ from .semantic_dataset import (
 )
 from .utils import (
     DATASETS_DIR,
+    build_class_remap,
     check_dataset,
     get_coco_annotation_file,
     get_coco_image_dir,
@@ -81,6 +82,7 @@ from .yolo_coco_api import YOLOCocoAPI, create_yolo_coco_api, parse_yolo_label_l
 
 __all__ = [
     "DATASETS_DIR",
+    "build_class_remap",
     "check_dataset",
     "get_coco_annotation_file",
     "get_coco_image_dir",

--- a/libreyolo/data/dataset.py
+++ b/libreyolo/data/dataset.py
@@ -238,6 +238,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
         load_obb: bool = False,
         num_classes: int | None = None,
         single_cls: bool = False,
+        class_remap: dict[int, int] | None = None,
     ):
         """
         Initialize YOLO dataset.
@@ -249,8 +250,17 @@ class YOLODataset(ImageCacheMixin, Dataset):
             preproc: Preprocessing transform.
             img_files: List of image paths (for file list mode).
             label_files: List of label paths (optional, inferred if not provided).
-            num_classes: Optional class-count bound used for OBB label validation.
+            num_classes: Optional class-count bound checked against every
+                parsed label; out-of-range ids are skipped with a warning
+                (non-OBB) or excluded (OBB) instead of reaching the loss.
             single_cls: Remap every non-negative class id to class 0.
+                Ignored when ``class_remap`` is given.
+            class_remap: Optional ``{orig_id: new_id}`` mapping for training
+                on a class subset (see ``load_data_config(classes=...)``).
+                Boxes whose original class id is not a key are dropped. For
+                plain ``classes=`` this is an identity mapping (kept ids are
+                unchanged); ``single_cls`` combined with ``classes=`` maps
+                every kept id to ``0`` instead.
         """
         self.img_size = imgsz_to_hw(img_size, name="img_size")
         self.preproc = preproc
@@ -258,6 +268,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
         self.load_segments = load_segments
         self.load_obb = load_obb
         self.num_classes = num_classes
+        self.class_remap = class_remap
         self.single_cls = bool(single_cls)
         if self.load_segments and self.load_obb:
             raise ValueError("YOLODataset cannot load segmentation and OBB labels together")
@@ -431,6 +442,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
                                 parts,
                                 num_classes=self.num_classes,
                                 clip=True,
+                                class_remap=self.class_remap,
                             )
                             pixel_corners = corners.copy()
                             pixel_corners[:, 0] *= width
@@ -441,7 +453,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
                             skipped_obb_rows += 1
                             first_obb_error = first_obb_error or f"{label_file.name}: {exc}"
                             continue
-                        if self.single_cls:
+                        if self.single_cls and self.class_remap is None:
                             cls_id = 0
                         labels.append([*proxy.tolist(), cls_id, float(xywhr[4])])
                     else:
@@ -459,6 +471,7 @@ class YOLODataset(ImageCacheMixin, Dataset):
                             label_file,
                             return_segment=self.load_segments,
                             single_cls=self.single_cls,
+                            class_remap=self.class_remap,
                         )
                         if parsed is None:
                             continue
@@ -613,6 +626,7 @@ class COCODataset(ImageCacheMixin, Dataset):
         num_classes: int | None = None,
         names=None,
         single_cls: bool = False,
+        classes: list[int] | None = None,
     ):
         """
         Initialize COCO dataset.
@@ -625,6 +639,12 @@ class COCODataset(ImageCacheMixin, Dataset):
             preproc: Preprocessing transform
             single_cls: Remap emitted annotations to class 0 after resolving
                 the original COCO category mapping.
+            classes: Optional list of original dataset class ids to keep;
+                categories outside this list are dropped, and kept ones stay
+                at their original label (not compacted), so ``names`` should
+                be the dataset's full, original names here -- pass
+                ``data_cfg.get("names")`` from ``load_data_config(classes=
+                ...)``, unchanged by classes= (see its docstring).
         """
         if load_segments and load_obb:
             raise ValueError("COCODataset cannot load segmentation and OBB labels together")
@@ -647,6 +667,7 @@ class COCODataset(ImageCacheMixin, Dataset):
         self.num_classes = num_classes
         self.names = names
         self.single_cls = bool(single_cls)
+        self.classes = list(classes) if classes is not None else None
 
         # Load COCO annotations
         ann_file = self._annotation_path()
@@ -723,6 +744,17 @@ class COCODataset(ImageCacheMixin, Dataset):
                     )
                 category_to_label[int(category["id"])] = name_to_label[category_name]
 
+        if self.classes is not None:
+            # Filter only -- kept labels stay at their original value so
+            # predictions remain directly comparable to the full dataset's
+            # numbering (see build_class_remap's docstring for why).
+            keep = set(self.classes)
+            category_to_label = {
+                category_id: label
+                for category_id, label in category_to_label.items()
+                if label in keep
+            }
+
         if self.num_classes is not None and not self.single_cls:
             for category_id, label in category_to_label.items():
                 if label < 0 or label >= self.num_classes:
@@ -740,7 +772,9 @@ class COCODataset(ImageCacheMixin, Dataset):
                 )
             label_to_category[label] = category_id
         if self.single_cls:
-            collapsed_category_id = self.class_ids[0] if self.class_ids else 0
+            collapsed_category_id = next(iter(category_to_label), None)
+            if collapsed_category_id is None:
+                collapsed_category_id = self.class_ids[0] if self.class_ids else 0
             label_to_category = {0: collapsed_category_id}
         return category_to_label, label_to_category
 
@@ -807,6 +841,10 @@ class COCODataset(ImageCacheMixin, Dataset):
             except (TypeError, ValueError):
                 area = 0.0
             if area <= 0.0:
+                continue
+            if obj["category_id"] not in self.category_id_to_label:
+                # Excluded by classes= filtering: drop, same as an
+                # annotation that was never made for a kept class.
                 continue
             if self.load_obb:
                 xywhr = _coco_obb_to_xywhr(obj, width, height)

--- a/libreyolo/data/obb.py
+++ b/libreyolo/data/obb.py
@@ -141,6 +141,7 @@ def parse_yolo_obb_label_line(
     num_classes: int | None = None,
     *,
     clip: bool = False,
+    class_remap: dict[int, int] | None = None,
 ) -> tuple[int, np.ndarray]:
     """Parse one YOLO OBB label row into ``(class_id, corners)``.
 
@@ -153,6 +154,12 @@ def parse_yolo_obb_label_line(
     slightly out-of-frame crop-boundary boxes instead of dropping the row. The
     parser validates the file format but does not canonicalize point order or
     convert corners to an angle representation.
+
+    ``class_remap``: optional ``{orig_id: new_id}`` mapping for training on a
+    class subset (see ``load_data_config(classes=...)``). A class id absent
+    from the mapping raises ``ValueError`` the same way callers already treat
+    an out-of-range id -- as a row to skip, not a hard failure -- since it
+    means this box's class was deliberately excluded, not malformed.
     """
     parts = line.split() if isinstance(line, str) else list(line)
     if len(parts) != 9:
@@ -169,7 +176,11 @@ def parse_yolo_obb_label_line(
 
     if class_id < 0:
         raise ValueError(f"OBB class id must be non-negative, got {class_id}")
-    if num_classes is not None:
+    if class_remap is not None:
+        if class_id not in class_remap:
+            raise ValueError(f"OBB class id {class_id} excluded by classes= filter")
+        class_id = class_remap[class_id]
+    elif num_classes is not None:
         if num_classes < 1:
             raise ValueError(f"num_classes must be positive, got {num_classes}")
         if class_id >= num_classes:

--- a/libreyolo/data/utils.py
+++ b/libreyolo/data/utils.py
@@ -231,12 +231,44 @@ def img2label_paths(img_paths: List[Path]) -> List[Path]:
     return label_paths
 
 
+def build_class_remap(
+    classes: Optional[List[int]], single_cls: bool = False
+) -> Optional[Dict[int, int]]:
+    """Build the ``{orig_id: new_id}`` mapping for training on a class
+    subset. ``None`` when ``classes`` is ``None`` (no filtering).
+
+    Without ``single_cls``, every kept id maps to itself: original class ids
+    are preserved (not compacted to a contiguous range), so a checkpoint
+    trained this way stays interchangeable with the full dataset's ids --
+    external tools (a standard COCO-style evaluator, an exported ONNX model
+    read by raw index, a person who knows "id 7 = train") need no
+    translation layer. The cost is that the head still covers every index up
+    to the highest kept id; slots for ids below it that were not requested
+    simply never receive positive supervision, the same as a class with zero
+    occurrences in an ordinary dataset.
+
+    With ``single_cls``, every kept id maps to ``0`` instead: classes filters
+    which boxes count at all, single_cls then collapses the kept ones to one
+    merged class -- that direction is an intentional, explicit remap in
+    either case. Shared by ``load_data_config`` and by the ``data_dir=`` (no
+    dataset yaml) training path, which has no ``load_data_config`` call to
+    derive it from.
+    """
+    if classes is None:
+        return None
+    ordered = sorted(set(int(c) for c in classes))
+    if single_cls:
+        return {orig_id: 0 for orig_id in ordered}
+    return {orig_id: orig_id for orig_id in ordered}
+
+
 def load_data_config(
     data: str,
     autodownload: bool = True,
     allow_scripts: bool = False,
     *,
     single_cls: bool = False,
+    classes: Optional[List[int]] = None,
 ) -> Dict:
     """
     Load dataset configuration from YAML file.
@@ -257,6 +289,16 @@ def load_data_config(
             permitted and script-based downloads are skipped with a warning.
         single_cls: Return a one-class detection view while retaining the source
             class names privately for native COCO category mapping.
+        classes: Train on only these original dataset class ids. Ids are
+            kept as-is, not compacted to a contiguous range, so predictions
+            stay directly comparable to the original dataset/checkpoint
+            numbering. ``nc``/``names`` are left untouched (the head still
+            covers every index up to the highest kept id); ``_class_remap``
+            (``{orig_id: orig_id}`` for kept ids) is returned in the config
+            for callers to thread into label parsers, which drop boxes for
+            ids not present. Source annotations are untouched. Combined with
+            ``single_cls``, the kept classes collapse to one merged class
+            (``{orig_id: 0}``) instead.
 
     Returns:
         Dictionary with dataset configuration including:
@@ -322,7 +364,27 @@ def load_data_config(
     # Keep 'root' for backward compatibility
     config["root"] = str(dataset_path)
 
-    if single_cls:
+    if classes is not None:
+        ordered = sorted(set(int(c) for c in classes))
+        declared_nc = config.get("nc")
+        if declared_nc is not None and any(c >= int(declared_nc) for c in ordered):
+            raise ValueError(
+                f"classes={ordered} contains an id outside this dataset's "
+                f"declared nc={declared_nc}"
+            )
+        config["_class_remap"] = build_class_remap(ordered, single_cls=single_cls)
+        if single_cls:
+            # Collapsing to one merged class is still an explicit remap;
+            # stash the originals the same way plain single_cls does below.
+            config["_original_names"] = config.get("names")
+            config["_original_nc"] = config.get("nc")
+            config["nc"] = 1
+            config["names"] = {0: "object"}
+        # Without single_cls, nc/names are left exactly as declared: classes=
+        # keeps original dataset class ids, it does not compact them, so
+        # there is nothing to override here -- only which boxes reach the
+        # loss changes, threaded separately via _class_remap.
+    elif single_cls:
         config["_original_names"] = config.get("names")
         config["_original_nc"] = config.get("nc")
         config["nc"] = 1

--- a/libreyolo/data/yolo_coco_api.py
+++ b/libreyolo/data/yolo_coco_api.py
@@ -11,7 +11,7 @@ Adapted for LibreYOLO.
 import logging
 import warnings
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from PIL import Image
@@ -29,6 +29,7 @@ def parse_yolo_label_line(
     label_path: Optional[Path] = None,
     return_segment: bool = False,
     single_cls: bool = False,
+    class_remap: Optional[Dict[int, int]] = None,
 ) -> Optional[Tuple]:
     """
     Parse a single line from a YOLO label file.
@@ -41,6 +42,12 @@ def parse_yolo_label_line(
             not have the dataset class count available.
         label_path: Path to label file (for warnings)
         single_cls: Remap non-negative class ids to class 0 before validation.
+            Ignored when ``class_remap`` is given.
+        class_remap: Optional ``{orig_id: new_id}`` mapping for training on a
+            class subset (see ``load_data_config(classes=...)``). A class id
+            not present as a key is silently dropped (excluded by design, not
+            a data error); one present is rewritten to its mapped id before
+            the bounds check below. Takes precedence over ``single_cls``.
 
     Returns:
         Tuple of (class_id, x1, y1, x2, y2, area) in pixel coordinates,
@@ -94,7 +101,11 @@ def parse_yolo_label_line(
             )
         return None
 
-    if single_cls and class_id >= 0:
+    if class_remap is not None:
+        if class_id not in class_remap:
+            return None
+        class_id = class_remap[class_id]
+    elif single_cls and class_id >= 0:
         class_id = 0
 
     # Validate class ID

--- a/libreyolo/models/base/model.py
+++ b/libreyolo/models/base/model.py
@@ -97,25 +97,32 @@ def _wrap_train_with_cfg(train_fn: Callable) -> Callable:
             merged.update(user_kwargs)
 
         resume = merged.get("resume", False)
-        if resume and not merged.get("single_cls", False):
+        if resume and (
+            not merged.get("single_cls", False) or not merged.get("classes")
+        ):
             resume_source = (
                 resume
                 if isinstance(resume, (str, Path)) and not isinstance(resume, bool)
                 else None
             )
             checkpoint_config = self._checkpoint_train_config(resume_source)
-            if bool(checkpoint_config.get("single_cls", False)):
+            if not merged.get("single_cls", False) and bool(
+                checkpoint_config.get("single_cls", False)
+            ):
                 merged["single_cls"] = True
+            if not merged.get("classes") and checkpoint_config.get("classes"):
+                merged["classes"] = checkpoint_config["classes"]
 
-        if merged.get("single_cls"):
+        if merged.get("single_cls") or merged.get("classes"):
             from ..registry import group_of
 
             group = group_of(self.FAMILY)
             task = getattr(self, "task", "detect")
             if group not in {"g0", "g1"} or task != "detect":
                 raise ValueError(
-                    "single_cls=True is supported only for G0/G1 detection "
-                    f"models; got family={self.FAMILY!r} ({group}), task={task!r}."
+                    "single_cls=True and classes=[...] are supported only for "
+                    "G0/G1 detection models; got family="
+                    f"{self.FAMILY!r} ({group}), task={task!r}."
                 )
 
         if merged.get("pretrained") is False:

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -38,6 +38,7 @@ import torch
 from tqdm import tqdm
 
 from ...data import (
+    build_class_remap,
     get_coco_annotation_file,
     get_coco_image_dir,
     get_img_files,
@@ -363,7 +364,9 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             data_cfg = load_data_config(
                 self.config.data,
                 single_cls=self.config.single_cls,
+                classes=self.config.classes,
             )
+            class_remap = data_cfg.get("_class_remap")
             data_dir = data_cfg["root"]
             self.num_classes = data_cfg.get("nc", self.config.num_classes)
 
@@ -382,6 +385,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     num_classes=int(self.num_classes),
                     names=data_cfg.get("_original_names", data_cfg.get("names")),
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             elif img_files:
                 train_dataset = YOLODataset(
@@ -391,6 +395,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     preproc=preproc,
                     num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
             elif ann_file.exists():
                 train_dataset = COCODataset(
@@ -402,6 +407,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     num_classes=int(self.num_classes),
                     names=data_cfg.get("_original_names", data_cfg.get("names")),
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             else:
                 train_path = data_cfg.get("train", "images/train")
@@ -419,10 +425,16 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     preproc=preproc,
                     num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
         elif self.config.data_dir:
             data_dir = self.config.data_dir
+            # classes= only filters which boxes reach the loss; it never
+            # changes nc (kept ids are not compacted -- see build_class_remap).
             self.num_classes = 1 if self.config.single_cls else self.config.num_classes
+            class_remap = build_class_remap(
+                self.config.classes, single_cls=self.config.single_cls
+            )
             if (Path(data_dir) / "annotations").exists():
                 train_dataset = COCODataset(
                     data_dir=data_dir,
@@ -432,6 +444,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     preproc=preproc,
                     num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             else:
                 train_dataset = YOLODataset(
@@ -441,6 +454,7 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     preproc=preproc,
                     num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
         else:
             raise ValueError("Either 'data' or 'data_dir' must be specified")

--- a/libreyolo/models/deim/trainer.py
+++ b/libreyolo/models/deim/trainer.py
@@ -368,7 +368,12 @@ class DEIMTrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             )
             class_remap = data_cfg.get("_class_remap")
             data_dir = data_cfg["root"]
-            self.num_classes = data_cfg.get("nc", self.config.num_classes)
+            data_nc = data_cfg.get("nc")
+            if data_nc is None and data_cfg.get("names") is not None:
+                data_nc = len(data_cfg["names"])
+            self.num_classes = (
+                int(data_nc) if data_nc is not None else self.config.num_classes
+            )
 
             ann_file = Path(data_dir) / "annotations" / "instances_train2017.json"
             coco_ann_file = get_coco_annotation_file(data_cfg, "train")

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -39,6 +39,7 @@ import torch
 from tqdm import tqdm
 
 from ...data import (
+    build_class_remap,
     get_coco_annotation_file,
     get_coco_image_dir,
     get_img_files,
@@ -417,7 +418,9 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             data_cfg = load_data_config(
                 self.config.data,
                 single_cls=self.config.single_cls,
+                classes=self.config.classes,
             )
+            class_remap = data_cfg.get("_class_remap")
             data_dir = data_cfg["root"]
             self.num_classes = data_cfg.get("nc", self.config.num_classes)
 
@@ -437,6 +440,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     names=data_cfg.get("_original_names", data_cfg.get("names")),
                     load_segments=load_segments,
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             elif img_files:
                 train_dataset = YOLODataset(
@@ -447,6 +451,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     load_segments=load_segments,
                     num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
             elif ann_file.exists():
                 train_dataset = COCODataset(
@@ -459,6 +464,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     names=data_cfg.get("_original_names", data_cfg.get("names")),
                     load_segments=load_segments,
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             else:
                 train_path = data_cfg.get("train", "images/train")
@@ -477,10 +483,16 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     load_segments=load_segments,
                     num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
         elif self.config.data_dir:
             data_dir = self.config.data_dir
+            # classes= only filters which boxes reach the loss; it never
+            # changes nc (kept ids are not compacted -- see build_class_remap).
             self.num_classes = 1 if self.config.single_cls else self.config.num_classes
+            class_remap = build_class_remap(
+                self.config.classes, single_cls=self.config.single_cls
+            )
             if (Path(data_dir) / "annotations").exists():
                 train_dataset = COCODataset(
                     data_dir=data_dir,
@@ -491,6 +503,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     num_classes=int(self.num_classes),
                     load_segments=load_segments,
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             else:
                 train_dataset = YOLODataset(
@@ -501,6 +514,7 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
                     load_segments=load_segments,
                     num_classes=int(self.num_classes),
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
         else:
             raise ValueError("Either 'data' or 'data_dir' must be specified")

--- a/libreyolo/models/dfine/trainer.py
+++ b/libreyolo/models/dfine/trainer.py
@@ -422,7 +422,12 @@ class DFINETrainer(DETREncoderCudaGraphMixin, BaseTrainer):
             )
             class_remap = data_cfg.get("_class_remap")
             data_dir = data_cfg["root"]
-            self.num_classes = data_cfg.get("nc", self.config.num_classes)
+            data_nc = data_cfg.get("nc")
+            if data_nc is None and data_cfg.get("names") is not None:
+                data_nc = len(data_cfg["names"])
+            self.num_classes = (
+                int(data_nc) if data_nc is not None else self.config.num_classes
+            )
 
             ann_file = Path(data_dir) / "annotations" / "instances_train2017.json"
             coco_ann_file = get_coco_annotation_file(data_cfg, "train")

--- a/libreyolo/training/config.py
+++ b/libreyolo/training/config.py
@@ -55,6 +55,18 @@ class TrainConfig:
     # Supported by G0/G1 detection families only; shared API/CLI gates reject
     # unsupported families and tasks before a trainer is built.
     single_cls: bool = False
+    # Train on only these original dataset class ids; every other class's
+    # boxes are dropped as if never annotated. Ids are kept as-is, not
+    # compacted to a contiguous range, so predictions stay directly
+    # comparable to the original dataset/checkpoint numbering -- the model
+    # head still covers every index up to the highest kept id. Source
+    # annotation files are untouched. Supported by G0/G1 detection families
+    # only, same gate as single_cls (both can resize the classification head
+    # via _rebuild_for_new_classes when the dataset's declared nc differs
+    # from the checkpoint's).
+    # Accepts a comma-separated string too (CLI convenience, matching how
+    # device="0,1" is written), e.g. "0,3,5".
+    classes: Optional[Union[List[int], str]] = None
 
     # Training
     epochs: int = 300
@@ -285,6 +297,17 @@ class TrainConfig:
         self.single_cls = bool(self.single_cls)
         self.class_balanced = bool(self.class_balanced)
         self.export_check = bool(self.export_check)
+        if self.classes is not None:
+            if isinstance(self.classes, str):
+                self.classes = [c for c in self.classes.split(",") if c.strip()]
+            classes = [int(c) for c in self.classes]
+            if not classes:
+                raise ValueError("classes must be a non-empty list when given")
+            if any(c < 0 for c in classes):
+                raise ValueError(f"classes must be non-negative ids, got {classes}")
+            if len(set(classes)) != len(classes):
+                raise ValueError(f"classes must not contain duplicates, got {classes}")
+            self.classes = classes
 
     @classmethod
     def from_kwargs(cls, **kwargs):

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -1427,7 +1427,10 @@ class BaseTrainer(ABC):
                 single_cls=self.config.single_cls,
                 classes=self.config.classes,
             )
-            resolved = int(data_cfg.get("nc", resolved))
+            data_nc = data_cfg.get("nc")
+            if data_nc is None and data_cfg.get("names") is not None:
+                data_nc = len(data_cfg["names"])
+            resolved = int(data_nc) if data_nc is not None else resolved
             self._resolved_class_names = data_cfg.get("names")
 
         self.num_classes = resolved

--- a/libreyolo/training/trainer.py
+++ b/libreyolo/training/trainer.py
@@ -57,6 +57,7 @@ from .freezing import FreezeGroup, apply_freeze, default_freeze_groups
 from .qat_defaults import apply_qat_training_guards
 from ..data.dataset import YOLODataset, COCODataset, create_dataloader
 from ..data import (
+    build_class_remap,
     get_coco_annotation_file,
     get_coco_image_dir,
     get_img_files,
@@ -795,7 +796,9 @@ class BaseTrainer(ABC):
                 self.config.data,
                 allow_scripts=self.config.allow_download_scripts,
                 single_cls=self.config.single_cls,
+                classes=self.config.classes,
             )
+            class_remap = data_cfg.get("_class_remap")
             data_dir = data_cfg["root"]
             data_nc = data_cfg.get("nc")
             if data_nc is None and data_cfg.get("names") is not None:
@@ -828,6 +831,7 @@ class BaseTrainer(ABC):
                     num_classes=self.num_classes,
                     names=data_cfg.get("_original_names", data_cfg.get("names")),
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             elif img_files:
                 train_dataset = YOLODataset(
@@ -839,6 +843,7 @@ class BaseTrainer(ABC):
                     load_obb=load_obb,
                     num_classes=self.num_classes,
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
             elif ann_file.exists():
                 train_dataset = COCODataset(
@@ -856,6 +861,7 @@ class BaseTrainer(ABC):
                     num_classes=self.num_classes,
                     names=data_cfg.get("_original_names", data_cfg.get("names")),
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             else:
                 train_path = data_cfg.get("train", "images/train")
@@ -882,10 +888,16 @@ class BaseTrainer(ABC):
                     load_obb=load_obb,
                     num_classes=self.num_classes,
                     single_cls=self.config.single_cls,
+                    class_remap=class_remap,
                 )
         elif self.config.data_dir:
             data_dir = self.config.data_dir
+            # classes= only filters which boxes reach the loss; it never
+            # changes nc (kept ids are not compacted -- see build_class_remap).
             self.num_classes = 1 if self.config.single_cls else self.config.num_classes
+            class_remap = build_class_remap(
+                self.config.classes, single_cls=self.config.single_cls
+            )
 
             if (Path(data_dir) / "annotations").exists():
                 train_dataset = COCODataset(
@@ -902,6 +914,7 @@ class BaseTrainer(ABC):
                     load_obb=load_obb,
                     num_classes=self.num_classes,
                     single_cls=self.config.single_cls,
+                    classes=self.config.classes,
                 )
             else:
                 train_dataset = YOLODataset(
@@ -912,6 +925,7 @@ class BaseTrainer(ABC):
                     load_segments=load_segments,
                     load_obb=load_obb,
                     num_classes=self.num_classes,
+                    class_remap=class_remap,
                     single_cls=self.config.single_cls,
                 )
         else:
@@ -1390,18 +1404,31 @@ class BaseTrainer(ABC):
         return train_dataset
 
     def _resolve_num_classes_from_data_config(self) -> int:
-        """Resolve dataset class count before criterion construction."""
+        """Resolve dataset class count before criterion construction.
+
+        Also stashes the dataset's class names on ``self._resolved_class_names``
+        so ``_sync_wrapped_model_num_classes`` can restore them after
+        ``_rebuild_for_new_classes`` resets the wrapper to generic
+        ``class_N`` placeholders. ``classes=`` does not affect either value
+        here -- it only filters which boxes reach the loss, never nc/names
+        (see ``build_class_remap``'s docstring for why).
+        """
         resolved = 1 if self.config.single_cls else int(self.config.num_classes)
+        self._resolved_class_names = None
         if self.config.data:
-            # Only the YAML's class count is needed here; the dataset itself is
-            # downloaded later in _setup_data.
+            # Only the YAML's class count is needed here; the dataset itself
+            # is downloaded later in _setup_data. classes= never changes nc
+            # (kept ids are not compacted -- see build_class_remap); passing
+            # it through here still gets its out-of-range validation early.
             data_cfg = load_data_config(
                 self.config.data,
                 autodownload=False,
                 allow_scripts=self.config.allow_download_scripts,
                 single_cls=self.config.single_cls,
+                classes=self.config.classes,
             )
             resolved = int(data_cfg.get("nc", resolved))
+            self._resolved_class_names = data_cfg.get("names")
 
         self.num_classes = resolved
         self.config.num_classes = resolved
@@ -1414,6 +1441,25 @@ class BaseTrainer(ABC):
             value = getattr(obj, "num_classes", None)
             if value is not None:
                 return int(value)
+        return None
+
+    def _effective_names_for_sync(self) -> Optional[Dict[int, str]]:
+        """Names to stamp on the wrapper after a class-count sync, or ``None``
+        to leave whatever is already there untouched.
+
+        single_cls always collapses to ``{0: "object"}``. classes= (and
+        ordinary full-dataset training) use ``_resolved_class_names``, stashed
+        by ``_resolve_num_classes_from_data_config`` -- without this,
+        ``_rebuild_for_new_classes`` resets the wrapper to generic
+        ``class_N`` placeholders and nothing ever restores the real names.
+        """
+        if self.config.single_cls:
+            return {0: "object"}
+        names = getattr(self, "_resolved_class_names", None)
+        if isinstance(names, dict):
+            return {int(k): str(v) for k, v in names.items()}
+        if names is not None:
+            return {i: str(name) for i, name in enumerate(names)}
         return None
 
     def _sync_wrapped_model_num_classes(self, num_classes: int) -> None:
@@ -1431,8 +1477,10 @@ class BaseTrainer(ABC):
         )
 
         if not needs_rebuild:
-            if wrapper is not None and self.config.single_cls:
-                wrapper.names = {0: "object"}
+            if wrapper is not None:
+                effective_names = self._effective_names_for_sync()
+                if effective_names is not None:
+                    wrapper.names = effective_names
             return
 
         if wrapper is None or not hasattr(wrapper, "_rebuild_for_new_classes"):
@@ -1453,8 +1501,9 @@ class BaseTrainer(ABC):
                 f"{self.get_model_family()} wrapper rebuild did not sync the model "
                 f"head to num_classes={num_classes}; got {rebuilt_nc}."
             )
-        if self.config.single_cls:
-            wrapper.names = {0: "object"}
+        effective_names = self._effective_names_for_sync()
+        if effective_names is not None:
+            wrapper.names = effective_names
 
     # =========================================================================
     # Setup / train / epoch

--- a/libreyolo/validation/config.py
+++ b/libreyolo/validation/config.py
@@ -52,6 +52,11 @@ class ValidationConfig:
     data_dir: Optional[str] = None
     split: str = "val"
     single_cls: bool = field(default=False, kw_only=True)
+    # Auto-inherited from the checkpoint's saved training config the same
+    # way single_cls is (see DetectionValidator.__init__); rarely set by
+    # hand. Must match the classes= the model was trained with, since the
+    # head size is shared.
+    classes: Optional[List[int]] = field(default=None, kw_only=True)
 
     # Inference
     batch_size: int = 16

--- a/libreyolo/validation/detection_validator.py
+++ b/libreyolo/validation/detection_validator.py
@@ -89,6 +89,9 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
         self._checkpoint_single_cls = bool(checkpoint_config.get("single_cls", False))
         if self._checkpoint_single_cls:
             self.config = self.config.update(single_cls=True)
+        self._checkpoint_classes = checkpoint_config.get("classes")
+        if self._checkpoint_classes and not self.config.classes:
+            self.config = self.config.update(classes=self._checkpoint_classes)
         self.val_preproc = None  # set in _setup_dataloader
         self._coco_annotation_file: Optional[Path] = None
         self._coco_label_to_category_id: Optional[Dict[int, int]] = None
@@ -137,6 +140,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
         Supports directory-based datasets, .txt file format, and COCO JSON.
         """
         from libreyolo.data import (
+            build_class_remap,
             get_coco_annotation_file,
             get_coco_image_dir,
             get_img_files,
@@ -165,7 +169,9 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 self.config.data,
                 allow_scripts=self.config.allow_download_scripts,
                 single_cls=self._single_cls_enabled(),
+                classes=self.config.classes,
             )
+            class_remap = data_cfg.get("_class_remap")
             data_dir = data_cfg["root"]
             model_nc = int(self.nc)
             self.nc = int(data_cfg.get("nc", self.nc))
@@ -242,6 +248,9 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
         else:
             data_dir = self.config.data_dir
             self.class_names = None
+            class_remap = build_class_remap(
+                self.config.classes, single_cls=self._single_cls_enabled()
+            )
 
         self.val_preproc = self.model._get_val_preprocessor(img_size=actual_imgsz)
         self._ensure_validation_loss_target_capacity()
@@ -292,6 +301,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                     else None
                 ),
                 single_cls=self._single_cls_enabled(),
+                classes=self.config.classes,
                 **dataset_kwargs,
             )
             self._coco_annotation_file = coco_annotation_file
@@ -307,6 +317,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 preproc=self.val_preproc,
                 num_classes=int(self.nc),
                 single_cls=self._single_cls_enabled(),
+                class_remap=class_remap,
                 **dataset_kwargs,
             )
         elif (data_path / "annotations").exists():
@@ -334,6 +345,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                     else None
                 ),
                 single_cls=self._single_cls_enabled(),
+                classes=self.config.classes,
                 **dataset_kwargs,
             )
         else:
@@ -345,6 +357,7 @@ class DetectionValidator(ValidationLossMixin, BaseValidator):
                 preproc=self.val_preproc,
                 num_classes=int(self.nc),
                 single_cls=self._single_cls_enabled(),
+                class_remap=class_remap,
                 **dataset_kwargs,
             )
 

--- a/tests/unit/cli/commands/test_train.py
+++ b/tests/unit/cli/commands/test_train.py
@@ -236,6 +236,48 @@ def test_train_dry_run_rejects_single_cls_outside_g0_g1_detection(args):
     assert "G0/G1 detection" in data["message"]
 
 
+@pytest.mark.parametrize("model", ["LibreYOLO9t.pt", "LibreRFDETRn.pt"])
+def test_train_dry_run_classes_is_visible_for_g0_detectors(model):
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        [
+            "data=coco8.yaml",
+            f"model={model}",
+            "classes=0,3,5",
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["resolved_config"]["classes"] == "0,3,5"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        # Unsupported family (G2), detect task.
+        ["model=LibreYOLOXn.pt", "classes=0,1"],
+        # Supported family, unsupported task. Uses a published checkpoint plus
+        # an explicit task so the PR gate never needs to fetch weights.
+        ["model=LibreRFDETRm.pt", "task=segment", "classes=0,1"],
+    ],
+)
+def test_train_dry_run_rejects_classes_outside_g0_g1_detection(args):
+    app = _make_app()
+    result = runner.invoke(
+        app,
+        ["data=coco8.yaml", *args, "--dry-run", "--json"],
+    )
+
+    assert result.exit_code == 2
+    data = json.loads(result.stdout)
+    assert data["error"] == "config_unsupported"
+    assert "G0/G1 detection" in data["message"]
+
+
 def test_train_dry_run_rfdetr_freeze_flag_is_visible():
     app = _make_app()
     result = runner.invoke(
@@ -603,6 +645,44 @@ def test_train_rfdetr_single_cls_reaches_trainer(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert captured["kwargs"]["single_cls"] is True
+
+
+def test_train_rfdetr_classes_reaches_trainer(monkeypatch, tmp_path):
+    app = _make_app()
+    captured = {}
+
+    class _RFDETRLike:
+        FAMILY = "rfdetr"
+        DEFAULT_TASK = "detect"
+        device = "cpu"
+
+        @classmethod
+        def detect_task_from_filename(cls, filename):
+            return None
+
+        def train(self, data, **kwargs):
+            captured["kwargs"] = kwargs
+            return {"output_dir": str(tmp_path / "rfdetr_exp")}
+
+    monkeypatch.setattr(
+        "libreyolo.cli.commands.train.load_model_or_exit",
+        lambda out, model, model_path, device: _RFDETRLike(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "data=dummy.yaml",
+            "model=LibreRFDETRm.pt",
+            "classes=0,3,5",
+            f"project={tmp_path}",
+            "exist_ok=true",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["classes"] == "0,3,5"
 
 
 def test_train_rfdetr_lr_drop_override_reaches_trainer(monkeypatch, tmp_path):

--- a/tests/unit/test_classes_subset.py
+++ b/tests/unit/test_classes_subset.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import torch
 import yaml
 from PIL import Image
 
@@ -28,7 +30,10 @@ from libreyolo.data.dataset import COCODataset, YOLODataset
 from libreyolo.data.obb import parse_yolo_obb_label_line
 from libreyolo.data.utils import build_class_remap, load_data_config
 from libreyolo.data.yolo_coco_api import parse_yolo_label_line
+from libreyolo.models.base.model import _wrap_train_with_cfg
 from libreyolo.training.config import TrainConfig
+from libreyolo.validation.config import ValidationConfig
+from libreyolo.validation.detection_validator import DetectionValidator
 
 pytestmark = pytest.mark.unit
 
@@ -267,3 +272,296 @@ def test_coco_dataset_classes_drops_excluded_keeps_original_labels(tmp_path):
     labels = dataset.annotations[0][0]
     assert labels.shape[0] == 3
     assert sorted(labels[:, 4].tolist()) == [0.0, 1.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end trainer
+# ---------------------------------------------------------------------------
+
+
+def _write_train_dataset(tmp_path, nc=4, names=("car", "bicycle", "dog", "cat")):
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    Image.new("RGB", (64, 48), color="white").save(img_dir / "sample.jpg")
+    (lbl_dir / "sample.txt").write_text(
+        "0 0.1 0.1 0.1 0.1\n1 0.3 0.3 0.1 0.1\n2 0.5 0.5 0.1 0.1\n3 0.7 0.7 0.1 0.1\n"
+    )
+    return _write_data_yaml(tmp_path, nc=nc, names=names)
+
+
+@pytest.mark.parametrize(
+    ("trainer_import", "size"),
+    [
+        # Uses the shared BaseTrainer._setup_data.
+        ("libreyolo.models.rtdetr.trainer:RTDETRTrainer", "r18"),
+        # DFINE/DEIM mirror BaseTrainer._setup_data by hand -- independent
+        # copy of the same class-filter wiring.
+        ("libreyolo.models.dfine.trainer:DFINETrainer", "n"),
+        ("libreyolo.models.deim.trainer:DEIMTrainer", "n"),
+    ],
+)
+def test_trainer_setup_data_trains_only_the_requested_class_subset(
+    tmp_path, trainer_import, size
+):
+    module_name, class_name = trainer_import.split(":")
+    module = __import__(module_name, fromlist=[class_name])
+    trainer_cls = getattr(module, class_name)
+
+    data_yaml = _write_train_dataset(tmp_path)
+    trainer = trainer_cls(
+        model=torch.nn.Identity(),
+        size=size,
+        num_classes=4,
+        data=str(data_yaml),
+        classes=[0, 1, 3],
+        epochs=1,
+        batch=1,
+        imgsz=64,
+        device="cpu",
+        amp=False,
+        ema=False,
+        workers=0,
+        eval_interval=-1,
+    )
+
+    trainer._setup_data()
+
+    # nc stays the full declared count -- classes= only filters the loss.
+    assert trainer.num_classes == 4
+    raw_dataset = trainer.train_loader.dataset.dataset
+    labels = raw_dataset.annotations[0][0]
+    assert labels.shape[0] == 3
+    assert sorted(labels[:, 4].tolist()) == [0.0, 1.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# Validator auto-inherit
+# ---------------------------------------------------------------------------
+
+
+def test_validator_auto_inherits_classes_from_checkpoint(tmp_path):
+    data_yaml = _write_train_dataset(tmp_path)
+    model = SimpleNamespace(
+        nb_classes=4,
+        _checkpoint_train_config=lambda: {"classes": [0, 1, 3]},
+        _get_val_preprocessor=lambda img_size: None,
+    )
+    config = ValidationConfig(
+        data=str(data_yaml), batch_size=1, num_workers=0, device="cpu"
+    )
+
+    validator = DetectionValidator(model, config)
+
+    assert validator.config.classes == [0, 1, 3]
+    dataloader = validator._setup_dataloader()
+    assert validator.nc == 4
+    assert validator.class_names == ["car", "bicycle", "dog", "cat"]
+    labels = dataloader.dataset.annotations[0][0]
+    assert labels.shape[0] == 3
+
+
+def test_validator_explicit_classes_not_overridden_by_checkpoint(tmp_path):
+    data_yaml = _write_train_dataset(tmp_path)
+    model = SimpleNamespace(
+        nb_classes=4,
+        _checkpoint_train_config=lambda: {"classes": [0, 1, 3]},
+        _get_val_preprocessor=lambda img_size: None,
+    )
+    config = ValidationConfig(
+        data=str(data_yaml),
+        batch_size=1,
+        num_workers=0,
+        device="cpu",
+        classes=[0, 2],
+    )
+
+    validator = DetectionValidator(model, config)
+
+    assert validator.config.classes == [0, 2]
+
+
+# ---------------------------------------------------------------------------
+# _wrap_train_with_cfg gate
+# ---------------------------------------------------------------------------
+
+
+def test_python_gate_accepts_classes_for_g0_g1_detection():
+    def train(self, data, **kwargs):
+        return kwargs
+
+    wrapped = _wrap_train_with_cfg(train)
+    wrapper = SimpleNamespace(FAMILY="rtdetr", task="detect")
+
+    result = wrapped(wrapper, "data.yaml", classes=[0, 1, 3])
+
+    assert result["classes"] == [0, 1, 3]
+
+
+def test_python_gate_rejects_classes_for_unsupported_family_or_task():
+    def train(self, data, **kwargs):
+        return kwargs
+
+    wrapped = _wrap_train_with_cfg(train)
+    wrapper = SimpleNamespace(FAMILY="yolox", task="detect")
+
+    with pytest.raises(ValueError, match="G0/G1 detection"):
+        wrapped(wrapper, "data.yaml", classes=[0, 1])
+
+
+def test_resume_inherits_classes_from_checkpoint():
+    def train(self, data, *, resume=False, **kwargs):
+        return kwargs
+
+    wrapped = _wrap_train_with_cfg(train)
+    wrapper = SimpleNamespace(
+        FAMILY="yolo9",
+        task="detect",
+        model_path="last.pt",
+        _checkpoint_train_config=lambda source=None: {"classes": [0, 1, 3]},
+    )
+
+    result = wrapped(wrapper, "data.yaml", resume=True)
+
+    assert result["classes"] == [0, 1, 3]
+
+
+# ---------------------------------------------------------------------------
+# on_num_classes_resolved: the wrapper's real names must survive the head
+# rebuild, not just its class count. _rebuild_for_new_classes() always resets
+# to generic class_N placeholders; only _sync_wrapped_model_num_classes
+# restores real names afterward, via _resolved_class_names stashed by
+# _resolve_num_classes_from_data_config. This holds regardless of classes=,
+# which never changes nc/names here -- see build_class_remap's docstring.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDetector(torch.nn.Module):
+    def __init__(self, num_classes: int):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(1))
+        self.decoder = SimpleNamespace(num_classes=num_classes, reg_max=32)
+
+
+class _FakeWrapper:
+    task = "detect"
+
+    def __init__(self, num_classes: int):
+        self.nb_classes = num_classes
+        self.names = {i: f"class_{i}" for i in range(num_classes)}
+        self.device = torch.device("cpu")
+        self.model = _FakeDetector(num_classes)
+
+    def _rebuild_for_new_classes(self, num_classes: int):
+        self.nb_classes = num_classes
+        self.names = {i: f"class_{i}" for i in range(num_classes)}
+        self.model = _FakeDetector(num_classes)
+
+
+def _build_rtdetr_trainer(data_yaml, wrapper, **overrides):
+    from libreyolo.models.rtdetr.trainer import RTDETRTrainer
+
+    kwargs = dict(
+        model=wrapper.model,
+        wrapper_model=wrapper,
+        size="r18",
+        num_classes=wrapper.nb_classes,
+        data=str(data_yaml),
+        epochs=1,
+        batch=1,
+        imgsz=64,
+        device="cpu",
+        workers=0,
+        amp=False,
+        ema=False,
+        no_aug_epochs=0,
+        warmup_epochs=0,
+        eval_interval=-1,
+    )
+    kwargs.update(overrides)
+    return RTDETRTrainer(**kwargs)
+
+
+def test_sync_ignores_classes_for_nc_and_names_resolution(tmp_path):
+    """classes= is a loss-time filter only: nc/names resolve exactly as they
+    would without it (the full 10-class dataset), even though only 7 ids are
+    requested for training."""
+    data_yaml = _write_data_yaml(tmp_path, nc=10, names=NAMES10)
+    wrapper = _FakeWrapper(num_classes=80)
+    trainer = _build_rtdetr_trainer(data_yaml, wrapper, classes=[0, 3, 5, 6, 7, 8, 9])
+
+    trainer.on_num_classes_resolved()
+
+    assert wrapper.nb_classes == 10
+    assert wrapper.names == {i: name for i, name in enumerate(NAMES10)}
+
+
+def test_sync_restores_real_names_for_plain_full_dataset_training(tmp_path):
+    """Not classes=-specific: any dataset-driven head resize (nc mismatch
+    against the loaded checkpoint) must end up with the dataset's real names,
+    not generic placeholders -- this held for single_cls already, now for
+    every case _resolved_class_names can supply."""
+    data_yaml = _write_data_yaml(tmp_path, nc=3, names=("car", "bicycle", "dog"))
+    wrapper = _FakeWrapper(num_classes=80)
+    trainer = _build_rtdetr_trainer(data_yaml, wrapper)
+
+    trainer.on_num_classes_resolved()
+
+    assert wrapper.nb_classes == 3
+    assert wrapper.names == {0: "car", 1: "bicycle", 2: "dog"}
+
+
+def test_sync_no_rebuild_still_applies_names(tmp_path):
+    """When the wrapper already has the right class count (no rebuild
+    needed), the not-needs-rebuild branch must still stamp the correct
+    names -- it used to only special-case single_cls there."""
+    data_yaml = _write_data_yaml(tmp_path, nc=10, names=NAMES10)
+    wrapper = _FakeWrapper(num_classes=10)  # already the right count
+    trainer = _build_rtdetr_trainer(data_yaml, wrapper, classes=[0, 3, 5, 6, 7, 8, 9])
+
+    trainer.on_num_classes_resolved()
+
+    assert wrapper.names == {i: name for i, name in enumerate(NAMES10)}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through LibreYOLO9.train() -- the real user-facing entry point.
+#
+# Confirms the three places that used to independently resolve nc/names
+# (Trainer._resolve_num_classes_from_data_config, BaseTrainer._setup_data,
+# and YOLO9's own model.py::train()) agree: none of them need to know about
+# classes= at all anymore, since it never changes nc/names. That is what
+# makes this design change smaller and safer than the compacting-remap one
+# it replaces -- see build_class_remap's docstring.
+# ---------------------------------------------------------------------------
+
+
+def test_libreyolo9_train_end_to_end_keeps_original_nc_and_names(tmp_path):
+    from libreyolo import LibreYOLO9
+
+    data_yaml = _write_train_dataset(tmp_path, nc=10, names=NAMES10)
+    model = LibreYOLO9(None, size="t", device="cpu")
+
+    model.train(
+        data=str(data_yaml),
+        classes=[0, 3, 5, 6, 7, 8, 9],
+        epochs=1,
+        batch=1,
+        imgsz=64,
+        device="cpu",
+        workers=0,
+        amp=False,
+        ema=False,
+        project=str(tmp_path / "runs"),
+        name="exp",
+    )
+
+    expected_names = {i: name for i, name in enumerate(NAMES10)}
+    assert model.nb_classes == 10
+    assert model.names == expected_names
+
+    checkpoint_path = tmp_path / "runs" / "exp" / "weights" / "last.pt"
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    assert checkpoint["nc"] == 10
+    assert checkpoint["names"] == expected_names

--- a/tests/unit/test_classes_subset.py
+++ b/tests/unit/test_classes_subset.py
@@ -18,6 +18,7 @@ id to 0) since that is an intentional merge, not an exclusion.
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -565,3 +566,75 @@ def test_libreyolo9_train_end_to_end_keeps_original_nc_and_names(tmp_path):
     checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
     assert checkpoint["nc"] == 10
     assert checkpoint["names"] == expected_names
+
+
+# ---------------------------------------------------------------------------
+# nc must be derivable from len(names) when the yaml omits an explicit nc:
+# key -- BaseTrainer._setup_data() already did this; _resolve_num_classes_
+# from_data_config() and DFINE/DEIM's by-hand _setup_data() copies did not,
+# so a trainer built with a stale initial num_classes (e.g. from a
+# previously loaded checkpoint) never got corrected and produced exactly
+# the out-of-range warning this test guards against.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("trainer_import", "size"),
+    [
+        ("libreyolo.models.rtdetr.trainer:RTDETRTrainer", "r18"),
+        ("libreyolo.models.dfine.trainer:DFINETrainer", "n"),
+        ("libreyolo.models.deim.trainer:DEIMTrainer", "n"),
+    ],
+)
+def test_nc_derives_from_names_when_yaml_omits_nc_even_with_stale_initial_value(
+    tmp_path, trainer_import, size
+):
+    module_name, class_name = trainer_import.split(":")
+    module = __import__(module_name, fromlist=[class_name])
+    trainer_cls = getattr(module, class_name)
+
+    img_dir = tmp_path / "images" / "train"
+    lbl_dir = tmp_path / "labels" / "train"
+    img_dir.mkdir(parents=True)
+    lbl_dir.mkdir(parents=True)
+    Image.new("RGB", (64, 48), color="white").save(img_dir / "sample.jpg")
+    (lbl_dir / "sample.txt").write_text("9 0.1 0.1 0.05 0.05\n0 0.5 0.5 0.05 0.05\n")
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "train": "images/train",
+                "names": [f"c{i}" for i in range(11)],
+                # deliberately no "nc" key
+            }
+        )
+    )
+
+    trainer = trainer_cls(
+        model=torch.nn.Identity(),
+        size=size,
+        num_classes=7,  # stale, e.g. from a previously loaded checkpoint
+        data=str(data_yaml),
+        classes=[0, 1, 2, 3, 4, 5, 9],
+        epochs=1,
+        batch=1,
+        imgsz=64,
+        device="cpu",
+        amp=False,
+        ema=False,
+        workers=0,
+        eval_interval=-1,
+    )
+
+    trainer.on_num_classes_resolved()
+    assert trainer.num_classes == 11
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        trainer._setup_data()
+    assert not any(issubclass(w.category, UserWarning) for w in caught)
+
+    assert trainer.num_classes == 11
+    labels = trainer.train_loader.dataset.dataset.annotations[0][0]
+    assert sorted(labels[:, 4].tolist()) == [0.0, 9.0]

--- a/tests/unit/test_classes_subset.py
+++ b/tests/unit/test_classes_subset.py
@@ -1,0 +1,269 @@
+"""Training on a subset of a dataset's classes, without editing annotation
+files (see repo-local research_class.md for the design writeup).
+
+Generalizes the existing single_cls remap-at-parse-time mechanism: classes=
+picks which original dataset class ids survive; every other class's boxes
+are dropped as if never annotated, source annotation files stay untouched.
+Kept ids are NOT compacted to a contiguous range -- they keep their original
+numbering, so predictions and checkpoint metadata stay directly comparable
+to the full dataset (an external COCO-style evaluator, an exported model
+read by raw class index, a person who knows "id 7 = train") without any
+translation layer. The cost is that the model head still covers every index
+up to the highest kept id; unrequested classes below it simply never
+receive positive supervision, the same as a class with zero occurrences in
+an ordinary dataset. single_cls stays a genuine remap (collapses every kept
+id to 0) since that is an intentional merge, not an exclusion.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from PIL import Image
+
+from libreyolo.data.dataset import COCODataset, YOLODataset
+from libreyolo.data.obb import parse_yolo_obb_label_line
+from libreyolo.data.utils import build_class_remap, load_data_config
+from libreyolo.data.yolo_coco_api import parse_yolo_label_line
+from libreyolo.training.config import TrainConfig
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# TrainConfig validation
+# ---------------------------------------------------------------------------
+
+
+def test_train_config_classes_defaults_off():
+    assert TrainConfig().classes is None
+
+
+def test_train_config_classes_normalizes_to_int_list():
+    assert TrainConfig(classes=[0, "1", 3]).classes == [0, 1, 3]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [[], [-1, 0], [0, 0, 1]],
+)
+def test_train_config_classes_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        TrainConfig(classes=bad)
+
+
+# ---------------------------------------------------------------------------
+# build_class_remap / load_data_config
+# ---------------------------------------------------------------------------
+
+
+def test_build_class_remap_none_when_no_classes():
+    assert build_class_remap(None) is None
+
+
+def test_build_class_remap_keeps_original_ids():
+    assert build_class_remap([3, 0, 1]) == {0: 0, 1: 1, 3: 3}
+
+
+def test_build_class_remap_single_cls_collapses_to_zero():
+    assert build_class_remap([3, 0, 1], single_cls=True) == {0: 0, 1: 0, 3: 0}
+
+
+NAMES10 = (
+    "car",
+    "bicycle",
+    "person",
+    "dog",
+    "truck",
+    "cat",
+    "bus",
+    "train",
+    "boat",
+    "bird",
+)
+
+
+def _write_data_yaml(tmp_path: Path, nc=4, names=("car", "bicycle", "dog", "cat")):
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": str(tmp_path),
+                "train": "images/train",
+                "val": "images/train",
+                "nc": nc,
+                "names": list(names),
+            }
+        )
+    )
+    return data_yaml
+
+
+def test_load_data_config_classes_leaves_nc_and_names_untouched(tmp_path):
+    data_yaml = _write_data_yaml(tmp_path)
+
+    cfg = load_data_config(str(data_yaml), autodownload=False, classes=[0, 1, 3])
+
+    assert cfg["nc"] == 4
+    assert cfg["names"] == ["car", "bicycle", "dog", "cat"]
+    assert cfg["_class_remap"] == {0: 0, 1: 1, 3: 3}
+    assert "_original_nc" not in cfg
+    assert "_original_names" not in cfg
+
+
+def test_load_data_config_classes_and_single_cls_collapse_kept_to_one(tmp_path):
+    data_yaml = _write_data_yaml(tmp_path)
+
+    cfg = load_data_config(
+        str(data_yaml), autodownload=False, classes=[0, 1, 3], single_cls=True
+    )
+
+    assert cfg["nc"] == 1
+    assert cfg["names"] == {0: "object"}
+    assert cfg["_class_remap"] == {0: 0, 1: 0, 3: 0}
+    assert cfg["_original_nc"] == 4
+    assert cfg["_original_names"] == ["car", "bicycle", "dog", "cat"]
+
+
+def test_load_data_config_classes_out_of_range_fails_fast(tmp_path):
+    data_yaml = _write_data_yaml(tmp_path)
+
+    with pytest.raises(ValueError, match="outside this dataset's declared nc"):
+        load_data_config(str(data_yaml), autodownload=False, classes=[0, 99])
+
+
+# ---------------------------------------------------------------------------
+# Label parsers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_yolo_label_line_excluded_class_is_silently_dropped():
+    remap = {0: 0, 1: 1, 3: 3}
+    line = "2 0.5 0.5 0.2 0.2"  # dog, excluded
+
+    assert parse_yolo_label_line(line, 100, 100, None, class_remap=remap) is None
+
+
+def test_parse_yolo_label_line_kept_class_keeps_its_original_id():
+    remap = {0: 0, 1: 1, 3: 3}
+    line = "3 0.5 0.5 0.2 0.2"  # cat, id 3, kept as 3
+
+    result = parse_yolo_label_line(line, 100, 100, None, class_remap=remap)
+
+    assert result[0] == 3
+
+
+def test_parse_yolo_obb_label_line_excluded_class_raises():
+    remap = {0: 0, 1: 1, 3: 3}
+    row = "2 0.1 0.1 0.2 0.1 0.2 0.2 0.1 0.2"
+
+    with pytest.raises(ValueError, match="excluded by classes"):
+        parse_yolo_obb_label_line(row, class_remap=remap)
+
+
+def test_parse_yolo_obb_label_line_kept_class_keeps_its_original_id():
+    remap = {0: 0, 1: 1, 3: 3}
+    row = "3 0.1 0.1 0.2 0.1 0.2 0.2 0.1 0.2"
+
+    cls_id, _ = parse_yolo_obb_label_line(row, class_remap=remap)
+
+    assert cls_id == 3
+
+
+# ---------------------------------------------------------------------------
+# YOLODataset (.txt)
+# ---------------------------------------------------------------------------
+
+
+def _write_yolo_sample(tmp_path: Path):
+    image_path = tmp_path / "sample.jpg"
+    label_path = tmp_path / "sample.txt"
+    Image.new("RGB", (64, 48), color="white").save(image_path)
+    label_path.write_text(
+        "0 0.1 0.1 0.1 0.1\n1 0.3 0.3 0.1 0.1\n2 0.5 0.5 0.1 0.1\n3 0.7 0.7 0.1 0.1\n",
+        encoding="utf-8",
+    )
+    return [image_path], [label_path]
+
+
+def test_yolo_dataset_class_remap_drops_excluded_keeps_original_ids(tmp_path):
+    image_files, label_files = _write_yolo_sample(tmp_path)
+    remap = {0: 0, 1: 1, 3: 3}  # drop original id 2 (dog); keep the rest as-is
+
+    dataset = YOLODataset(
+        img_files=image_files,
+        label_files=label_files,
+        img_size=(64, 64),
+        class_remap=remap,
+    )
+
+    labels = dataset.annotations[0][0]
+    assert labels.shape[0] == 3
+    assert sorted(labels[:, 4].tolist()) == [0.0, 1.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# COCODataset (JSON)
+# ---------------------------------------------------------------------------
+
+
+def _write_coco_sample(tmp_path: Path):
+    image_dir = tmp_path / "images" / "train"
+    annotation_dir = tmp_path / "annotations"
+    image_dir.mkdir(parents=True)
+    annotation_dir.mkdir()
+    Image.new("RGB", (64, 48), color="white").save(image_dir / "sample.jpg")
+    (annotation_dir / "train.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {"id": 1, "file_name": "sample.jpg", "width": 64, "height": 48}
+                ],
+                "annotations": [
+                    {
+                        "id": i,
+                        "image_id": 1,
+                        "category_id": cat_id,
+                        "bbox": [4, 4, 10, 10],
+                        "area": 100,
+                        "iscrowd": 0,
+                    }
+                    for i, cat_id in enumerate((1, 2, 3, 4), start=1)
+                ],
+                "categories": [
+                    {"id": 1, "name": "car"},
+                    {"id": 2, "name": "bicycle"},
+                    {"id": 3, "name": "dog"},
+                    {"id": 4, "name": "cat"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_coco_dataset_classes_drops_excluded_keeps_original_labels(tmp_path):
+    pytest.importorskip("pycocotools")
+    _write_coco_sample(tmp_path)
+
+    dataset = COCODataset(
+        data_dir=str(tmp_path),
+        json_file="annotations/train.json",
+        name="images/train",
+        img_size=(64, 64),
+        num_classes=4,
+        names={0: "car", 1: "bicycle", 2: "dog", 3: "cat"},
+        classes=[0, 1, 3],
+    )
+
+    # category 3 (dog, label 2) is excluded; the rest keep their original label.
+    assert dataset.category_id_to_label == {1: 0, 2: 1, 4: 3}
+    # names cover the full original set, including the excluded class --
+    # nothing is hidden, it just never receives positive supervision.
+    assert dataset._classes == ("car", "bicycle", "dog", "cat")
+    labels = dataset.annotations[0][0]
+    assert labels.shape[0] == 3
+    assert sorted(labels[:, 4].tolist()) == [0.0, 1.0, 3.0]


### PR DESCRIPTION
This PR introduces a new feature as discussed in #828 

**What**: Add `classes=` to train()/val()/predict() (Python API + CLI) so a dataset's declared classes can be filtered to a subset without editing annotation files.

**Why**: Users want to fine-tune on fewer classes than a dataset declares, without hand-editing labels or losing comparability with the original class ids.

- `classes=[...]` filters which original class ids receive supervision; kept ids are NOT compacted to a contiguous range, so predictions/checkpoints stay directly comparable to the full dataset (generalizes the existing `single_cls` remap-at-parse-time mechanism)
- `nc`/`names` are left untouched by `classes=`; only which boxes reach the loss changes
- gated to G0/G1 detection families (single_cls=True and classes=[...] both trigger the same gate)
- `model.val()` and the checkpoint resume path auto-inherit `classes` from the saved training config, same pattern as `single_cls`
- CLI: `libreyolo train ... classes=0,3,5` / `--classes 0,3,5`
- fixes: per-epoch training-time validation wasn't threading `classes=` into its own `ValidationConfig`, so periodic mAP was silently scored against the full, unfiltered dataset
- logs a clear warning when a run is training/validating on a class subset

## Code provenance
Original code written for this PR; bug fixes to LibreYOLO's own first-party code; no third-party code ported, adapted, or introduced; no GPL/AGPL/LGPL/non-commercial/unknown-license material involved.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=64988894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 1/5</h2>

The PR is not yet safe to merge because four previously reported behavioral gaps remain, including incomplete subset metrics and training paths that still ignore or cannot safely accept the option.

<h2><a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibreyolo%2Fvalidation%2Fdetection_validator.py%3Aundefined-339%0AValidation%20filters%20the%20dataloader%20annotations%20by%20%60classes%60%2C%20but%20%60_init_metrics%60%20separately%20builds%20COCO%20ground%20truth%20from%20the%20full%20JSON%20or%20YOLO%20labels%2C%20and%20%60_update_metrics%60%20submits%20predictions%20without%20filtering%20their%20classes.%20As%20a%20result%2C%20standalone%20and%20per-epoch%20validation%20report%20mAP%20over%20the%20full%20dataset%20rather%20than%20the%20requested%20subset.%20With%20native%20COCO%20data%2C%20excluded%20labels%20can%20also%20fall%20through%20the%20incomplete%20label-to-category%20mapping.%20Apply%20the%20selected%20original%20class%20IDs%20consistently%20to%20evaluator%20ground%20truth%20and%20predictions.%0A%0A%23%23%23%20Issue%202%0Alibreyolo%2Ftraining%2Ftrainer.py%3A848-853%0AWhen%20a%20dataset%20uses%20an%20%60input_profile%60%2C%20this%20branch%20derives%20%60_class_remap%60%20and%20then%20immediately%20delegates%20to%20%60setup_histogram_data%60.%20That%20function%20creates%20%60YOLODataset%60%20without%20the%20remap.%20A%20supported%20G0%2FG1%20run%20therefore%20accepts%20and%20saves%20%60classes%60%2C%20but%20histogram%20training%20still%20supervises%20every%20annotation%20class.%0A%0A%23%23%23%20Issue%203%0Alibreyolo%2Fvalidation%2Fconfig.py%3A55-59%0A%60ValidationConfig%60%20adds%20%60classes%60%20without%20the%20normalization%20and%20validation%20already%20used%20by%20%60TrainConfig%60.%20Consequently%2C%20%60model.val%28classes%3D%5B%5D%29%60%20or%20a%20malformed%20checkpoint%20value%20can%20create%20an%20empty%20or%20negative%20remap%20and%20silently%20discard%20all%20dataloader%20labels%2C%20while%20the%20comma-separated%20form%20%60%220%2C3%2C5%22%60%20fails%20during%20integer%20conversion.%20Apply%20the%20same%20string%20normalization%20and%20non-empty%2C%20non-negative%2C%20duplicate%20checks%20at%20validation%20entry%20points.%0A%0A%23%23%23%20Issue%204%0Alibreyolo%2Fcli%2Fcommands%2Ftrain.py%3A323-328%0AOnly%20the%20train%20CLI%20exposes%20the%20new%20dataset-subset%20option.%20%60libreyolo%20val%20...%20classes%3D0%2C3%2C5%60%20is%20still%20rejected%20because%20%60val_cmd%60%20declares%20no%20%60classes%60%20option%20and%20does%20not%20pass%20one%20to%20%60loaded_model.val%60.%20Checkpoint%20inheritance%20does%20not%20address%20users%20who%20explicitly%20want%20to%20evaluate%20a%20different%20subset.%0A%0A%23%23%23%20Issue%205%0Atests%2Funit%2Ftest_classes_subset.py%3Aundefined-680%0AThis%20fast-unit%20test%20constructs%20a%20real%20LibreYOLO9%20model%2C%20runs%20a%20complete%20training%20epoch%2C%20and%20writes%20a%20checkpoint.%20That%20adds%20integration-level%20runtime%20and%20resource%20sensitivity%20to%20routine%20unit%20execution.%20Move%20this%20coverage%20to%20an%20integration%20or%20smoke%20tier%20and%20retain%20a%20lightweight%20mocked%20API%20test%20here.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=875&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=7"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Subset Metrics Stay Unfiltered** <a href="https://github.com/LibreYOLO/libreyolo/pull/875#discussion_r4026701667">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Histogram Training Ignores Classes** <a href="https://github.com/LibreYOLO/libreyolo/pull/875#discussion_r4026701685">▶</a>
3. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Validation Classes Lack Checks** <a href="https://github.com/LibreYOLO/libreyolo/pull/875#discussion_r4026701700">▶</a>
4. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Validation CLI Lacks Classes** <a href="https://github.com/LibreYOLO/libreyolo/pull/875#discussion_r4026701717">▶</a>
5. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Unit Test Trains Model** <a href="https://github.com/LibreYOLO/libreyolo/pull/875#discussion_r4026701724">▶</a>

<details><summary>Summary</summary>

This PR adds class-subset filtering for G0/G1 detection training and validation while preserving original class IDs and the dataset’s full class metadata.
- Threads `classes` through configuration, dataset parsing, training, checkpoint resume, and periodic validation.
- Filters YOLO and native COCO ground truth for subset evaluation.
- Adds warnings and local test coverage for subset behavior.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[classes configuration] --> B[Build original-ID remap]
    B --> C[Training dataset]
    B --> D[Validation dataset]
    C --> E[Drop excluded annotations]
    D --> F[Filter evaluator ground truth]
    G[Model predictions] --> H[COCO evaluator]
    F --> H
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix:  Subset Metrics Stay Unfiltered"](https://github.com/libreyolo/libreyolo/commit/d68dd7246de1afee86b731173d423a6ead667f19)</sub>

<!-- /greptile_comment -->